### PR TITLE
Add a scoped template reader

### DIFF
--- a/templates.go
+++ b/templates.go
@@ -19,6 +19,8 @@ type fileTemplates struct {
 }
 
 // FileTemplates creates a template reader that looks up templates in a file system directory.
+// The provided template directory will be used as a root.  It is the responsibility of the caller
+// to ensure that the template root directory exists.
 func FileTemplates(dir string) (Templates, error) {
 	stat, err := os.Stat(dir)
 	if err != nil {
@@ -31,6 +33,8 @@ func FileTemplates(dir string) (Templates, error) {
 	return &fileTemplates{dir: dir}, nil
 }
 
+// Reads a template by name, associated with the provided provisioner name.  Neither the provisioner
+// name nor the template name may contain a path separator character.
 func (f *fileTemplates) Read(provisioner string, template string) ([]byte, error) {
 	if strings.Contains(provisioner, string(os.PathSeparator)) {
 		return nil, errors.New("Provisioner name must not contain a path separator")

--- a/templates_test.go
+++ b/templates_test.go
@@ -1,6 +1,7 @@
 package libmachete
 
 import (
+	"fmt"
 	"github.com/stretchr/testify/require"
 	"io/ioutil"
 	"os"
@@ -75,14 +76,29 @@ func TestFileTemplatesBadInputs(t *testing.T) {
 	require.Nil(t, err)
 	defer os.RemoveAll(tempDir)
 
-	templates, err := FileTemplates("a/path/that/does/not/exist/")
+	templates, err := FileTemplates(tempDir)
+	require.Nil(t, err)
+
+	data, err := templates.Read(
+		fmt.Sprintf("bad%sprovisioner", string(os.PathSeparator)),
+		"template")
+	require.NotNil(t, err, "A provisioner name containing a path separator must error")
+	require.Nil(t, data)
+
+	data, err = templates.Read(
+		"provisioner",
+		fmt.Sprintf("bad%stemplate", string(os.PathSeparator)))
+	require.NotNil(t, err, "A template name containing a path separator must error")
+	require.Nil(t, data)
+
+	templates, err = FileTemplates("a/path/that/does/not/exist/")
+	require.NotNil(t, err, "A non-existent template root must error")
 	require.Nil(t, templates)
-	require.NotNil(t, err)
 
 	writer := fileWriter{t: t, dir: tempDir}
 
 	tempFile := writer.write("nothing", "hello", "")
 	templates, err = FileTemplates(tempFile)
+	require.NotNil(t, err, "A file must be disallowed as a template root")
 	require.Nil(t, templates)
-	require.NotNil(t, err)
 }


### PR DESCRIPTION
This provides an implementation of `machine.templateLoader`.
