### PR TITLE
Allow plumbing of alternate aws credentials sources.

### DIFF
--- a/e2e/aws/aws_test.go
+++ b/e2e/aws/aws_test.go
@@ -1,6 +1,7 @@
 package aws
 
 import (
+	"github.com/aws/aws-sdk-go/aws/credentials"
 	"github.com/docker/libmachete/provisioners/api"
 	"github.com/docker/libmachete/provisioners/aws"
 	"github.com/stretchr/testify/require"
@@ -40,7 +41,8 @@ func TestCreate(t *testing.T) {
 		region = "us-west-2"
 	}
 
-	provisioner := aws.New(aws.CreateClient(region, accessKey, secretKey, "", 10))
+	awsCredentials := credentials.NewStaticCredentials(accessKey, secretKey, "")
+	provisioner := aws.New(aws.CreateClient(region, &awsCredentials, 10))
 
 	request := aws.CreateInstanceRequest{
 		AvailabilityZone:         "us-west-2a",

--- a/provisioners/aws/aws.go
+++ b/provisioners/aws/aws.go
@@ -22,10 +22,10 @@ func New(client ec2iface.EC2API) api.Provisioner {
 }
 
 // CreateClient creates the actual EC2 API client.
-func CreateClient(region, accessKey, secretKey, sessionToken string, retryCount int) ec2iface.EC2API {
+func CreateClient(region string, awsCredentials *credentials.Credentials, retryCount int) ec2iface.EC2API {
 	return ec2.New(session.New(aws.NewConfig().
 		WithRegion(region).
-		WithCredentials(credentials.NewStaticCredentials(accessKey, secretKey, sessionToken)).
+		WithCredentials(awsCredentials).
 		WithLogger(getLogger()).
 		WithLogLevel(aws.LogDebugWithHTTPBody).
 		WithMaxRetries(retryCount)))


### PR DESCRIPTION
This allows levels higher in the stack to decide whether to use credentials stored at `~/.aws`, which will be useful for the command line client.
