### PR TITLE
Use struct embedding for BaseMachineRequest.

### DIFF
--- a/provisioners/api/api.go
+++ b/provisioners/api/api.go
@@ -44,6 +44,17 @@ type MachineRequest interface {
 	Name() string
 }
 
+// BaseMachineRequest defines fields that all machine request types should contain.  This struct
+// should be embedded in all provider-specific request structs.
+type BaseMachineRequest struct {
+	MachineName string `yaml:"name"`
+}
+
+// Name returns the name to give the machine, once created.
+func (req BaseMachineRequest) Name() string {
+	return req.MachineName
+}
+
 // A Provisioner is a vendor-agnostic API used to create and manage
 // resources with an infrastructure provider.
 type Provisioner interface {

--- a/provisioners/aws/aws_test.go
+++ b/provisioners/aws/aws_test.go
@@ -207,7 +207,8 @@ func TestDestroyInstanceError(t *testing.T) {
 	require.Equal(t, expectedEvents, collectDestroyInstanceEvents(eventChan))
 }
 
-const yamlDoc = `availability_zone: us-west-2a
+const yamlDoc = `name: database
+availability_zone: us-west-2a
 image_id: ami-5
 block_device_name: /dev/sdb
 root_size: 64
@@ -231,6 +232,7 @@ monitoring: true`
 
 func TestYamlSpec(t *testing.T) {
 	expected := CreateInstanceRequest{
+		BaseMachineRequest:       api.BaseMachineRequest{MachineName: "database"},
 		AvailabilityZone:         "us-west-2a",
 		ImageID:                  "ami-5",
 		BlockDeviceName:          "/dev/sdb",

--- a/provisioners/aws/types.go
+++ b/provisioners/aws/types.go
@@ -1,8 +1,10 @@
 package aws
 
+import "github.com/docker/libmachete/provisioners/api"
+
 // CreateInstanceRequest is the struct used to create new instances.
 type CreateInstanceRequest struct {
-	MachineName              string            `yaml:"name"`
+	api.BaseMachineRequest   `yaml:",inline"`
 	AvailabilityZone         string            `yaml:"availability_zone"`
 	ImageID                  string            `yaml:"image_id"`
 	BlockDeviceName          string            `yaml:"block_device_name"`
@@ -22,11 +24,6 @@ type CreateInstanceRequest struct {
 	VpcID                    string            `yaml:"vpc_id"`
 	Zone                     string            `yaml:"zone"`
 	Monitoring               bool              `yaml:"monitoring"`
-}
-
-// Name gets the name to be associated with the machine.
-func (req CreateInstanceRequest) Name() string {
-	return req.MachineName
 }
 
 // Validate checks the data and returns error if not valid


### PR DESCRIPTION
The yaml parser has a handy `inline` tag that lifts a struct's fields up a level.  This means we can leverage struct embedding for the base request code reuse.
