### PR TITLE
Simplify provisioner task specification.

### DIFF
--- a/machines.go
+++ b/machines.go
@@ -13,7 +13,7 @@ import (
 )
 
 // MachineRequestBuilder is a provisioner-provided function that creates a typed request
-// that satifies the MachineRequest interface.
+// that satisfies the MachineRequest interface.
 type MachineRequestBuilder func() api.MachineRequest
 
 var (
@@ -33,14 +33,6 @@ func RegisterMachineRequestBuilder(provisionerName string, f MachineRequestBuild
 type Machines interface {
 	// NewMachines creates an instance of the manager given the backing store.
 	NewMachineRequest(provisionerName string) (api.MachineRequest, error)
-
-	// Unmarshal decodes the bytes and applies onto the machine object, using a given encoding.
-	// If nil codec is passed, the default encoding / content type will be used.
-	Unmarshal(contentType *Codec, data []byte, m api.MachineRequest) error
-
-	// Marshal encodes the given machine object and returns the bytes.
-	// If nil codec is passed, the default encoding / content type will be used.
-	Marshal(contentType *Codec, m api.MachineRequest) ([]byte, error)
 
 	// List
 	List() ([]storage.MachineSummary, error)
@@ -77,18 +69,6 @@ func (cm *machines) NewMachineRequest(provisionerName string) (api.MachineReques
 		return c(), nil
 	}
 	return nil, fmt.Errorf("Unknown provisioner: %v", provisionerName)
-}
-
-// Unmarshal decodes the bytes and applies onto the machine object, using a given encoding.
-// If nil codec is passed, the default encoding / content type will be used.
-func (cm *machines) Unmarshal(contentType *Codec, data []byte, m api.MachineRequest) error {
-	return ensureValidContentType(contentType).unmarshal(data, m)
-}
-
-// Marshal encodes the given machine object and returns the bytes.
-// If nil codec is passed, the default encoding / content type will be used.
-func (cm *machines) Marshal(contentType *Codec, m api.MachineRequest) ([]byte, error) {
-	return ensureValidContentType(contentType).marshal(m)
 }
 
 func (cm *machines) List() ([]storage.MachineSummary, error) {
@@ -143,27 +123,52 @@ func (cm *machines) Exists(key string) bool {
 	return err == nil
 }
 
-// CreateMachine creates a new machine from the input reader.
-func (cm *machines) CreateMachine(provisioner api.Provisioner, ctx context.Context, cred api.Credential,
-	template api.MachineRequest, input io.Reader, codec *Codec) (<-chan interface{}, *Error) {
+func (cm *machines) populateRequest(
+	provisioner api.Provisioner,
+	template api.MachineRequest,
+	input io.Reader,
+	codec *Codec) (api.MachineRequest, error) {
 
-	provisionerName := cred.ProvisionerName()
-	mr := provisioner.NewRequestInstance()
+	// Three components are used to fully populate a MachineRequest:
+	// 1. a stock request with low-level defaults from the provisioner
+	// 2. an externally-defined template which may be incomplete
+	// 3. extra parameters that should supplement (and possibly override) fields in (1) or (2)
+
+	request := provisioner.NewRequestInstance()
 
 	if template != nil {
-		mr = template
+		request = template
 	}
 
 	buff, err := ioutil.ReadAll(input)
 	if err == nil && len(buff) > 0 {
-		if err = cm.Unmarshal(codec, buff, mr); err != nil {
-			return nil, &Error{Message: err.Error()}
+		err = ensureValidContentType(codec).unmarshal(buff, request)
+		if err != nil {
+			return nil, err
 		}
 	}
 
-	key := mr.Name()
+	return request, nil
+}
 
-	log.Infoln("name=", key, "cred=", cred, "template=", template, "req=", mr)
+// CreateMachine creates a new machine from the input reader.
+func (cm *machines) CreateMachine(
+	provisioner api.Provisioner,
+	ctx context.Context,
+	cred api.Credential,
+	template api.MachineRequest,
+	input io.Reader,
+	codec *Codec) (<-chan interface{}, *Error) {
+
+	provisionerName := cred.ProvisionerName()
+	request, err := cm.populateRequest(provisioner, template, input, codec)
+	if err != nil {
+		return nil, &Error{Message: err.Error()}
+	}
+
+	key := request.Name()
+
+	log.Infoln("name=", key, "cred=", cred, "template=", template, "req=", request)
 
 	if cm.Exists(key) {
 		return nil, &Error{ErrDuplicate, fmt.Sprintf("Key exists: %v", key)}
@@ -178,25 +183,14 @@ func (cm *machines) CreateMachine(provisioner api.Provisioner, ctx context.Conte
 			Created:     storage.Timestamp(time.Now().Unix()),
 		},
 	}
-	record.AppendEvent(storage.Event{Name: "init", Message: "Create starts", Data: mr})
+	record.AppendEvent(storage.Event{Name: "init", Message: "Create starts", Data: request})
 
-	if err = cm.store.Save(*record, mr); err != nil {
+	if err := cm.store.Save(*record, request); err != nil {
 		return nil, &Error{Message: err.Error()}
 	}
-	tasks := []api.Task{}
-	for _, tn := range mr.ProvisionWorkflow() {
-
-		if task, ok := GetTask(tn); ok {
-			taskHandler := provisioner.GetTaskHandler(tn)
-			if taskHandler != nil {
-				task.Do = taskHandler // override the impl
-			}
-			tasks = append(tasks, task)
-		}
-	}
-
-	if len(tasks) != len(mr.ProvisionWorkflow()) {
-		return nil, &Error{Message: "unknown tasks"}
+	tasks, err := provisioner.GetTasks(request.ProvisionWorkflow())
+	if err != nil {
+		return nil, &Error{Message: err.Error()}
 	}
 
 	log.Infoln("About to run tasks:", tasks)
@@ -213,9 +207,9 @@ func (cm *machines) CreateMachine(provisioner api.Provisioner, ctx context.Conte
 			go func() {
 				log.Infoln("RUNNING:", task)
 				event := storage.Event{
-					Name: string(task.Type),
+					Name: string(task.Name),
 				}
-				if err := task.Do(ctx, cred, mr, taskEvents); err != nil {
+				if err := task.Do(provisioner, ctx, cred, request, taskEvents); err != nil {
 					event.Message = task.Message + " errored: " + err.Error()
 					event.Error = err.Error()
 				} else {
@@ -235,13 +229,13 @@ func (cm *machines) CreateMachine(provisioner api.Provisioner, ctx context.Conte
 				stop := false
 
 				event := storage.Event{
-					Name: string(task.Type),
+					Name: string(task.Name),
 				}
 
 				event.Data = te
 
-				// Some events implement both Error and HashMachineState.  So first check for errors
-				// then do type switch on HashMachineState
+				// Some events implement both Error and HashMachineState.
+				// So first check for errors then do type switch on HashMachineState
 
 				log.Infoln("Check error:", te)
 				switch te := te.(type) {
@@ -263,12 +257,12 @@ func (cm *machines) CreateMachine(provisioner api.Provisioner, ctx context.Conte
 					log.Infoln("HasMachineState:", te)
 					if provisionedState := ms.GetState(); provisionedState != nil {
 						log.Infoln("Final provisioned state:", provisionedState)
-						mr = provisionedState
+						request = provisionedState
 					}
 				}
 
 				record.AppendEvent(event)
-				err = cm.store.Save(*record, mr)
+				err = cm.store.Save(*record, request)
 				log.Infoln("Saved:", "err=", err, len(record.Events), record)
 
 				if stop {
@@ -276,7 +270,7 @@ func (cm *machines) CreateMachine(provisioner api.Provisioner, ctx context.Conte
 
 					record.Status = "failed"
 					record.LastModified = storage.Timestamp(time.Now().Unix())
-					err := cm.store.Save(*record, mr)
+					err := cm.store.Save(*record, request)
 					if err != nil {
 						log.Warningln("err=", err)
 					}
@@ -286,13 +280,13 @@ func (cm *machines) CreateMachine(provisioner api.Provisioner, ctx context.Conte
 
 			record.Status = "running"
 			record.LastModified = storage.Timestamp(time.Now().Unix())
-			if ip, err := provisioner.GetIPAddress(mr); err == nil {
+			if ip, err := provisioner.GetIPAddress(request); err == nil {
 				record.IPAddress = ip
 			} else {
 				log.Warning("can't get ip=", err)
 			}
 
-			err := cm.store.Save(*record, mr)
+			err := cm.store.Save(*record, request)
 			if err != nil {
 				log.Warningln("err=", err)
 			}

--- a/provisioners/aws/aws_test.go
+++ b/provisioners/aws/aws_test.go
@@ -57,9 +57,6 @@ func (w WrongRequestType) Name() string {
 	return "nope"
 }
 
-func (w *WrongRequestType) SetName(_ string) {
-}
-
 func (w WrongRequestType) ProvisionerName() string {
 	return "nope"
 }
@@ -68,8 +65,8 @@ func (w WrongRequestType) Version() string {
 	return "nope"
 }
 
-func (w WrongRequestType) ProvisionWorkflow() []api.TaskType {
-	return []api.TaskType{}
+func (w WrongRequestType) ProvisionWorkflow() []api.TaskName {
+	return []api.TaskName{}
 }
 
 func TestCreateIncompatibleType(t *testing.T) {

--- a/provisioners/aws/init.go
+++ b/provisioners/aws/init.go
@@ -1,20 +1,8 @@
 package aws
 
 import (
-	log "github.com/Sirupsen/logrus"
 	"github.com/docker/libmachete"
-	"github.com/docker/libmachete/provisioners/api"
-	"golang.org/x/net/context"
-	"time"
 )
-
-func dummy(m string) api.TaskHandler {
-	return func(ctx context.Context, cred api.Credential, req api.MachineRequest, events chan<- interface{}) error {
-		time.Sleep(5 * time.Second)
-		log.Infoln(m)
-		return nil
-	}
-}
 
 func init() {
 	libmachete.RegisterContextBuilder(ProvisionerName, BuildContextFromKVPair)

--- a/provisioners/azure/azure.go
+++ b/provisioners/azure/azure.go
@@ -21,13 +21,21 @@ func NewMachineRequest() api.MachineRequest {
 	req := new(CreateInstanceRequest)
 	req.Provisioner = ProvisionerName
 	req.ProvisionerVersion = ProvisionerVersion
-	req.Workflow = []api.TaskType{
-		libmachete.TaskSSHKeyGen.Type,
-		libmachete.TaskCreateInstance.Type,
-		libmachete.TaskUserData.Type,
-		libmachete.TaskInstallDockerEngine.Type,
-	}
+	req.Workflow = getTaskMap().Names()
 	return req
+}
+
+func getTaskMap() *libmachete.TaskMap {
+	return libmachete.NewTaskMap(
+		libmachete.TaskSSHKeyGen,
+		libmachete.TaskUserData,
+		libmachete.TaskInstallDockerEngine,
+		libmachete.TaskCreateInstance,
+	)
+}
+
+func (p *provisioner) GetTasks(tasks []api.TaskName) ([]api.Task, error) {
+	return getTaskMap().Filter(tasks)
 }
 
 func (p *provisioner) NewRequestInstance() api.MachineRequest {
@@ -35,10 +43,6 @@ func (p *provisioner) NewRequestInstance() api.MachineRequest {
 }
 
 func (p *provisioner) GetIPAddress(req api.MachineRequest) (string, error) {
-	panic(errors.New("not implemented"))
-}
-
-func (p *provisioner) GetTaskHandler(t api.TaskType) api.TaskHandler {
 	panic(errors.New("not implemented"))
 }
 

--- a/provisioners/mock/mock_provisioner.go
+++ b/provisioners/mock/mock_provisioner.go
@@ -62,14 +62,15 @@ func (_mr *_MockProvisionerRecorder) GetIPAddress(arg0 interface{}) *gomock.Call
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "GetIPAddress", arg0)
 }
 
-func (_m *MockProvisioner) GetTaskHandler(_param0 api.TaskType) api.TaskHandler {
-	ret := _m.ctrl.Call(_m, "GetTaskHandler", _param0)
-	ret0, _ := ret[0].(api.TaskHandler)
-	return ret0
+func (_m *MockProvisioner) GetTasks(_param0 []api.TaskName) ([]api.Task, error) {
+	ret := _m.ctrl.Call(_m, "GetTasks", _param0)
+	ret0, _ := ret[0].([]api.Task)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
 }
 
-func (_mr *_MockProvisionerRecorder) GetTaskHandler(arg0 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "GetTaskHandler", arg0)
+func (_mr *_MockProvisionerRecorder) GetTasks(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "GetTasks", arg0)
 }
 
 func (_m *MockProvisioner) NewRequestInstance() api.MachineRequest {

--- a/tasks_test.go
+++ b/tasks_test.go
@@ -1,0 +1,36 @@
+package libmachete
+
+import (
+	"github.com/docker/libmachete/provisioners/api"
+	"github.com/stretchr/testify/require"
+	"testing"
+)
+
+func makeTask(name string) api.Task {
+	return api.Task{
+		Name:    api.TaskName(name),
+		Message: "message",
+		Do:      nil,
+	}
+}
+
+func TestTaskMap(t *testing.T) {
+	a := makeTask("a")
+	b := makeTask("b")
+	c := makeTask("c")
+
+	require.Panics(t, func() {
+		NewTaskMap(a, a)
+	})
+
+	taskMap := NewTaskMap(a, b, c)
+
+	require.Equal(t, []api.TaskName{a.Name, b.Name, c.Name}, taskMap.Names())
+
+	_, err := taskMap.Filter([]api.TaskName{api.TaskName("d")})
+	require.Error(t, err)
+
+	filtered, err := taskMap.Filter([]api.TaskName{a.Name, c.Name})
+	require.NoError(t, err)
+	require.Equal(t, []api.Task{a, c}, filtered)
+}


### PR DESCRIPTION
This inverts the flow of specifying/overriding tasks to place it entirely in the control of the provisioner.  The provisioner is now able to easily add/remove/customize tasks in a direct way.
