### PR TITLE
Collapse multiple provisioner-related registries into one.

### DIFF
--- a/Godeps/Godeps.json
+++ b/Godeps/Godeps.json
@@ -1,7 +1,7 @@
 {
 	"ImportPath": "github.com/docker/libmachete",
 	"GoVersion": "go1.6",
-	"GodepVersion": "v63",
+	"GodepVersion": "v69",
 	"Packages": [
 		"./..."
 	],
@@ -148,17 +148,14 @@
 		},
 		{
 			"ImportPath": "github.com/conductant/gohm/pkg/auth",
-			"Comment": "v0.1-5-g75cd719",
 			"Rev": "75cd71981203dec11a63c486f27ca79ec41cc319"
 		},
 		{
 			"ImportPath": "github.com/conductant/gohm/pkg/encoding",
-			"Comment": "v0.1-5-g75cd719",
 			"Rev": "75cd71981203dec11a63c486f27ca79ec41cc319"
 		},
 		{
 			"ImportPath": "github.com/conductant/gohm/pkg/server",
-			"Comment": "v0.1-5-g75cd719",
 			"Rev": "75cd71981203dec11a63c486f27ca79ec41cc319"
 		},
 		{

--- a/contexts.go
+++ b/contexts.go
@@ -16,31 +16,19 @@ type KVPair map[string]interface{}
 // can load in configuration parameters such as region, timeouts, OAuth app id, etc.
 type ContextBuilder func(context.Context, KVPair) context.Context
 
-var (
-	contextBuilders = map[string]ContextBuilder{}
-)
-
-// RegisterContextBuilder registers the a provisioner's configuration / context builder.
-// This method should be invoke in the init() of the provisioner package.
-func RegisterContextBuilder(provisionerName string, f ContextBuilder) {
-	lock.Lock()
-	defer lock.Unlock()
-
-	contextBuilders[provisionerName] = f
-}
-
 // BuildContext builds the runtime context customized for the provisioner
 func BuildContext(provisionerName string, root context.Context, ctx Context) context.Context {
-	builder, has := contextBuilders[provisionerName]
+	builder, has := GetProvisionerBuilder(provisionerName)
 	if !has {
 		return root
 	}
+
 	// get the NVPair by the provisioner name
 	nvpair, has := ctx[provisionerName]
 	if !has {
 		return root
 	}
-	return builder(root, nvpair)
+	return builder.BuildContext(root, nvpair)
 }
 
 // Context is the application / provisioner-level configuration object that

--- a/machines.go
+++ b/machines.go
@@ -16,24 +16,8 @@ import (
 // that satisfies the MachineRequest interface.
 type MachineRequestBuilder func() api.MachineRequest
 
-var (
-	machineCreators = map[string]MachineRequestBuilder{}
-)
-
-// RegisterMachineRequestBuilder registers by provisioner the request builder.
-// This method should be invoke in the init() of the provisioner package.
-func RegisterMachineRequestBuilder(provisionerName string, f MachineRequestBuilder) {
-	lock.Lock()
-	defer lock.Unlock()
-
-	machineCreators[provisionerName] = f
-}
-
 // Machines manages the lifecycle of a machine / node.
 type Machines interface {
-	// NewMachines creates an instance of the manager given the backing store.
-	NewMachineRequest(provisionerName string) (api.MachineRequest, error)
-
 	// List
 	List() ([]storage.MachineSummary, error)
 
@@ -61,14 +45,6 @@ type machines struct {
 // NewMachines creates an instance of the manager given the backing store.
 func NewMachines(store storage.Machines) Machines {
 	return &machines{store: store}
-}
-
-// NewMachine returns an empty machine object for a provisioner.
-func (cm *machines) NewMachineRequest(provisionerName string) (api.MachineRequest, error) {
-	if c, has := machineCreators[provisionerName]; has {
-		return c(), nil
-	}
-	return nil, fmt.Errorf("Unknown provisioner: %v", provisionerName)
 }
 
 func (cm *machines) List() ([]storage.MachineSummary, error) {

--- a/provisioners.go
+++ b/provisioners.go
@@ -3,26 +3,43 @@ package libmachete
 import (
 	"github.com/docker/libmachete/provisioners/api"
 	"golang.org/x/net/context"
+	"sync"
 )
 
-// ProvisionerBuilder constructs an instance of provisioner given the context and credential.
-type ProvisionerBuilder func(context.Context, api.Credential) (api.Provisioner, error)
-
-var (
-	provisionerBuilders = map[string]ProvisionerBuilder{}
-)
-
-// RegisterProvisionerBuilder is called in the init() of the provisioner package to register provisioner implementation
-func RegisterProvisionerBuilder(provisionerName string, builder ProvisionerBuilder) {
-	lock.Lock()
-	defer lock.Unlock()
-	provisionerBuilders[provisionerName] = builder
+// ProvisionerBuilder defines structures needed for the provisioner to operate, and is capable
+// of constructing a provisioner.
+type ProvisionerBuilder struct {
+	Name                  string
+	DefaultCredential     api.Credential
+	DefaultMachineRequest api.MachineRequest
+	BuildContext          ContextBuilder
+	Build                 func(ctx context.Context, cred api.Credential) (api.Provisioner, error)
 }
 
-// GetProvisioner returns an instance of a provisioner identified by name and for the running context and credential
-func GetProvisioner(provisionerName string, ctx context.Context, cred api.Credential) (api.Provisioner, error) {
-	if builder, has := provisionerBuilders[provisionerName]; has {
-		return builder(ctx, cred)
+var (
+	buildersLock = sync.Mutex{}
+	builders     = map[string]ProvisionerBuilder{}
+)
+
+// RegisterProvisioner makes a provisioner available for other components to fetch.
+func RegisterProvisioner(builder ProvisionerBuilder) {
+	buildersLock.Lock()
+	defer buildersLock.Unlock()
+
+	builders[builder.Name] = builder
+}
+
+// GetProvisionerBuilder fetches a provisioner builder by name.
+func GetProvisionerBuilder(name string) (ProvisionerBuilder, bool) {
+	builder, has := builders[name]
+	return builder, has
+}
+
+// GetProvisioner returns an instance of a provisioner identified by name and for the running
+// context and credential.
+func GetProvisioner(name string, ctx context.Context, cred api.Credential) (api.Provisioner, error) {
+	if builder, has := builders[name]; has {
+		return builder.Build(ctx, cred)
 	}
-	return nil, &Error{Code: ErrNotFound, Message: "no such provisioner " + provisionerName}
+	return nil, &Error{Code: ErrNotFound, Message: "no such provisioner " + name}
 }

--- a/provisioners/aws/init.go
+++ b/provisioners/aws/init.go
@@ -5,11 +5,13 @@ import (
 )
 
 func init() {
-	libmachete.RegisterContextBuilder(ProvisionerName, BuildContextFromKVPair)
-	libmachete.RegisterCredentialer(ProvisionerName, NewCredential)
-	libmachete.RegisterTemplateBuilder(ProvisionerName, NewMachineRequest)
-	libmachete.RegisterMachineRequestBuilder(ProvisionerName, NewMachineRequest)
-	libmachete.RegisterProvisionerBuilder(ProvisionerName, ProvisionerWith)
+	libmachete.RegisterProvisioner(libmachete.ProvisionerBuilder{
+		Name:                  ProvisionerName,
+		DefaultCredential:     NewCredential(),
+		DefaultMachineRequest: NewMachineRequest(),
+		BuildContext:          BuildContextFromKVPair,
+		Build:                 ProvisionerWith,
+	})
 }
 
 const (

--- a/provisioners/azure/init.go
+++ b/provisioners/azure/init.go
@@ -5,10 +5,13 @@ import (
 )
 
 func init() {
-	libmachete.RegisterCredentialer(ProvisionerName, NewCredential)
-	libmachete.RegisterTemplateBuilder(ProvisionerName, NewMachineRequest)
-	libmachete.RegisterMachineRequestBuilder(ProvisionerName, NewMachineRequest)
-	libmachete.RegisterProvisionerBuilder(ProvisionerName, ProvisionerWith)
+	libmachete.RegisterProvisioner(libmachete.ProvisionerBuilder{
+		Name:                  ProvisionerName,
+		DefaultCredential:     NewCredential(),
+		DefaultMachineRequest: NewMachineRequest(),
+		BuildContext:          nil,
+		Build:                 ProvisionerWith,
+	})
 }
 
 const (


### PR DESCRIPTION
This at least clarifies what a provisioner _should_ provide to satisfy all components.  Note that `azure/init.go` was missing a call to `libmachete.RegisterContextBuilder()`, which i have glossed over for now.

Eventually i would like to push the registry pattern out of the majority of the codebase to make the design easier to follow and more testable.  We can address the desire to provide import-only component registration in a higher level to simplify use for callers.
