### PR TITLE
Improve testability of stores by allowing Sandbox injection

### DIFF
--- a/storage/filestores/contexts.go
+++ b/storage/filestores/contexts.go
@@ -5,25 +5,20 @@ import (
 )
 
 type contexts struct {
-	sandbox *sandbox
+	sandbox Sandbox
 }
 
-// NewContexts creates a new contexts store backed by the local file system.
-func NewContexts(dir string) (storage.Contexts, error) {
-	sandbox, err := newSandbox(dir)
-	if err != nil {
-		return nil, err
-	}
-
-	return &contexts{sandbox: sandbox}, nil
+// NewContexts creates a new contexts store within the provided sandbox.
+func NewContexts(sandbox Sandbox) storage.Contexts {
+	return &contexts{sandbox: sandbox}
 }
 
 func (c contexts) Save(id storage.ContextID, contextData interface{}) error {
-	return c.sandbox.MarshalAndSave(string(id), contextData)
+	return c.sandbox.marshalAndSave(string(id), contextData)
 }
 
 func (c contexts) List() ([]storage.ContextID, error) {
-	contents, err := c.sandbox.List()
+	contents, err := c.sandbox.list()
 	if err != nil {
 		return nil, err
 	}
@@ -35,9 +30,9 @@ func (c contexts) List() ([]storage.ContextID, error) {
 }
 
 func (c contexts) GetContext(id storage.ContextID, contextData interface{}) error {
-	return c.sandbox.ReadAndUnmarshal(string(id), contextData)
+	return c.sandbox.readAndUnmarshal(string(id), contextData)
 }
 
 func (c contexts) Delete(id storage.ContextID) error {
-	return c.sandbox.Remove(string(id))
+	return c.sandbox.remove(string(id))
 }

--- a/storage/filestores/credentials.go
+++ b/storage/filestores/credentials.go
@@ -5,25 +5,20 @@ import (
 )
 
 type credentials struct {
-	sandbox *sandbox
+	sandbox Sandbox
 }
 
-// NewCredentials creates a new credentials store backed by the local file system.
-func NewCredentials(dir string) (storage.Credentials, error) {
-	sandbox, err := newSandbox(dir)
-	if err != nil {
-		return nil, err
-	}
-
-	return &credentials{sandbox: sandbox}, nil
+// NewCredentials creates a new credentials store within the provided sandbox.
+func NewCredentials(sandbox Sandbox) storage.Credentials {
+	return &credentials{sandbox: sandbox}
 }
 
 func (c credentials) Save(id storage.CredentialsID, credentialsData interface{}) error {
-	return c.sandbox.MarshalAndSave(string(id), credentialsData)
+	return c.sandbox.marshalAndSave(string(id), credentialsData)
 }
 
 func (c credentials) List() ([]storage.CredentialsID, error) {
-	contents, err := c.sandbox.List()
+	contents, err := c.sandbox.list()
 	if err != nil {
 		return nil, err
 	}
@@ -35,9 +30,9 @@ func (c credentials) List() ([]storage.CredentialsID, error) {
 }
 
 func (c credentials) GetCredentials(id storage.CredentialsID, credentialsData interface{}) error {
-	return c.sandbox.ReadAndUnmarshal(string(id), credentialsData)
+	return c.sandbox.readAndUnmarshal(string(id), credentialsData)
 }
 
 func (c credentials) Delete(id storage.CredentialsID) error {
-	return c.sandbox.Remove(string(id))
+	return c.sandbox.remove(string(id))
 }

--- a/storage/filestores/credentials_test.go
+++ b/storage/filestores/credentials_test.go
@@ -17,7 +17,7 @@ func TestCredentialsCrud(t *testing.T) {
 	fs := afero.NewMemMapFs()
 	testPath := ".machete/credentials"
 	require.NoError(t, fs.Mkdir(testPath, 0700))
-	store := credentials{sandbox: &sandbox{fs: fs, dir: testPath}}
+	store := credentials{sandbox: Sandbox{fs: fs, dir: testPath}}
 
 	idA := storage.CredentialsID("id_a")
 

--- a/storage/filestores/machines.go
+++ b/storage/filestores/machines.go
@@ -7,31 +7,26 @@ import (
 )
 
 type machines struct {
-	sandbox *sandbox
+	sandbox Sandbox
 }
 
-// NewMachines creates a new machine store backed by the local file system.
-func NewMachines(dir string) (storage.Machines, error) {
-	sandbox, err := newSandbox(dir)
-	if err != nil {
-		return nil, err
-	}
-
-	return &machines{sandbox: sandbox}, nil
+// NewMachines creates a new machine store within the provided sandbox.
+func NewMachines(sandbox Sandbox) storage.Machines {
+	return &machines{sandbox: sandbox}
 }
 
 func (m machines) Save(record storage.MachineRecord, provisionerData interface{}) error {
-	err := m.sandbox.Mkdir(string(record.Name))
+	err := m.sandbox.mkdir(string(record.Name))
 	if err != nil {
 		return fmt.Errorf("Failed to create machine directory: %s", err)
 	}
 
-	err = m.sandbox.MarshalAndSave(m.recordPath(record.Name), record)
+	err = m.sandbox.marshalAndSave(m.recordPath(record.Name), record)
 	if err != nil {
 		return err
 	}
 
-	err = m.sandbox.MarshalAndSave(m.provisionerRecordPath(record.Name), provisionerData)
+	err = m.sandbox.marshalAndSave(m.provisionerRecordPath(record.Name), provisionerData)
 	if err != nil {
 		return err
 	}
@@ -40,7 +35,7 @@ func (m machines) Save(record storage.MachineRecord, provisionerData interface{}
 }
 
 func (m machines) List() ([]storage.MachineID, error) {
-	contents, err := m.sandbox.List()
+	contents, err := m.sandbox.list()
 	if err != nil {
 		return nil, err
 	}
@@ -53,7 +48,7 @@ func (m machines) List() ([]storage.MachineID, error) {
 
 func (m machines) GetRecord(id storage.MachineID) (*storage.MachineRecord, error) {
 	record := new(storage.MachineRecord)
-	err := m.sandbox.ReadAndUnmarshal(m.recordPath(id), record)
+	err := m.sandbox.readAndUnmarshal(m.recordPath(id), record)
 	if err != nil {
 		return nil, err
 	}
@@ -61,12 +56,12 @@ func (m machines) GetRecord(id storage.MachineID) (*storage.MachineRecord, error
 }
 
 func (m machines) GetDetails(id storage.MachineID, provisionerData interface{}) error {
-	err := m.sandbox.ReadAndUnmarshal(m.provisionerRecordPath(id), provisionerData)
+	err := m.sandbox.readAndUnmarshal(m.provisionerRecordPath(id), provisionerData)
 	return err
 }
 
 func (m machines) Delete(id storage.MachineID) error {
-	return m.sandbox.RemoveAll(m.machinePath(id))
+	return m.sandbox.removeAll(m.machinePath(id))
 }
 
 func (m machines) machinePath(id storage.MachineID) string {

--- a/storage/filestores/machines_test.go
+++ b/storage/filestores/machines_test.go
@@ -17,7 +17,7 @@ func TestMachinesCrud(t *testing.T) {
 	fs := afero.NewMemMapFs()
 	testPath := ".machete/machines"
 	require.NoError(t, fs.Mkdir(testPath, 0700))
-	store := machines{sandbox: &sandbox{fs: fs, dir: testPath}}
+	store := machines{sandbox: Sandbox{fs: fs, dir: testPath}}
 
 	db16 := storage.MachineID("db-16")
 

--- a/storage/filestores/templates.go
+++ b/storage/filestores/templates.go
@@ -5,25 +5,20 @@ import (
 )
 
 type templates struct {
-	sandbox *sandbox
+	sandbox Sandbox
 }
 
 // NewTemplates creates a new templates store backed by the local file system.
-func NewTemplates(dir string) (storage.Templates, error) {
-	sandbox, err := newSandbox(dir)
-	if err != nil {
-		return nil, err
-	}
-
-	return &templates{sandbox: sandbox}, nil
+func NewTemplates(sandbox Sandbox) storage.Templates {
+	return &templates{sandbox: sandbox}
 }
 
 func (c templates) Save(id storage.TemplateID, templatesData interface{}) error {
-	return c.sandbox.MarshalAndSave(id.Key(), templatesData)
+	return c.sandbox.marshalAndSave(id.Key(), templatesData)
 }
 
 func (c templates) List() ([]storage.TemplateID, error) {
-	contents, err := c.sandbox.List()
+	contents, err := c.sandbox.list()
 	if err != nil {
 		return nil, err
 	}
@@ -35,9 +30,9 @@ func (c templates) List() ([]storage.TemplateID, error) {
 }
 
 func (c templates) GetTemplate(id storage.TemplateID, templatesData interface{}) error {
-	return c.sandbox.ReadAndUnmarshal(id.Key(), templatesData)
+	return c.sandbox.readAndUnmarshal(id.Key(), templatesData)
 }
 
 func (c templates) Delete(id storage.TemplateID) error {
-	return c.sandbox.Remove(id.Key())
+	return c.sandbox.remove(id.Key())
 }


### PR DESCRIPTION
This will allow for cleaner integration tests as an in-memory file system can be used throughout.  I also introduced the `Sandbox` `Nested()` and `Mkdirs()` functions to simplify setup for the caller.
