### PR TITLE
Introduce a slimmed-down HTTP handler interface

### DIFF
--- a/cmd/machined/http/templates.go
+++ b/cmd/machined/http/templates.go
@@ -1,8 +1,6 @@
 package http
 
 import (
-	"fmt"
-	log "github.com/Sirupsen/logrus"
 	"github.com/docker/libmachete"
 	"github.com/docker/libmachete/storage"
 	"github.com/gorilla/mux"
@@ -13,85 +11,28 @@ type templatesHandler struct {
 	templates libmachete.Templates
 }
 
-func (h *templatesHandler) getOne(resp http.ResponseWriter, req *http.Request) {
-	id := getTemplateID(req)
-	template, err := h.templates.Get(id)
-	if err != nil {
-		respondError(http.StatusNotFound, resp, fmt.Errorf("Unknown template:%s", id.Name))
-		return
-	}
-	libmachete.ContentTypeJSON.Respond(resp, template)
+func (h *templatesHandler) getOne(req *http.Request) (interface{}, *libmachete.Error) {
+	return h.templates.Get(getTemplateID(req))
 }
 
-func (h *templatesHandler) getBlank(resp http.ResponseWriter, req *http.Request) {
-	provisioner := getProvisionerName(req)
-	log.Infof("Get template example %v", provisioner)
-
-	example, err := h.templates.NewBlankTemplate(provisioner)
-	if err != nil {
-		respondError(http.StatusNotFound, resp, err)
-		return
-	}
-	libmachete.ContentTypeJSON.Respond(resp, example)
+func (h *templatesHandler) getBlank(req *http.Request) (interface{}, *libmachete.Error) {
+	return h.templates.NewBlankTemplate(getProvisionerName(req))
 }
 
-func (h *templatesHandler) getAll(resp http.ResponseWriter, req *http.Request) {
-	log.Infoln("List templates")
-	all, err := h.templates.ListIds()
-	if err != nil {
-		respondError(http.StatusInternalServerError, resp, err)
-		return
-	}
-	libmachete.ContentTypeJSON.Respond(resp, all)
+func (h *templatesHandler) getAll(req *http.Request) (interface{}, *libmachete.Error) {
+	return h.templates.ListIds()
 }
 
-var errorCodeMap = map[int]int{
-	libmachete.ErrBadInput:  http.StatusBadRequest,
-	libmachete.ErrUnknown:   http.StatusInternalServerError,
-	libmachete.ErrDuplicate: http.StatusConflict,
-	libmachete.ErrNotFound:  http.StatusNotFound,
+func (h *templatesHandler) create(req *http.Request) (interface{}, *libmachete.Error) {
+	return nil, h.templates.CreateTemplate(getTemplateID(req), req.Body, libmachete.ContentTypeJSON)
 }
 
-func handleError(resp http.ResponseWriter, err libmachete.Error) {
-	statusCode, mapped := errorCodeMap[err.Code]
-	if !mapped {
-		statusCode = http.StatusInternalServerError
-	}
-
-	respondError(statusCode, resp, err)
+func (h *templatesHandler) update(req *http.Request) (interface{}, *libmachete.Error) {
+	return nil, h.templates.UpdateTemplate(getTemplateID(req), req.Body, libmachete.ContentTypeJSON)
 }
 
-func (h *templatesHandler) create(resp http.ResponseWriter, req *http.Request) {
-	id := getTemplateID(req)
-	log.Infof("Add template %v", id)
-
-	err := h.templates.CreateTemplate(id, req.Body, libmachete.ContentTypeJSON)
-
-	if err != nil {
-		handleError(resp, *err)
-	}
-}
-
-func (h *templatesHandler) update(resp http.ResponseWriter, req *http.Request) {
-	id := getTemplateID(req)
-	log.Infof("Update template %v", id.Name)
-
-	err := h.templates.UpdateTemplate(id, req.Body, libmachete.ContentTypeJSON)
-
-	if err != nil {
-		handleError(resp, *err)
-	}
-}
-
-func (h *templatesHandler) delete(resp http.ResponseWriter, req *http.Request) {
-	id := getTemplateID(req)
-	err := h.templates.Delete(id)
-
-	// TODO(wfarner): Convert to use handleError() for status code mapping.
-	if err != nil {
-		respondError(http.StatusNotFound, resp, fmt.Errorf("Unknown template:%s", id.Name))
-		return
-	}
+func (h *templatesHandler) delete(req *http.Request) (interface{}, *libmachete.Error) {
+	return nil, h.templates.Delete(getTemplateID(req))
 }
 
 func getTemplateID(request *http.Request) storage.TemplateID {
@@ -106,10 +47,10 @@ func getProvisionerName(request *http.Request) string {
 }
 
 func (h *templatesHandler) attachTo(router *mux.Router) {
-	router.HandleFunc("/json", h.getAll).Methods("GET")
-	router.HandleFunc("/meta/{provisioner}/json", h.getBlank).Methods("GET")
-	router.HandleFunc("/{provisioner}/{key}/create", h.create).Methods("POST")
-	router.HandleFunc("/{provisioner}/{key}", h.update).Methods("PUT")
-	router.HandleFunc("/{provisioner}/{key}/json", h.getOne).Methods("GET")
-	router.HandleFunc("/{provisioner}/{key}", h.delete).Methods("DELETE")
+	router.HandleFunc("/json", outputHandler(h.getAll)).Methods("GET")
+	router.HandleFunc("/meta/{provisioner}/json", outputHandler(h.getBlank)).Methods("GET")
+	router.HandleFunc("/{provisioner}/{key}/create", outputHandler(h.create)).Methods("POST")
+	router.HandleFunc("/{provisioner}/{key}", outputHandler(h.update)).Methods("PUT")
+	router.HandleFunc("/{provisioner}/{key}/json", outputHandler(h.getOne)).Methods("GET")
+	router.HandleFunc("/{provisioner}/{key}", outputHandler(h.delete)).Methods("DELETE")
 }

--- a/cmd/machined/http/types.go
+++ b/cmd/machined/http/types.go
@@ -1,8 +1,41 @@
 package http
 
 import (
+	"github.com/docker/libmachete"
 	"net/http"
 )
 
 // Handler is shorthand for an HTTP request handler function.
 type Handler func(resp http.ResponseWriter, req *http.Request)
+
+var errorCodeMap = map[int]int{
+	libmachete.ErrBadInput:  http.StatusBadRequest,
+	libmachete.ErrUnknown:   http.StatusInternalServerError,
+	libmachete.ErrDuplicate: http.StatusConflict,
+	libmachete.ErrNotFound:  http.StatusNotFound,
+}
+
+// SimpleHandler is a reduced HTTP handler interface that may be used with handleError().
+type SimpleHandler func(req *http.Request) (interface{}, *libmachete.Error)
+
+func handleError(err libmachete.Error, resp http.ResponseWriter) {
+	statusCode, mapped := errorCodeMap[err.Code]
+	if !mapped {
+		statusCode = http.StatusInternalServerError
+	}
+
+	respondError(statusCode, resp, err)
+}
+
+func outputHandler(handler SimpleHandler) Handler {
+	return func(resp http.ResponseWriter, req *http.Request) {
+		result, err := handler(req)
+		if result != nil {
+			libmachete.ContentTypeJSON.Respond(resp, result)
+		}
+
+		if err != nil {
+			handleError(*err, resp)
+		}
+	}
+}

--- a/storage/filestores/templates.go
+++ b/storage/filestores/templates.go
@@ -29,6 +29,8 @@ func (c templates) List() ([]storage.TemplateID, error) {
 	return ids, nil
 }
 
+// TODO(wfarner): Consider pushing unmarshaling higher up the stack.  At the very least, other store implementations
+// should not need to reimplement this.
 func (c templates) GetTemplate(id storage.TemplateID, templatesData interface{}) error {
 	return c.sandbox.readAndUnmarshal(id.Key(), templatesData)
 }

--- a/templates.go
+++ b/templates.go
@@ -15,31 +15,16 @@ type TemplateBuilder MachineRequestBuilder
 // Templates looks up and reads template data, scoped by provisioner name.
 type Templates interface {
 	// NewTemplate returns a blank template, which can be used to describe the template schema.
-	NewBlankTemplate(provisionerName string) (api.MachineRequest, error)
-
-	// Unmarshal decodes the bytes and applies onto the machine request object, using a given encoding.
-	// If nil codec is passed, the default encoding / content type will be used.
-	Unmarshal(contentType *Codec, data []byte, cred api.MachineRequest) error
-
-	// Marshal encodes the given template object and returns the bytes.
-	// If nil codec is passed, the default encoding / content type will be used.
-	Marshal(contentType *Codec, cred api.MachineRequest) ([]byte, error)
+	NewBlankTemplate(provisionerName string) (api.MachineRequest, *Error)
 
 	// ListIds
-	ListIds() ([]storage.TemplateID, error)
-
-	// Saves the template identified by provisioner and key
-	Save(id storage.TemplateID, cred api.MachineRequest) error
+	ListIds() ([]storage.TemplateID, *Error)
 
 	// Get returns a template identified by provisioner and key
-	Get(id storage.TemplateID) (api.MachineRequest, error)
+	Get(id storage.TemplateID) (api.MachineRequest, *Error)
 
 	// Deletes the template identified by provisioner and key
-	// TODO(wfarner): Consider replacing this return type (and others) to *Error for uniformity.
-	Delete(id storage.TemplateID) error
-
-	// Exists returns true if template identified by provisioner and key already exists
-	Exists(id storage.TemplateID) bool
+	Delete(id storage.TemplateID) *Error
 
 	// CreateTemplate adds a new template from the input reader.
 	CreateTemplate(id storage.TemplateID, input io.Reader, codec *Codec) *Error
@@ -58,86 +43,82 @@ func NewTemplates(store storage.Templates, provisioners *MachineProvisioners) Te
 	return &templates{store: store, provisioners: provisioners}
 }
 
-func (t *templates) NewBlankTemplate(provisionerName string) (api.MachineRequest, error) {
+func (t *templates) NewBlankTemplate(provisionerName string) (api.MachineRequest, *Error) {
 	if builder, has := t.provisioners.GetBuilder(provisionerName); has {
 		return builder.DefaultMachineRequest(), nil
 	}
-	return nil, fmt.Errorf("Unknown provisioner: %v", provisionerName)
+	return nil, &Error{ErrBadInput, fmt.Sprintf("Unknown provisioner: %v", provisionerName)}
 }
 
-// Unmarshal decodes the bytes and applies onto the template object, using a given encoding.
-// If nil codec is passed, the default encoding / content type will be used.
-func (t *templates) Unmarshal(contentType *Codec, data []byte, tmpl api.MachineRequest) error {
-	return contentType.unmarshal(data, tmpl)
-}
-
-// Marshal encodes the given template object and returns the bytes.
-// If nil codec is passed, the default encoding / content type will be used.
-func (t *templates) Marshal(contentType *Codec, tmpl api.MachineRequest) ([]byte, error) {
-	return contentType.marshal(tmpl)
-}
-
-func (t *templates) ListIds() ([]storage.TemplateID, error) {
-	return t.store.List()
-}
-
-func (t *templates) Save(id storage.TemplateID, tmpl api.MachineRequest) error {
-	return t.store.Save(id, tmpl)
-}
-
-func (t *templates) Get(id storage.TemplateID) (api.MachineRequest, error) {
-	detail, err := t.NewBlankTemplate(id.Provisioner)
+func (t *templates) ListIds() ([]storage.TemplateID, *Error) {
+	ids, err := t.store.List()
 	if err != nil {
-		return nil, err
+		return nil, &Error{ErrUnknown, err.Error()}
+	}
+	return ids, nil
+}
+
+func (t *templates) Get(id storage.TemplateID) (api.MachineRequest, *Error) {
+	detail, apiErr := t.NewBlankTemplate(id.Provisioner)
+	if apiErr != nil {
+		return nil, apiErr
 	}
 
-	err = t.store.GetTemplate(id, detail)
+	err := t.store.GetTemplate(id, detail)
 	if err != nil {
-		return nil, err
+		return nil, &Error{ErrNotFound, err.Error()}
 	}
 	return detail, nil
 }
 
-func (t *templates) Delete(id storage.TemplateID) error {
-	return t.store.Delete(id)
+func (t *templates) Delete(id storage.TemplateID) *Error {
+	err := t.store.Delete(id)
+	if err != nil {
+		return &Error{ErrNotFound, err.Error()}
+	}
+	return nil
 }
 
-func (t *templates) Exists(id storage.TemplateID) bool {
+func (t *templates) exists(id storage.TemplateID) bool {
 	tmpl, err := t.NewBlankTemplate(id.Provisioner)
 	if err != nil {
 		return false
 	}
-	err = t.store.GetTemplate(id, tmpl)
+
 	// TODO(wfarner): This result mixes error cases (failure to read/unmarshal with absence).
-	return err == nil
+	return t.store.GetTemplate(id, tmpl) == nil
+}
+
+func (t *templates) unmarshal(contentType *Codec, data []byte, tmpl api.MachineRequest) error {
+	return contentType.unmarshal(data, tmpl)
 }
 
 func (t *templates) CreateTemplate(id storage.TemplateID, input io.Reader, codec *Codec) *Error {
-	if t.Exists(id) {
+	if t.exists(id) {
 		return &Error{ErrDuplicate, fmt.Sprintf("Key exists: %v", id)}
 	}
 
-	tmpl, err := t.NewBlankTemplate(id.Provisioner)
-	if err != nil {
+	tmpl, apiErr := t.NewBlankTemplate(id.Provisioner)
+	if apiErr != nil {
 		return &Error{ErrNotFound, fmt.Sprintf("Unknown provisioner:%s", id.Provisioner)}
 	}
 
 	buff, err := ioutil.ReadAll(input)
 	if err != nil {
-		return &Error{Message: err.Error()}
+		return &Error{ErrUnknown, err.Error()}
 	}
 
-	if err = t.Unmarshal(codec, buff, tmpl); err != nil {
+	if err = t.unmarshal(codec, buff, tmpl); err != nil {
 		return &Error{ErrBadInput, err.Error()}
 	}
-	if err = t.Save(id, tmpl); err != nil {
-		return &Error{Message: err.Error()}
+	if err = t.store.Save(id, tmpl); err != nil {
+		return &Error{ErrUnknown, err.Error()}
 	}
 	return nil
 }
 
 func (t *templates) UpdateTemplate(id storage.TemplateID, input io.Reader, codec *Codec) *Error {
-	if !t.Exists(id) {
+	if !t.exists(id) {
 		return &Error{ErrNotFound, fmt.Sprintf("Template not found: %v", id)}
 	}
 
@@ -147,16 +128,16 @@ func (t *templates) UpdateTemplate(id storage.TemplateID, input io.Reader, codec
 
 	}
 
-	tmpl, err := t.NewBlankTemplate(id.Provisioner)
-	if err != nil {
-		return &Error{ErrNotFound, fmt.Sprintf("Unknow provisioner: %v", id.Provisioner)}
+	tmpl, apiErr := t.NewBlankTemplate(id.Provisioner)
+	if apiErr != nil {
+		return apiErr
 	}
 
-	if err = t.Unmarshal(codec, buff, tmpl); err != nil {
+	if err = t.unmarshal(codec, buff, tmpl); err != nil {
 		return &Error{Message: err.Error()}
 	}
 
-	if err = t.Save(id, tmpl); err != nil {
+	if err = t.store.Save(id, tmpl); err != nil {
 		return &Error{Message: err.Error()}
 	}
 	return nil


### PR DESCRIPTION
If this looks good, i'd like to apply the pattern in other HTTP handlers.  The reduced boilerplate in HTTP handling also makes it more natural to separate logic from presentation (for example, if/when we introduce a CLI).
