### PR TITLE
Add scaffolding for /swarms endpoint

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -53,6 +53,27 @@ type Machines interface {
 		machine MachineID) (<-chan interface{}, *Error)
 }
 
+// Swarms manages the lifecycle of a cluster of machines.
+type Swarms interface {
+	// ListIDs returns the IDs for all known swarms.
+	ListIDs() ([]SwarmID, *Error)
+
+	// Get returns the description of a swarm.
+	// TODO(wfarner): Return the specific document type once defined.
+	Get(id SwarmID) (interface{}, *Error)
+
+	// CreateSwarm creates a new cluster based on instructions from the input data.
+	Create(
+		provisionerName string,
+		credentialsName string,
+		templateName string,
+		input io.Reader,
+		codec Codec) (<-chan interface{}, *Error)
+
+	// DeleteMachine deletes a swarm.
+	Delete(credentialsName string, machine SwarmID) (<-chan interface{}, *Error)
+}
+
 // SSHKeys provides operations for generating and managing SSH keys.
 type SSHKeys interface {
 	// NewKeyPair creates and saves a new key pair identified by the id

--- a/api/errors.go
+++ b/api/errors.go
@@ -42,11 +42,3 @@ func UnknownError(err error) *Error {
 func NewError(code int, format string, args ...interface{}) error {
 	return Error{Code: code, Message: fmt.Sprintf(format, args...)}
 }
-
-// IsErr returns whether the error is an Error and has the specified code
-func IsErr(e error, code int) bool {
-	if err, ok := e.(Error); ok {
-		return err.Code == code
-	}
-	return false
-}

--- a/api/types.go
+++ b/api/types.go
@@ -134,3 +134,6 @@ type TemplateID struct {
 
 // SSHKeyID is a unique id for an SSH key
 type SSHKeyID string
+
+// SwarmID is the unique id for a swarm cluster.
+type SwarmID string

--- a/cmd/machined/http/swarms.go
+++ b/cmd/machined/http/swarms.go
@@ -1,0 +1,45 @@
+package http
+
+import (
+	"github.com/docker/libmachete/api"
+	"github.com/gorilla/mux"
+	"net/http"
+)
+
+type swarmHandler struct {
+	swarms api.Swarms
+}
+
+func getSwarmID(req *http.Request) api.SwarmID {
+	return api.SwarmID(mux.Vars(req)["key"])
+}
+
+func (h *swarmHandler) getAll(req *http.Request) (interface{}, *api.Error) {
+	return h.swarms.ListIDs()
+}
+
+func (h *swarmHandler) getOne(req *http.Request) (interface{}, *api.Error) {
+	return h.swarms.Get(getSwarmID(req))
+}
+
+func (h *swarmHandler) create(req *http.Request) (interface{}, *api.Error) {
+	events, err := h.swarms.Create(
+		provisionerNameFromQuery(req),
+		orDefault(req.URL.Query().Get("credentials"), "default"),
+		orDefault(req.URL.Query().Get("template"), "default"),
+		req.Body,
+		api.ContentTypeJSON)
+	return handleEventResponse(req, events, err)
+}
+
+func (h *swarmHandler) delete(req *http.Request) (interface{}, *api.Error) {
+	events, err := h.swarms.Delete(orDefault(req.URL.Query().Get("credentials"), "default"), getSwarmID(req))
+	return handleEventResponse(req, events, err)
+}
+
+func (h *swarmHandler) attachTo(router *mux.Router) {
+	router.HandleFunc("/", outputHandler(h.getAll)).Methods("GET")
+	router.HandleFunc("/{key}", outputHandler(h.getOne)).Methods("GET")
+	router.HandleFunc("/{key}", outputHandler(h.create)).Methods("POST")
+	router.HandleFunc("/{key}", outputHandler(h.delete)).Methods("DELETE")
+}

--- a/cmd/machined/http/swarms_test.go
+++ b/cmd/machined/http/swarms_test.go
@@ -1,0 +1,30 @@
+package http
+
+import (
+	"github.com/drewolson/testflight"
+	"github.com/golang/mock/gomock"
+	"github.com/stretchr/testify/require"
+	"testing"
+)
+
+func TestSwarmLifecycle(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	_, handler := prepareTest(t, ctrl)
+
+	testflight.WithServer(handler, func(r *testflight.Requester) {
+		// Functions all return 500 as they are not yet implemented.
+		response := r.Get("/swarms")
+		require.Equal(t, 500, response.StatusCode)
+
+		response = r.Get("/swarms/production")
+		require.Equal(t, 500, response.StatusCode)
+
+		response = r.Post("/swarms/production", JSON, "")
+		require.Equal(t, 500, response.StatusCode)
+
+		response = r.Delete("/swarms/production", JSON, "")
+		require.Equal(t, 500, response.StatusCode)
+	})
+}

--- a/swarms/swarms.go
+++ b/swarms/swarms.go
@@ -1,0 +1,49 @@
+package swarms
+
+import (
+	"errors"
+	"github.com/docker/libmachete/api"
+	"github.com/docker/libmachete/machines"
+	"io"
+)
+
+type swarms struct {
+	provisioners machines.MachineProvisioners
+	templates    api.Templates
+	credentials  api.Credentials
+}
+
+// New creates a swarm manager instance.
+func New(
+	provisioners machines.MachineProvisioners,
+	templates api.Templates,
+	credentials api.Credentials) api.Swarms {
+
+	return &swarms{
+		provisioners: provisioners,
+		templates:    templates,
+		credentials:  credentials,
+	}
+}
+
+func (s swarms) ListIDs() ([]api.SwarmID, *api.Error) {
+	return nil, api.UnknownError(errors.New("Not implemented"))
+}
+
+func (s swarms) Get(id api.SwarmID) (interface{}, *api.Error) {
+	return nil, api.UnknownError(errors.New("Not implemented"))
+}
+
+func (s swarms) Create(
+	provisionerName string,
+	credentialsName string,
+	templateName string,
+	input io.Reader,
+	codec api.Codec) (<-chan interface{}, *api.Error) {
+
+	return nil, api.UnknownError(errors.New("Not implemented"))
+}
+
+func (s swarms) Delete(credentialsName string, swarm api.SwarmID) (<-chan interface{}, *api.Error) {
+	return nil, api.UnknownError(errors.New("Not implemented"))
+}


### PR DESCRIPTION
No implementation yet, just defining the top layers that will expose cluster operations.
