### PR TITLE
MachineProvisioner

### DIFF
--- a/cmd/machined/http/http_test.go
+++ b/cmd/machined/http/http_test.go
@@ -34,7 +34,7 @@ func prepareTest(t *testing.T, ctrl *gomock.Controller) (*mock_spi.MockProvision
 		Name:                  "testcloud",
 		DefaultCredential:     func() spi.Credential { return &testCredentials{} },
 		DefaultMachineRequest: func() spi.MachineRequest { return &testMachineRequest{} },
-		Build: func(controls spi.ProvisionControls, cred spi.Credential) (spi.Provisioner, error) {
+		Build: func(controls spi.ProvisionControls, cred spi.Credential) (spi.MachineProvisioner, error) {
 			return provisioner, nil
 		},
 	}

--- a/machines/provisioners.go
+++ b/machines/provisioners.go
@@ -18,7 +18,7 @@ type ProvisionerBuilder struct {
 	DefaultCredential func() spi.Credential
 	// TODO(wfarner): This function is redundant with Provisioner.NewRequestInstance().
 	DefaultMachineRequest func() spi.MachineRequest
-	Build                 func(controls spi.ProvisionControls, cred spi.Credential) (spi.Provisioner, error)
+	Build                 func(controls spi.ProvisionControls, cred spi.Credential) (spi.MachineProvisioner, error)
 }
 
 // MachineProvisioners maintains the collection of available provisioners.

--- a/machines/tasks/instance.go
+++ b/machines/tasks/instance.go
@@ -14,7 +14,7 @@ const (
 
 // CreateInstance creates an instance using a provisioner.
 type CreateInstance struct {
-	Provisioner spi.Provisioner
+	Provisioner spi.MachineProvisioner
 }
 
 // Name returns the task name.
@@ -38,7 +38,7 @@ func (c CreateInstance) Run(resource spi.Resource, req spi.MachineRequest, event
 
 // DestroyInstance creates an instance using a provisioner.
 type DestroyInstance struct {
-	Provisioner spi.Provisioner
+	Provisioner spi.MachineProvisioner
 }
 
 // Name returns the task name.

--- a/provisioners/aws/aws.go
+++ b/provisioners/aws/aws.go
@@ -57,7 +57,7 @@ func getConfig(controls spi.ProvisionControls) (*Config, error) {
 }
 
 // ProvisionerWith returns a provision given the runtime context and credential
-func ProvisionerWith(controls spi.ProvisionControls, cred spi.Credential) (spi.Provisioner, error) {
+func ProvisionerWith(controls spi.ProvisionControls, cred spi.Credential) (spi.MachineProvisioner, error) {
 	config, err := getConfig(controls)
 	if err != nil {
 		return nil, err

--- a/provisioners/azure/azure.go
+++ b/provisioners/azure/azure.go
@@ -8,7 +8,7 @@ import (
 )
 
 // ProvisionerWith returns a provision given the runtime context and credential
-func ProvisionerWith(controls spi.ProvisionControls, cred spi.Credential) (spi.Provisioner, error) {
+func ProvisionerWith(controls spi.ProvisionControls, cred spi.Credential) (spi.MachineProvisioner, error) {
 	return &provisioner{}, nil
 }
 

--- a/provisioners/spi/spi.go
+++ b/provisioners/spi/spi.go
@@ -227,6 +227,11 @@ type Provisioner interface {
 
 	// GetTeardownTasks returns a list of available tasks for tearing down a resource.
 	GetTeardownTasks() []Task
+}
+
+// MachineProvisioner interface adds additional methods appropriate for machine provisioning
+type MachineProvisioner interface {
+	Provisioner
 
 	// GetInstanceKey returns an instanceID based on the request.  It's up to the provisioner
 	// on how to manage the mapping of machine request (which has a user-friendly name) to
@@ -245,4 +250,10 @@ type Provisioner interface {
 	CreateInstance(request MachineRequest) (<-chan CreateInstanceEvent, error)
 
 	DestroyInstance(instanceID string) (<-chan DestroyInstanceEvent, error)
+}
+
+// SwarmProvisioner provisions entire infrastructure for a swarm.  This can be implemented
+// in a variety of ways from CloudFormation on AWS to programmatic API calls on other platforms.
+type SwarmProvisioner interface {
+	Provisioner
 }


### PR DESCRIPTION
- Make `Provisioner` a generic, base interface 
- Create a specialized interface `MachineProvisioner` that embeds `Provisioner` and has machine-specific methods.
- Renamed `spi.Provisioner` to `spi.MachineProvisioner`

This is needed to lay the foundation for provisioners of other types of resources -- `swarm` and `loadbalancer` are the ones to come.
