### PR TITLE
Add a directory that defines the new repo layout

### DIFF
--- a/machete/controller/bootstrap/README.md
+++ b/machete/controller/bootstrap/README.md
@@ -1,0 +1,1 @@
+Bootstrap controller (container).

--- a/machete/controller/scaler/README.md
+++ b/machete/controller/scaler/README.md
@@ -1,0 +1,1 @@
+Scaler controller (container).

--- a/machete/provider/aws/README.md
+++ b/machete/provider/aws/README.md
@@ -1,0 +1,1 @@
+AWS SPI implmeentation.

--- a/machete/provider/azure/README.md
+++ b/machete/provider/azure/README.md
@@ -1,0 +1,1 @@
+Azure SPI implementation.

--- a/machete/server/README.md
+++ b/machete/server/README.md
@@ -1,0 +1,1 @@
+HTTP server (container) that mounts and serves SPI implementations.

--- a/machete/spi/instance/README.md
+++ b/machete/spi/instance/README.md
@@ -1,0 +1,1 @@
+SPI for managing machine instances.


### PR DESCRIPTION
This defines the new repo layout in a subdirectory.  The idea would be to continue development here while whittling away at the rest of the repository, ultimately promoting this directory to the root of the repo.
