### PR TITLE
Make Error package-private

### DIFF
--- a/provider/aws/instance.go
+++ b/provider/aws/instance.go
@@ -148,7 +148,7 @@ func (p provisioner) Destroy(id instance.ID) error {
 
 	if len(result.TerminatingInstances) != 1 {
 		// There was no match for the instance ID.
-		return spi.Error{Code: spi.ErrBadInput, Message: "No matching instance"}
+		return spi.NewError(spi.ErrBadInput, "No matching instance")
 	}
 
 	return nil

--- a/server/instance.go
+++ b/server/instance.go
@@ -19,7 +19,7 @@ func getInstanceID(req *http.Request) instance.ID {
 func (h *instanceHandler) listGroup(req *http.Request) (interface{}, error) {
 	group := req.URL.Query().Get("group")
 	if len(group) == 0 {
-		return nil, spi.Error{Code: spi.ErrBadInput, Message: "Group must be specified"}
+		return nil, spi.NewError(spi.ErrBadInput, "Group must be specified")
 	}
 
 	return h.provisioner.ListGroup(instance.GroupID(group))
@@ -28,7 +28,7 @@ func (h *instanceHandler) listGroup(req *http.Request) (interface{}, error) {
 func (h *instanceHandler) provision(req *http.Request) (interface{}, error) {
 	buff, err := ioutil.ReadAll(req.Body)
 	if err != nil {
-		return nil, spi.Error{Code: spi.ErrBadInput, Message: "Failed to read request input"}
+		return nil, spi.NewError(spi.ErrBadInput, "Failed to read request input")
 	}
 
 	return h.provisioner.Provision(string(buff))

--- a/server/instance_test.go
+++ b/server/instance_test.go
@@ -12,7 +12,7 @@ import (
 	"testing"
 )
 
-var BadInputError = spi.Error{Code: spi.ErrBadInput, Message: "Bad Input"}
+var BadInputError = spi.NewError(spi.ErrBadInput, "Bad Input")
 
 func TestListGroup(t *testing.T) {
 	ctrl := gomock.NewController(t)
@@ -38,7 +38,7 @@ func expectBadInputError(t *testing.T, response *testflight.Response) {
 	require.Equal(t, 400, response.StatusCode)
 	body := map[string]string{}
 	require.NoError(t, json.Unmarshal([]byte(response.Body), &body))
-	require.Equal(t, map[string]string{"error": BadInputError.Message}, body)
+	require.Equal(t, map[string]string{"error": BadInputError.Error()}, body)
 }
 
 func TestListGroupError(t *testing.T) {

--- a/spi/errors.go
+++ b/spi/errors.go
@@ -15,10 +15,13 @@ const (
 
 	// ErrBadInput is returned when an operation was supplied invalid user input.
 	ErrBadInput
+
+	// ErrNotImplemented is returned when a provisioner does not implement certain operations
+	ErrNotImplemented
 )
 
-// Error is the libmachete specific error
-type Error struct {
+// spiError is the libmachete specific error
+type spiError struct {
 	// Code is the error code
 	Code int
 
@@ -27,24 +30,24 @@ type Error struct {
 }
 
 // Implements the Error interface.
-func (e Error) Error() string {
+func (e spiError) Error() string {
 	return e.Message
 }
 
 // UnknownError creates a standard Error when the cause is unknown.
 func UnknownError(err error) error {
-	return Error{ErrUnknown, err.Error()}
+	return spiError{ErrUnknown, err.Error()}
 }
 
 // NewError creates an Error with the specified code.
 func NewError(code int, format string, args ...interface{}) error {
-	return Error{Code: code, Message: fmt.Sprintf(format, args...)}
+	return spiError{Code: code, Message: fmt.Sprintf(format, args...)}
 }
 
 // CodeFromError returns the code associated with an error.
 // Returns ErrUnknown if the error is not an spi error.
 func CodeFromError(err error) int {
-	spiErr, is := err.(Error)
+	spiErr, is := err.(spiError)
 	if !is {
 		return ErrUnknown
 	}


### PR DESCRIPTION
Per earlier issue #96 this PR makes the `Error` type package-private.  Errors are created using the `NewError` function with code instead.

Also renaming `aws/aws.go` to `aws/instance.go` in preparation for other files in another PR that has `elb.go`.   Let's have the file names match the resource type (instance, elb, etc.) on that platform. 
