### PR TITLE
Machete server: use persistent flags for cluster and port

### DIFF
--- a/server/machete/main.go
+++ b/server/machete/main.go
@@ -15,8 +15,8 @@ func main() {
 
 	rootCmd := &cobra.Command{Use: "machete"}
 
-	rootCmd.Flags().UintVar(&port, "port", 8888, "Port the server listens on")
-	rootCmd.Flags().StringVar(
+	rootCmd.PersistentFlags().UintVar(&port, "port", 8888, "Port the server listens on")
+	rootCmd.PersistentFlags().StringVar(
 		&cluster,
 		"cluster",
 		"default",


### PR DESCRIPTION
These flags cannot be used with subcommands otherwise, which is what we want.
