### PR TITLE
When updating, only proceed once the scaler has quiesced

### DIFF
--- a/plugin/group/rollingupdate.go
+++ b/plugin/group/rollingupdate.go
@@ -1,6 +1,7 @@
 package scaler
 
 import (
+	"errors"
 	"fmt"
 	log "github.com/Sirupsen/logrus"
 	"github.com/docker/libmachete/spi/group"
@@ -8,11 +9,6 @@ import (
 	"sort"
 	"time"
 )
-
-type rollingupdate struct {
-	context  *groupContext
-	newProps groupProperties
-}
 
 func minInt(a, b int) int {
 	if a < b {
@@ -25,38 +21,52 @@ func planRollingUpdate(id group.ID, context *groupContext, newProps groupPropert
 
 	instances, err := context.scaled.describe()
 	if err != nil {
-		return updatePlan{}, err
-	}
-
-	undesiredInstances, err := findUndesiredInstances(
-		instances,
-		instanceConfigHash(newProps.InstancePluginProperties))
-	if err != nil {
-		return updatePlan{}, err
+		return nil, err
 	}
 
 	sizeChange := int(newProps.Size) - int(context.properties.Size)
+
+	_, undesiredInstances := desiredAndUndesiredInstances(instances, newProps)
 	rollCount := minInt(len(undesiredInstances), int(newProps.Size))
 
+	update := rollingupdate{
+		context:  context,
+		newProps: newProps,
+		stop:     make(chan bool),
+	}
+
 	if rollCount == 0 && sizeChange == 0 {
-		return updatePlan{desc: "Noop", execute: func() error { return nil }}, nil
+		if instanceConfigHash(context.properties.InstancePluginProperties) ==
+			instanceConfigHash(newProps.InstancePluginProperties) {
+
+			// This is a no-op update because:
+			//  - the instance configuration is unchanged
+			//  - the group contains no instances with an undesired state
+			//  - the group size is unchanged
+			return &noexecUpdate{desc: "Noop"}, nil
+		}
+
+		// This case likely occurs because a group was created in a way that no instances are being created.
+		// We proceed with the update here, which will likely only change the target configuration in the
+		// scaler.
+		update.desc = "Adjusts the instance configuration, no restarts necessary"
+		return &update, nil
 	}
 
 	rollDesc := fmt.Sprintf("a rolling update on %d instances", rollCount)
 
-	var desc string
 	switch {
 	case sizeChange == 0:
-		desc = fmt.Sprintf("Performs %s", rollDesc)
+		update.desc = fmt.Sprintf("Performs %s", rollDesc)
 	case sizeChange < 0:
 		if rollCount > 0 {
-			desc = fmt.Sprintf(
+			update.desc = fmt.Sprintf(
 				"Terminates %d instances to reduce the group size to %d, then performs %s",
 				int(sizeChange)*-1,
 				newProps.Size,
 				rollDesc)
 		} else {
-			desc = fmt.Sprintf(
+			update.desc = fmt.Sprintf(
 				"Terminates %d instances to reduce the group size to %d",
 				int(sizeChange)*-1,
 				newProps.Size)
@@ -64,45 +74,95 @@ func planRollingUpdate(id group.ID, context *groupContext, newProps groupPropert
 
 	case sizeChange > 0:
 		if rollCount > 0 {
-			desc = fmt.Sprintf(
+			update.desc = fmt.Sprintf(
 				"Performs %s, then adds %d instances to increase the group size to %d",
 				rollDesc,
 				sizeChange,
 				newProps.Size)
 		} else {
-			desc = fmt.Sprintf(
+			update.desc = fmt.Sprintf(
 				"Adds %d instances to increase the group size to %d",
 				sizeChange,
 				newProps.Size)
 		}
 	}
 
-	execute := func() error {
-		update := rollingupdate{context: context, newProps: newProps}
-		update.Run()
-		log.Infof("Finished updating group %s", id)
-
-		return nil
-	}
-
-	return updatePlan{desc: desc, execute: execute}, nil
+	return &update, nil
 }
 
-func findUndesiredInstances(instances []instance.Description, desiredConfig string) ([]instance.ID, error) {
-	undesiredInstances := []instance.ID{}
+func desiredAndUndesiredInstances(instances []instance.Description, props groupProperties) ([]instance.ID, []instance.ID) {
+	desiredConfig := instanceConfigHash(props.InstancePluginProperties)
+
+	desired := []instance.ID{}
+	undesired := []instance.ID{}
 	for _, inst := range instances {
 		actualConfig, specified := inst.Tags[configTag]
-		if !specified || actualConfig != desiredConfig {
-			undesiredInstances = append(undesiredInstances, inst.ID)
+		if specified && actualConfig == desiredConfig {
+			desired = append(desired, inst.ID)
+		} else {
+			undesired = append(undesired, inst.ID)
 		}
 	}
 
-	return undesiredInstances, nil
+	return desired, undesired
+}
+
+type rollingupdate struct {
+	desc     string
+	context  *groupContext
+	newProps groupProperties
+	stop     chan bool
+}
+
+func (r rollingupdate) Explain() string {
+	return r.desc
+}
+
+func (r *rollingupdate) waitUntilQuiesced(pollInterval time.Duration, expectedNewInstances int) error {
+	// Block until the expected number of instances in the desired state are ready.  Updates are unconcerned with
+	// the health of instances in the undesired state.  This allows a user to dig out of a hole where the original
+	// state of the group is bad, and instances are not reporting as healthy.
+
+	ticker := time.NewTicker(pollInterval)
+	for {
+		select {
+		case <-ticker.C:
+			// Gather instances in the scaler with the desired state
+			// Check:
+			//   - that the scaler has the expected number of instances
+			//   - instances with the desired config are healthy (e.g. represented in `swarm node ls`)
+
+			// TODO(wfarner): Get this information from the scaler to reduce redundant network calls.
+			instances, err := r.context.scaled.describe()
+			if err != nil {
+				return err
+			}
+
+			matching, _ := desiredAndUndesiredInstances(instances, r.newProps)
+
+			// We are only concerned with the expected number of instances in the desired state.
+			// For example, if the original state of the group was failing to successfully create instances,
+			// old instances may never show up.  We should, however, avoid proceeding if the new instances
+			// are not showing up.
+			if len(matching) >= int(expectedNewInstances) {
+				return nil
+			}
+
+			log.Info("Waiting for scaler to quiesce")
+
+			// TODO(wfarner): Provide a mechanism for health feedback.
+
+		case <-r.stop:
+			ticker.Stop()
+			return errors.New("Update halted by user")
+		}
+	}
 }
 
 // Run identifies instances not matching the desired state and destroys them one at a time until all instances in the
 // group match the desired state, with the desired number of instances.
-func (r *rollingupdate) Run() error {
+// TODO(wfarner): Make this routine more resilient to transient errors.
+func (r *rollingupdate) Run(pollInterval time.Duration) error {
 	originalSize := r.context.properties.Size
 
 	// If the number of instances is being decreased, first lower the group size.  This eliminates
@@ -113,24 +173,30 @@ func (r *rollingupdate) Run() error {
 		r.context.scaler.SetSize(r.newProps.Size)
 	}
 
+	instances, err := r.context.scaled.describe()
+	if err != nil {
+		return err
+	}
+
+	desired, _ := desiredAndUndesiredInstances(instances, r.newProps)
+	expectedNewInstances := len(desired)
+
 	r.context.setProperties(&r.newProps)
 	r.context.scaled.setProvisionTemplate(r.newProps.InstancePluginProperties, identityTags(r.newProps))
 
 	for {
-		// TODO(wfarner): Wait until all desired instances in the new configuration are healthy.
-		time.Sleep(1 * time.Second)
+		err := r.waitUntilQuiesced(pollInterval, minInt(expectedNewInstances, int(r.newProps.Size)))
+		if err != nil {
+			return err
+		}
+		log.Info("Scaler has quiesced")
 
 		instances, err := r.context.scaled.describe()
 		if err != nil {
 			return err
 		}
 
-		undesiredInstances, err := findUndesiredInstances(
-			instances,
-			instanceConfigHash(r.newProps.InstancePluginProperties))
-		if err != nil {
-			return err
-		}
+		_, undesiredInstances := desiredAndUndesiredInstances(instances, r.newProps)
 
 		if len(undesiredInstances) == 0 {
 			break
@@ -141,10 +207,13 @@ func (r *rollingupdate) Run() error {
 		// Sort instances first to ensure predictable destroy order.
 		sort.Sort(sortByID(undesiredInstances))
 
+		// TODO(wfarner): Provide a mechanism to gracefully drain instances.
+		// TODO(wfarner): Make the 'batch size' configurable.
 		err = r.context.scaled.Destroy(undesiredInstances[0])
 		if err != nil {
 			return err
 		}
+		expectedNewInstances++
 	}
 
 	// Rolling has completed.  If the update included a group size increase, perform that now.
@@ -153,4 +222,8 @@ func (r *rollingupdate) Run() error {
 	}
 
 	return nil
+}
+
+func (r *rollingupdate) Stop() {
+	r.stop <- true
 }

--- a/plugin/group/scaler.go
+++ b/plugin/group/scaler.go
@@ -22,6 +22,7 @@ type Scaled interface {
 // of an autoscaling group / scale set on AWS or Azure.
 type Scaler interface {
 	util.RunStop
+	GetSize() uint32
 	SetSize(size uint32)
 }
 
@@ -42,6 +43,13 @@ func NewAdjustableScaler(scaled Scaled, size uint32, pollInterval time.Duration)
 		pollInterval: pollInterval,
 		stop:         make(chan bool),
 	}
+}
+
+func (s *scaler) GetSize() uint32 {
+	s.lock.Lock()
+	defer s.lock.Unlock()
+
+	return s.size
 }
 
 func (s *scaler) SetSize(size uint32) {

--- a/plugin/group/state.go
+++ b/plugin/group/state.go
@@ -19,7 +19,22 @@ type groupContext struct {
 	instancePlugin instance.Plugin
 	scaler         Scaler
 	scaled         *scaledGroup
+	update         updatePlan
 	lock           sync.Mutex
+}
+
+func (c *groupContext) setUpdate(plan updatePlan) {
+	c.lock.Lock()
+	defer c.lock.Unlock()
+
+	c.update = plan
+}
+
+func (c *groupContext) getUpdate() updatePlan {
+	c.lock.Lock()
+	defer c.lock.Unlock()
+
+	return c.update
 }
 
 func (c *groupContext) setProperties(properties *groupProperties) {

--- a/spi/group/group.go
+++ b/spi/group/group.go
@@ -17,6 +17,8 @@ type Plugin interface {
 
 	UpdateGroup(updated Configuration) error
 
+	StopUpdate(id ID) error
+
 	DestroyGroup(id ID) error
 }
 


### PR DESCRIPTION
This introduces a feedback mechanism into the updater, which will get progress.  Only presence in the scaler is used now (which maps to presence in the third-party API), but we can use the same mechanism for node health.

Since i saw the opportunity, i also added the ability to stop in-flight updates.

Finally, i changed most of the unit test cases for the updater to use a fake instead of a mock.  I find the tests much easier to write and reason about now, but we will need some more plumbing to validate things like instance churn and sequencing.
