### PR TITLE
Small change to constructor function of group plugin

### DIFF
--- a/plugin/group/groupctl/main.go
+++ b/plugin/group/groupctl/main.go
@@ -132,9 +132,13 @@ func main() {
 			log.Error(err)
 		}
 
-		grp := group_plugin.NewGroupPlugin(func() map[string]instance.Plugin {
-			return map[string]instance.Plugin{"test": group_plugin.NewTestInstancePlugin()}
-		}, swarm.NewSwarmProvisionHelper(dockerClient), 1*time.Second)
+		grp := group_plugin.NewGroupPlugin(
+			func(key string) (instance.Plugin, error) {
+				if key == "test" {
+					return group_plugin.NewTestInstancePlugin(), nil
+				}
+				return nil, nil
+			}, swarm.NewSwarmProvisionHelper(dockerClient), 1*time.Second)
 
 		adapter := httpAdapter{plugin: grp}
 

--- a/plugin/group/integration_test.go
+++ b/plugin/group/integration_test.go
@@ -61,11 +61,18 @@ func leaderProperties(ips []string, data string) json.RawMessage {
 	}`, ipValue, data))
 }
 
+func fakeInstancePluginLookup(pluginName string, plugin instance.Plugin) InstancePluginLookup {
+	return func(key string) (instance.Plugin, error) {
+		if key == pluginName {
+			return plugin, nil
+		}
+		return nil, nil
+	}
+}
+
 func mockedPluginGroup(ctrl *gomock.Controller) (*mock_instance.MockPlugin, group.Plugin) {
 	plugin := mock_instance.NewMockPlugin(ctrl)
-	grp := NewGroupPlugin(func() map[string]instance.Plugin {
-		return map[string]instance.Plugin{pluginName: plugin}
-	}, &provisionHelper, 1*time.Millisecond)
+	grp := NewGroupPlugin(fakeInstancePluginLookup(pluginName, plugin), &provisionHelper, 1*time.Millisecond)
 	return plugin, grp
 }
 
@@ -132,9 +139,7 @@ func TestNoopUpdate(t *testing.T) {
 		provisionTags(minions),
 		provisionTags(minions),
 	)
-	grp := NewGroupPlugin(func() map[string]instance.Plugin {
-		return map[string]instance.Plugin{pluginName: plugin}
-	}, &provisionHelper, 1*time.Millisecond)
+	grp := NewGroupPlugin(fakeInstancePluginLookup(pluginName, plugin), &provisionHelper, 1*time.Millisecond)
 
 	require.NoError(t, grp.WatchGroup(minions))
 
@@ -158,9 +163,7 @@ func TestRollingUpdate(t *testing.T) {
 		provisionTags(minions),
 		provisionTags(minions),
 	)
-	grp := NewGroupPlugin(func() map[string]instance.Plugin {
-		return map[string]instance.Plugin{pluginName: plugin}
-	}, &provisionHelper, 1*time.Millisecond)
+	grp := NewGroupPlugin(fakeInstancePluginLookup(pluginName, plugin), &provisionHelper, 1*time.Millisecond)
 
 	require.NoError(t, grp.WatchGroup(minions))
 
@@ -186,9 +189,7 @@ func TestRollAndAdjustScale(t *testing.T) {
 		provisionTags(minions),
 		provisionTags(minions),
 	)
-	grp := NewGroupPlugin(func() map[string]instance.Plugin {
-		return map[string]instance.Plugin{pluginName: plugin}
-	}, &provisionHelper, 1*time.Millisecond)
+	grp := NewGroupPlugin(fakeInstancePluginLookup(pluginName, plugin), &provisionHelper, 1*time.Millisecond)
 
 	require.NoError(t, grp.WatchGroup(minions))
 
@@ -220,9 +221,7 @@ func TestScaleIncrease(t *testing.T) {
 		provisionTags(minions),
 		provisionTags(minions),
 	)
-	grp := NewGroupPlugin(func() map[string]instance.Plugin {
-		return map[string]instance.Plugin{pluginName: plugin}
-	}, &provisionHelper, 1*time.Millisecond)
+	grp := NewGroupPlugin(fakeInstancePluginLookup(pluginName, plugin), &provisionHelper, 1*time.Millisecond)
 
 	require.NoError(t, grp.WatchGroup(minions))
 
@@ -251,9 +250,7 @@ func TestScaleDecrease(t *testing.T) {
 		provisionTags(minions),
 		provisionTags(minions),
 	)
-	grp := NewGroupPlugin(func() map[string]instance.Plugin {
-		return map[string]instance.Plugin{pluginName: plugin}
-	}, &provisionHelper, 1*time.Millisecond)
+	grp := NewGroupPlugin(fakeInstancePluginLookup(pluginName, plugin), &provisionHelper, 1*time.Millisecond)
 
 	require.NoError(t, grp.WatchGroup(minions))
 
@@ -331,9 +328,7 @@ func TestDestroyGroup(t *testing.T) {
 		provisionTags(minions),
 		provisionTags(minions),
 	)
-	grp := NewGroupPlugin(func() map[string]instance.Plugin {
-		return map[string]instance.Plugin{pluginName: plugin}
-	}, &provisionHelper, 1*time.Millisecond)
+	grp := NewGroupPlugin(fakeInstancePluginLookup(pluginName, plugin), &provisionHelper, 1*time.Millisecond)
 
 	require.NoError(t, grp.WatchGroup(minions))
 	require.NoError(t, grp.DestroyGroup(minions.ID))
@@ -381,9 +376,7 @@ func TestSuperviseQuorum(t *testing.T) {
 		provisionTags(leaders),
 		provisionTags(leaders),
 	)
-	grp := NewGroupPlugin(func() map[string]instance.Plugin {
-		return map[string]instance.Plugin{pluginName: plugin}
-	}, &provisionHelper, 1*time.Millisecond)
+	grp := NewGroupPlugin(fakeInstancePluginLookup(pluginName, plugin), &provisionHelper, 1*time.Millisecond)
 
 	require.NoError(t, grp.WatchGroup(leaders))
 


### PR DESCRIPTION
Make group plugin take a function which returns the lookup map of instance plugins.

This is in preparation for a group plugins that is truly generic and separate from the IaaS instance plugins.   The map of instance plugin will be updated dynamically as new plugins are installed (either by user on command line or via activation by the swim file processor).  
