### PR TITLE
Instance provision SPI method signature change

### DIFF
--- a/mock/plugin/group/types/types.go
+++ b/mock/plugin/group/types/types.go
@@ -31,11 +31,10 @@ func (_m *MockProvisionHelper) EXPECT() *_MockProvisionHelperRecorder {
 	return _m.recorder
 }
 
-func (_m *MockProvisionHelper) GroupKind(_param0 string) (types.GroupKind, error) {
+func (_m *MockProvisionHelper) GroupKind(_param0 string) types.GroupKind {
 	ret := _m.ctrl.Call(_m, "GroupKind", _param0)
 	ret0, _ := ret[0].(types.GroupKind)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
+	return ret0
 }
 
 func (_mr *_MockProvisionHelperRecorder) GroupKind(arg0 interface{}) *gomock.Call {
@@ -53,9 +52,9 @@ func (_mr *_MockProvisionHelperRecorder) Healthy(arg0 interface{}) *gomock.Call 
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "Healthy", arg0)
 }
 
-func (_m *MockProvisionHelper) PreProvision(_param0 group.Configuration, _param1 types.ProvisionDetails) (types.ProvisionDetails, error) {
+func (_m *MockProvisionHelper) PreProvision(_param0 group.Configuration, _param1 instance.Spec) (instance.Spec, error) {
 	ret := _m.ctrl.Call(_m, "PreProvision", _param0, _param1)
-	ret0, _ := ret[0].(types.ProvisionDetails)
+	ret0, _ := ret[0].(instance.Spec)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }

--- a/mock/spi/instance/instance.go
+++ b/mock/spi/instance/instance.go
@@ -51,15 +51,15 @@ func (_mr *_MockPluginRecorder) Destroy(arg0 interface{}) *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "Destroy", arg0)
 }
 
-func (_m *MockPlugin) Provision(_param0 json.RawMessage, _param1 map[string]string, _param2 string, _param3 *string, _param4 *instance.VolumeID) (*instance.ID, error) {
-	ret := _m.ctrl.Call(_m, "Provision", _param0, _param1, _param2, _param3, _param4)
+func (_m *MockPlugin) Provision(_param0 instance.Spec) (*instance.ID, error) {
+	ret := _m.ctrl.Call(_m, "Provision", _param0)
 	ret0, _ := ret[0].(*instance.ID)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-func (_mr *_MockPluginRecorder) Provision(arg0, arg1, arg2, arg3, arg4 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "Provision", arg0, arg1, arg2, arg3, arg4)
+func (_mr *_MockPluginRecorder) Provision(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "Provision", arg0)
 }
 
 func (_m *MockPlugin) Validate(_param0 json.RawMessage) error {

--- a/plugin/group/swarm/helper_test.go
+++ b/plugin/group/swarm/helper_test.go
@@ -46,17 +46,17 @@ func TestAssociation(t *testing.T) {
 
 	details, err := helper.PreProvision(
 		group.Configuration{Role: "worker"},
-		types.ProvisionDetails{Tags: map[string]string{"a": "b"}})
+		instance.Spec{Tags: map[string]string{"a": "b"}})
 	require.NoError(t, err)
 	require.Equal(t, "b", details.Tags["a"])
 	associationID := details.Tags[associationTag]
 	require.NotEqual(t, "", associationID)
 
-	// Perform a rudimentary check to ensure that the expected fields are in the BootScript, without having any
+	// Perform a rudimentary check to ensure that the expected fields are in the InitScript, without having any
 	// other knowledge about the script structure.
-	require.Contains(t, details.BootScript, associationID)
-	require.Contains(t, details.BootScript, swarmInfo.JoinTokens.Worker)
-	require.Contains(t, details.BootScript, nodeInfo.ManagerStatus.Addr)
+	require.Contains(t, details.InitScript, associationID)
+	require.Contains(t, details.InitScript, swarmInfo.JoinTokens.Worker)
+	require.Contains(t, details.InitScript, nodeInfo.ManagerStatus.Addr)
 
 	// An instance with no association information is considered unhealthy.
 	healthy, err := helper.Healthy(instance.Description{})

--- a/plugin/group/testplugin.go
+++ b/plugin/group/testplugin.go
@@ -47,14 +47,9 @@ func (d *testplugin) addInstance(inst fakeInstance) instance.ID {
 	return id
 }
 
-func (d *testplugin) Provision(
-	req json.RawMessage,
-	tags map[string]string,
-	bootScript string,
-	privateIP *string,
-	volume *instance.VolumeID) (*instance.ID, error) {
+func (d *testplugin) Provision(spec instance.Spec) (*instance.ID, error) {
 
-	id := d.addInstance(fakeInstance{ip: privateIP, tags: tags})
+	id := d.addInstance(fakeInstance{ip: spec.PrivateIPAddress, tags: spec.Tags})
 	return &id, nil
 }
 
@@ -126,14 +121,13 @@ func (t testProvisionHelper) GroupKind(roleName string) types.GroupKind {
 }
 
 func (t testProvisionHelper) PreProvision(
-	config group.Configuration,
-	details types.ProvisionDetails) (types.ProvisionDetails, error) {
+	config group.Configuration, spec instance.Spec) (instance.Spec, error) {
 
-	details.BootScript = "echo hello"
+	spec.InitScript = "echo hello"
 	for k, v := range t.tags {
-		details.Tags[k] = v
+		spec.Tags[k] = v
 	}
-	return details, nil
+	return spec, nil
 }
 
 func (t testProvisionHelper) Healthy(inst instance.Description) (bool, error) {

--- a/plugin/group/types/types.go
+++ b/plugin/group/types/types.go
@@ -21,14 +21,6 @@ const (
 	KindStaticIP  GroupKind = iota
 )
 
-// ProvisionDetails are the parameters that will be used to provision a machine.
-type ProvisionDetails struct {
-	BootScript string
-	Tags       map[string]string
-	PrivateIP  *string
-	Volume     *instance.VolumeID
-}
-
 // A ProvisionHelper defines custom behavior for provisioning instances.
 type ProvisionHelper interface {
 
@@ -42,7 +34,7 @@ type ProvisionHelper interface {
 	// PreProvision allows the helper to modify the provisioning instructions for an instance.  For example, a
 	// helper could be used to place additional tags on the machine, or generate a specialized BootScript based on
 	// the machine configuration.
-	PreProvision(config group.Configuration, details ProvisionDetails) (ProvisionDetails, error)
+	PreProvision(config group.Configuration, spec instance.Spec) (instance.Spec, error)
 
 	// Healthy determines whether an instance is healthy.
 	Healthy(inst instance.Description) (bool, error)
@@ -89,7 +81,7 @@ func instanceHash(config json.RawMessage) string {
 		panic(err)
 	}
 
-	stable, err := json.Marshal(props)
+	stable, err := json.MarshalIndent(props, "  ", "  ") // sorts the fields
 	if err != nil {
 		panic(err)
 	}

--- a/spi/instance/spi.go
+++ b/spi/instance/spi.go
@@ -7,13 +7,8 @@ type Plugin interface {
 	// Validate performs local validation on a provision request.
 	Validate(req json.RawMessage) error
 
-	// Provision creates a new instance.
-	Provision(
-		req json.RawMessage,
-		tags map[string]string,
-		bootScript string,
-		privateIP *string,
-		volume *VolumeID) (*ID, error)
+	// Provision creates a new instance based on the spec.
+	Provision(spec Spec) (*ID, error)
 
 	// Destroy terminates an existing instance.
 	Destroy(instance ID) error

--- a/spi/instance/types.go
+++ b/spi/instance/types.go
@@ -1,5 +1,9 @@
 package instance
 
+import (
+	"encoding/json"
+)
+
 // ID is the identifier for an instance.
 type ID string
 
@@ -11,4 +15,13 @@ type Description struct {
 	ID               ID
 	PrivateIPAddress string
 	Tags             map[string]string
+}
+
+// Spec is a specification of an instance to be provisioned
+type Spec struct {
+	Properties       json.RawMessage
+	Tags             map[string]string
+	InitScript       string
+	PrivateIPAddress *string
+	Volume           *VolumeID
 }


### PR DESCRIPTION
- Add new `instance.Spec` type to capture the growing list of parameters in `instanceSpi.Provision()`.  Called `instance.Spec` to match terminology (`spec`) already used by swarm and other Docker projects.
- Change `BootScript` to `InitScript` to better match the cloudinit-like purpose of this field and also avoid implication of machine booting (aka this is not related to PXE boot)
- Changed `group.ProvisionDetail` references to use the new struct type
