### PR TITLE
Restore plugin HTTP utility

### DIFF
--- a/plugin/util/server.go
+++ b/plugin/util/server.go
@@ -1,0 +1,146 @@
+package util
+
+import (
+	"fmt"
+	"net"
+	"net/http"
+	"os"
+	"os/signal"
+	"path/filepath"
+	"regexp"
+	"syscall"
+)
+
+// StartServer starts a server listening at addr.  Addr can be a path (for unix socket) or of the form ip:port
+// Returns a channel to signal stop when closed, a channel to block on stopping, and an error if occurs.
+func StartServer(addr string, endpoint http.Handler, shutdown ...func() error) (chan<- struct{}, <-chan error, error) {
+	shutdownTasks := []func() error{}
+
+	for _, onShutdown := range shutdown {
+		shutdownTasks = append(shutdownTasks, onShutdown)
+	}
+
+	engineStop, engineStopped, err := runHTTP(&http.Server{Handler: endpoint, Addr: addr})
+	if err != nil {
+		return nil, nil, err
+	}
+
+	shutdownTasks = append(shutdownTasks, func() error {
+		// close channels that others may block on for shutdown
+		close(engineStop)
+		err := <-engineStopped
+		return err
+	})
+
+	// Pid file
+	if pid, pidErr := savePidFile(); pidErr == nil {
+		shutdownTasks = append(shutdownTasks, func() error {
+			// remove pid file
+			os.Remove(pid)
+			return nil
+		})
+	}
+
+	// Triggers to start shutdown sequence
+	fromKernel := make(chan os.Signal, 1)
+
+	// kill -9 is SIGKILL and is uncatchable.
+	signal.Notify(fromKernel, syscall.SIGHUP)  // 1
+	signal.Notify(fromKernel, syscall.SIGINT)  // 2
+	signal.Notify(fromKernel, syscall.SIGQUIT) // 3
+	signal.Notify(fromKernel, syscall.SIGABRT) // 6
+	signal.Notify(fromKernel, syscall.SIGTERM) // 15
+
+	fromUser := make(chan struct{})
+	stopped := make(chan error)
+	go func(tasks []func() error) {
+		defer close(stopped)
+
+		select {
+		case <-fromKernel:
+		case <-fromUser:
+		}
+		for _, task := range tasks {
+			if err := task(); err != nil {
+				stopped <- err
+				return
+			}
+		}
+		return
+	}(shutdownTasks)
+
+	return fromUser, stopped, nil
+}
+
+// ProtocolFromListenString checks the format of the input listen string
+// to see if it should be a tcp or unix socket protcol. For example,
+// --listen :8080 is tcp, while --listen /path/to/uds/file is unix
+func ProtocolFromListenString(listen string) string {
+	protocol := "tcp"
+	// e.g. 0.0.0.0:80 or :80 or :8080
+	if match, _ := regexp.MatchString("[a-zA-Z0-9\\.]*:[0-9]{2,}", listen); !match {
+		protocol = "unix"
+	}
+	return protocol
+}
+
+// Runs the http server.  This server offers more control than the standard go's default http server.
+// When the returned stop channel is closed, a clean shutdown and shutdown tasks are executed.
+// The return value is a channel that can be used to block on.  An error is received if server shuts
+// down in error; or a nil is received on a clean signalled shutdown.
+func runHTTP(server *http.Server) (chan<- struct{}, <-chan error, error) {
+	protocol := ProtocolFromListenString(server.Addr)
+	listener, err := net.Listen(protocol, server.Addr)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	if protocol == "unix" {
+		if _, err = os.Lstat(server.Addr); err == nil {
+			// Update socket filename permission
+			if err := os.Chmod(server.Addr, 0777); err != nil {
+				return nil, nil, err
+			}
+		} else {
+			return nil, nil, err
+		}
+	}
+
+	stop := make(chan struct{})
+	stopped := make(chan error)
+
+	userInitiated := new(bool)
+	go func() {
+		<-stop
+		*userInitiated = true
+		listener.Close()
+	}()
+
+	go func() {
+		// Serve will block until an error (e.g. from shutdown, closed connection) occurs.
+		err := server.Serve(listener)
+
+		defer close(stopped)
+
+		switch {
+		case !*userInitiated && err != nil:
+			panic(err)
+		case *userInitiated:
+			stopped <- nil
+		default:
+			stopped <- err
+		}
+	}()
+	return stop, stopped, nil
+}
+
+func savePidFile() (string, error) {
+	cmd := filepath.Base(os.Args[0])
+	pidFile, err := os.Create(fmt.Sprintf("%s.pid", cmd))
+	if err != nil {
+		return "", err
+	}
+	defer pidFile.Close()
+	fmt.Fprintf(pidFile, "%d", os.Getpid())
+	return pidFile.Name(), nil
+}

--- a/plugin/util/server_test.go
+++ b/plugin/util/server_test.go
@@ -1,0 +1,91 @@
+package util
+
+import (
+	"fmt"
+	"github.com/gorilla/mux"
+	"github.com/stretchr/testify/require"
+	"net"
+	"net/http"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+type handler int
+
+func TestStartServer(t *testing.T) {
+
+	servedCall := make(chan struct{})
+
+	router := mux.NewRouter()
+	router.HandleFunc("/test", func(resp http.ResponseWriter, req *http.Request) {
+		close(servedCall)
+		return
+	})
+	ranShutdown := make(chan struct{})
+
+	stop, errors, err := StartServer(":4321", router, func() error {
+		close(ranShutdown)
+		return nil
+	})
+
+	require.NoError(t, err)
+	require.NotNil(t, stop)
+	require.NotNil(t, errors)
+
+	client := &http.Client{}
+	resp, err := client.Get("http://localhost:4321/test")
+	require.NoError(t, err)
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+
+	<-servedCall
+
+	// Check the pid file exists
+	_, err = os.Open(fmt.Sprintf("%s.pid", filepath.Base(os.Args[0])))
+	require.NoError(t, err)
+
+	// Now we stop the server
+	close(stop)
+	<-ranShutdown
+
+	// We shouldn't block here.
+	<-errors
+}
+
+func TestStartServerUnixSocket(t *testing.T) {
+
+	servedCall := make(chan struct{})
+
+	router := mux.NewRouter()
+	router.HandleFunc("/test", func(resp http.ResponseWriter, req *http.Request) {
+		close(servedCall)
+		return
+	})
+	ranShutdown := make(chan struct{})
+
+	socket := filepath.Join(os.TempDir(), fmt.Sprintf("%d.sock", time.Now().Unix()))
+	stop, _, err := StartServer(socket, router, func() error {
+		close(ranShutdown)
+		return nil
+	})
+
+	require.NoError(t, err)
+
+	client := &http.Client{
+		Transport: &http.Transport{
+			Dial: func(proto, addr string) (conn net.Conn, err error) {
+				return net.Dial("unix", socket)
+			},
+		},
+	}
+	resp, err := client.Get("http://local/test")
+	require.NoError(t, err)
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+
+	<-servedCall
+
+	// Now we stop the server
+	close(stop)
+	<-ranShutdown
+}


### PR DESCRIPTION
This should not have been removed in the recent cleanup PR, as it
is useful for developing plugins, and this is the best home for now.
