### PR TITLE
Fix flaky scaler.Stop() behavior for low-duration timers

### DIFF
--- a/plugin/group/quorum.go
+++ b/plugin/group/quorum.go
@@ -44,7 +44,7 @@ func (q *quorum) PlanUpdate(scaled Scaled, settings groupSettings, newSettings g
 }
 
 func (q *quorum) Stop() {
-	q.stop <- true
+	close(q.stop)
 }
 
 func (q *quorum) Run() {

--- a/plugin/group/scaler.go
+++ b/plugin/group/scaler.go
@@ -180,7 +180,7 @@ func (s *scaler) getSize() uint32 {
 }
 
 func (s *scaler) Stop() {
-	s.stop <- true
+	close(s.stop)
 }
 
 func (s *scaler) Run() {


### PR DESCRIPTION
Fixes #160 
