### PR TITLE
Make flavor plugin responsible for defining group Size and logical IDs

### DIFF
--- a/plugin/group/group.go
+++ b/plugin/group/group.go
@@ -63,26 +63,13 @@ func (p *plugin) validate(config group.Configuration) (groupSettings, error) {
 		return noSettings, fmt.Errorf("Failed to find Flavor plugin '%s':%v", parsed.FlavorPlugin, err)
 	}
 
-	allocation, err := flavorPlugin.Validate(parsed.FlavorPluginProperties, parsed)
+	allocation, err := flavorPlugin.Validate(parsed.FlavorPluginProperties)
 	if err != nil {
 		return noSettings, err
 	}
 
-	if allocation == flavor.IDKindUnknown {
-		return noSettings, errors.New("Unrecognized group ID kind")
-	}
-
-	switch allocation {
-	case flavor.IDKindPhysicalWithLogical:
-		if parsed.Size != 0 {
-			return noSettings, errors.New("Size is unsupported for static IP flavors, use IPs instead")
-		}
-	case flavor.IDKindPhysical:
-		if len(parsed.LogicalIDs) != 0 {
-			return noSettings, errors.New("IPs is unsupported for dynamic IP flavors, use Size instead")
-		}
-	default:
-		return noSettings, errors.New("Unsupported Role type")
+	if allocation.Size == 0 && (allocation.LogicalIDs == nil || len(allocation.LogicalIDs) == 0) {
+		return noSettings, errors.New("Invalid allocation method")
 	}
 
 	instancePlugin, err := p.instancePlugins(parsed.InstancePlugin)
@@ -124,13 +111,12 @@ func (p *plugin) WatchGroup(config group.Configuration) error {
 	scaled.changeSettings(settings)
 
 	var supervisor Supervisor
-	switch settings.allocation {
-	case flavor.IDKindPhysical:
-		supervisor = NewScalingGroup(scaled, settings.config.Size, p.pollInterval)
-	case flavor.IDKindPhysicalWithLogical:
-		supervisor = NewQuorum(scaled, settings.config.LogicalIDs, p.pollInterval)
-	default:
-		panic("Unhandled Role type")
+	if settings.allocation.Size != 0 {
+		supervisor = NewScalingGroup(scaled, settings.allocation.Size, p.pollInterval)
+	} else if len(settings.allocation.LogicalIDs) > 0 {
+		supervisor = NewQuorum(scaled, settings.allocation.LogicalIDs, p.pollInterval)
+	} else {
+		panic("Invalid empty allocation method")
 	}
 
 	if _, exists := p.groups.get(config.ID); exists {
@@ -139,7 +125,6 @@ func (p *plugin) WatchGroup(config group.Configuration) error {
 
 	p.groups.put(config.ID, &groupContext{supervisor: supervisor, scaled: scaled, settings: settings})
 
-	// TODO(wfarner): Consider changing Run() to not block.
 	go supervisor.Run()
 	log.Infof("Watching group '%v'", config.ID)
 
@@ -204,10 +189,6 @@ func (p *plugin) planUpdate(id group.ID, updatedSettings groupSettings) (updateP
 	context, exists := p.groups.get(id)
 	if !exists {
 		return nil, fmt.Errorf("Group '%s' is not being watched", id)
-	}
-
-	if context.settings.allocation != updatedSettings.allocation {
-		return nil, errors.New("A group's allocation kind cannot be changed")
 	}
 
 	return context.supervisor.PlanUpdate(context.scaled, context.settings, updatedSettings)

--- a/plugin/group/integration_test.go
+++ b/plugin/group/integration_test.go
@@ -41,16 +41,16 @@ func flavorPluginLookup(_ string) (flavor.Plugin, error) {
 
 func minionProperties(instances int, data string) json.RawMessage {
 	return json.RawMessage(fmt.Sprintf(`{
-	  "Size": %d,
 	  "InstancePlugin": "test",
 	  "InstancePluginProperties": {
 	    "OpaqueValue": "%s"
 	  },
 	  "FlavorPlugin": "test",
 	  "FlavorPluginProperties": {
-	    "type": "minion"
+	    "Type": "minion",
+	    "Size": %d
 	  }
-	}`, instances, data))
+	}`, data, instances))
 }
 
 func leaderProperties(logicalIDs []instance.LogicalID, data string) json.RawMessage {
@@ -60,16 +60,16 @@ func leaderProperties(logicalIDs []instance.LogicalID, data string) json.RawMess
 	}
 
 	return json.RawMessage(fmt.Sprintf(`{
-	  "LogicalIDs": %s,
 	  "InstancePlugin": "test",
 	  "InstancePluginProperties": {
 	    "OpaqueValue": "%s"
 	  },
 	  "FlavorPlugin": "test",
 	  "FlavorPluginProperties": {
-	    "type": "leader"
+	    "Type": "leader",
+	    "Shards": %s
 	  }
-	}`, idsValue, data))
+	}`, data, idsValue))
 }
 
 func fakeInstancePluginLookup(pluginName string, plugin instance.Plugin) InstancePluginLookup {

--- a/plugin/group/quorum.go
+++ b/plugin/group/quorum.go
@@ -27,16 +27,15 @@ func NewQuorum(scaled Scaled, logicalIDs []instance.LogicalID, pollInterval time
 }
 
 func (q *quorum) PlanUpdate(scaled Scaled, settings groupSettings, newSettings groupSettings) (updatePlan, error) {
-	if settings.config.Size != newSettings.config.Size {
-		return nil, errors.New("A quorum group cannot be resized")
-	}
 
-	if !reflect.DeepEqual(settings.config.LogicalIDs, newSettings.config.LogicalIDs) {
+	if !reflect.DeepEqual(settings.allocation.LogicalIDs, newSettings.allocation.LogicalIDs) {
 		return nil, errors.New("Logical ID changes to a quorum is not currently supported")
 	}
 
 	return &rollingupdate{
-		desc:       fmt.Sprintf("Performs a rolling update on %d instances", len(settings.config.LogicalIDs)),
+		desc: fmt.Sprintf(
+			"Performs a rolling update on %d instances",
+			len(settings.allocation.LogicalIDs)),
 		scaled:     scaled,
 		updatingTo: newSettings,
 		stop:       make(chan bool),

--- a/plugin/group/rollingupdate.go
+++ b/plugin/group/rollingupdate.go
@@ -56,7 +56,7 @@ func (r *rollingupdate) waitUntilQuiesced(pollInterval time.Duration, expectedNe
 			// Gather instances in the scaler with the desired state
 			// Check:
 			//   - that the scaler has the expected number of instances
-			//   - instances with the desired config are healthy (e.g. represented in `swarm node ls`)
+			//   - instances with the desired config are healthy
 
 			// TODO(wfarner): Get this information from the scaler to reduce redundant network calls.
 			instances, err := r.scaled.List()
@@ -99,7 +99,9 @@ func (r *rollingupdate) Run(pollInterval time.Duration) error {
 	expectedNewInstances := len(desired)
 
 	for {
-		err := r.waitUntilQuiesced(pollInterval, minInt(expectedNewInstances, int(r.updatingTo.config.Size)))
+		err := r.waitUntilQuiesced(
+			pollInterval,
+			minInt(expectedNewInstances, int(r.updatingTo.allocation.Size)))
 		if err != nil {
 			return err
 		}
@@ -122,7 +124,7 @@ func (r *rollingupdate) Run(pollInterval time.Duration) error {
 		sort.Sort(sortByID(undesiredInstances))
 
 		// TODO(wfarner): Provide a mechanism to gracefully drain instances.
-		// TODO(wfarner): Make the 'batch size' configurable, but not for manager role groups.
+		// TODO(wfarner): Make the 'batch size' configurable.
 		r.scaled.Destroy(undesiredInstances[0].ID)
 
 		expectedNewInstances++

--- a/plugin/group/scaled.go
+++ b/plugin/group/scaled.go
@@ -67,7 +67,7 @@ func (s *scaledGroup) getSpec(logicalID *instance.LogicalID) (instance.Spec, err
 		spec.Tags = tags
 
 		var err error
-		spec, err = s.flavorPlugin.PreProvision(s.flavorProperties, spec)
+		spec, err = s.flavorPlugin.Prepare(s.flavorProperties, spec)
 		if err != nil {
 			return spec, err
 		}

--- a/plugin/group/state.go
+++ b/plugin/group/state.go
@@ -18,7 +18,7 @@ type Supervisor interface {
 }
 
 type groupSettings struct {
-	allocation     flavor.InstanceIDKind
+	allocation     flavor.AllocationMethod
 	instancePlugin instance.Plugin
 	flavorPlugin   flavor.Plugin
 	config         types.Schema

--- a/plugin/group/types/types.go
+++ b/plugin/group/types/types.go
@@ -6,7 +6,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"github.com/docker/libmachete/spi/group"
-	"github.com/docker/libmachete/spi/instance"
 )
 
 // These types are declared in a separate package to break an import cycle between group (test) -> mock -> group.
@@ -30,8 +29,6 @@ func MustParse(s Schema, e error) Schema {
 
 // Schema is the document schema for the plugin, provided in group.Configuration.
 type Schema struct {
-	Size                     uint32
-	LogicalIDs               []instance.LogicalID
 	InstancePlugin           string
 	InstancePluginProperties json.RawMessage
 	FlavorPlugin             string
@@ -40,7 +37,7 @@ type Schema struct {
 
 // InstanceHash computes a stable hash of the document in InstancePluginProperties.
 func (c Schema) InstanceHash() string {
-	// TODO(wfarner): This does not take ProvisionHelper augmentations (e.g. tags, bootScript) into consideration.
+	// TODO(wfarner): This does not take Flavor augmentations (e.g. Tags, Init) into consideration.
 	return instanceHash(c.InstancePluginProperties)
 }
 

--- a/spi/flavor/spi.go
+++ b/spi/flavor/spi.go
@@ -2,30 +2,25 @@ package flavor
 
 import (
 	"encoding/json"
-	"github.com/docker/libmachete/plugin/group/types"
 	"github.com/docker/libmachete/spi/instance"
 )
 
-// InstanceIDKind is the kind of instance identifier for a group.
-type InstanceIDKind int
-
-// Definitions of supported instance identifier kinds.
-const (
-	IDKindUnknown InstanceIDKind = iota
-	IDKindPhysical
-	IDKindPhysicalWithLogical
-)
+// AllocationMethod defines the type of allocation and supervision needed by a flavor's Group.
+type AllocationMethod struct {
+	Size       uint
+	LogicalIDs []instance.LogicalID
+}
 
 // Plugin defines custom behavior for what runs on instances.
 type Plugin interface {
 
 	// Validate checks whether the helper can support a configuration, and returns the allocation kind required.
-	Validate(flavorProperties json.RawMessage, parsed types.Schema) (InstanceIDKind, error)
+	Validate(flavorProperties json.RawMessage) (AllocationMethod, error)
 
-	// PreProvision allows the helper to modify the provisioning instructions for an instance.  For example, a
-	// helper could be used to place additional tags on the machine, or generate a specialized BootScript based on
-	// the machine configuration.
-	PreProvision(flavorProperties json.RawMessage, spec instance.Spec) (instance.Spec, error)
+	// PreProvision allows the flavor to modify the provisioning instructions for an instance.  For example, a
+	// helper could be used to place additional tags on the machine, or generate a specialized Init command based on
+	// the flavor configuration.
+	Prepare(flavorProperties json.RawMessage, spec instance.Spec) (instance.Spec, error)
 
 	// Healthy determines whether an instance is healthy.
 	Healthy(inst instance.Description) (bool, error)


### PR DESCRIPTION
This began as an effort to address the TODO:

> `// TODO(wfarner): Need access to the parsed group properties.`

The problem being that in some cases, Flavor plugins need to know the logical IDs of all members of the group.  As an example, configuring a ZK member requires knowledge of all member IP addresses.  I initially intended to pass the `group.Configuration` to accomplish this.  However, it dawned on me that the API could be simplified by moving `Size` and `LogicalIDs` concepts away from the group and into properties of the Flavor.  This brings an additional benefit of more user-friendly configuration:

``` json
{
  "ID": "members",
  "flavor": {
    "plugin": "zookeeper",
    "properties": {
      "Type": "voting-member",
      "IPs": ["192.168.0.4", "192.168.0.5", "192.168.0.6"]
    }
  }
}
```

which i find less awkward than:

``` json
{
  "ID": "members",
  "LogicalIDs": ["192.168.0.4", "192.168.0.5", "192.168.0.6"],
  "flavor": {
    "plugin": "zookeeper",
    "properties": {
      "Type": "voting-member"
    }
  }
}
```
