### PR TITLE
Bug fix for discovery

### DIFF
--- a/discovery/dir.go
+++ b/discovery/dir.go
@@ -1,6 +1,7 @@
 package discovery
 
 import (
+	"fmt"
 	"io/ioutil"
 	"os"
 	"path/filepath"
@@ -52,7 +53,15 @@ func (r *Dir) PluginByName(name string) (plugin.Callable, error) {
 	if err := r.Refresh(); err != nil {
 		return nil, err
 	}
-	return r.plugins[name], nil
+
+	r.lock.RLock()
+	defer r.lock.RUnlock()
+	inst, has := r.plugins[name]
+	if !has {
+		return nil, fmt.Errorf("not-found:%s", name)
+	}
+
+	return inst, nil
 }
 
 // NewDir creates a registry instance with the given file directory path.  The entries in the directory


### PR DESCRIPTION
Previously the discovery code was making assumptions about the filename convention
(e.g. `.sock` extension) and this demanded code with lots of special cases and assumptions.

Instead, if there's a miss in locating the plugin, just rescan the whole directory and rebuild the index.  This will make it more resilient to user-made naming changes as well as discovering 
plugins that are installed later.
