### PR TITLE
UX improvements

### DIFF
--- a/cmd/cli/group.go
+++ b/cmd/cli/group.go
@@ -13,9 +13,14 @@ import (
 	"github.com/spf13/cobra"
 )
 
+const (
+	// DefaultGroupPluginName specifies the default name of the group plugin if name flag isn't specified.
+	DefaultGroupPluginName = "group"
+)
+
 func groupPluginCommand(pluginDir func() *discovery.Dir) *cobra.Command {
 
-	name := ""
+	name := DefaultGroupPluginName
 	var groupPlugin group.Plugin
 
 	cmd := &cobra.Command{


### PR DESCRIPTION
- Set default flag value for plugin name for the `group` subcommand to `group`.  

TODO - Ideally we'd discover the plugins by interface type (e.g. `GroupDriver/1.0`) and use the names as default if only one of the group plugin is available.  
