### PR TITLE
Added support for ENV var at the cli

### DIFF
--- a/cmd/cli/main.go
+++ b/cmd/cli/main.go
@@ -65,7 +65,7 @@ func main() {
 	})
 
 	f := func() *discovery.Dir {
-		d, err := discovery.NewDir(viper.GetString("dir"))
+		d, err := discovery.NewDir(viper.GetString("discovery"))
 		if err != nil {
 			log.Errorf("Failed to initialize plugin discovery: %s", err)
 			os.Exit(1)
@@ -74,9 +74,9 @@ func main() {
 	}
 	cmd.AddCommand(pluginCommand(f), instancePluginCommand(f), groupPluginCommand(f), flavorPluginCommand(f))
 
-	cmd.PersistentFlags().String("dir", discoveryDir, "Dir path for plugin discovery")
-	viper.BindEnv("dir", "INFRAKIT_PLUGINS_DIR")
-	viper.BindPFlag("dir", cmd.PersistentFlags().Lookup("dir"))
+	cmd.PersistentFlags().String("discovery", discoveryDir, "Dir discovery path for plugin discovery")
+	viper.BindEnv("discovery", "INFRAKIT_PLUGINS_DIR")
+	viper.BindPFlag("discovery", cmd.PersistentFlags().Lookup("discovery"))
 	cmd.PersistentFlags().IntVar(&logLevel, "log", logLevel, "Logging level. 0 is least verbose. Max is 5")
 
 	err := cmd.Execute()

--- a/cmd/cli/main.go
+++ b/cmd/cli/main.go
@@ -10,6 +10,7 @@ import (
 	log "github.com/Sirupsen/logrus"
 	"github.com/docker/infrakit/discovery"
 	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
 )
 
 // This is a generic client for infrakit
@@ -64,7 +65,7 @@ func main() {
 	})
 
 	f := func() *discovery.Dir {
-		d, err := discovery.NewDir(discoveryDir)
+		d, err := discovery.NewDir(viper.GetString("dir"))
 		if err != nil {
 			log.Errorf("Failed to initialize plugin discovery: %s", err)
 			os.Exit(1)
@@ -73,7 +74,9 @@ func main() {
 	}
 	cmd.AddCommand(pluginCommand(f), instancePluginCommand(f), groupPluginCommand(f), flavorPluginCommand(f))
 
-	cmd.PersistentFlags().StringVar(&discoveryDir, "dir", discoveryDir, "Dir path for plugin discovery")
+	cmd.PersistentFlags().String("dir", discoveryDir, "Dir path for plugin discovery")
+	viper.BindEnv("dir", "INFRAKIT_PLUGINS_DIR")
+	viper.BindPFlag("dir", cmd.PersistentFlags().Lookup("dir"))
 	cmd.PersistentFlags().IntVar(&logLevel, "log", logLevel, "Logging level. 0 is least verbose. Max is 5")
 
 	err := cmd.Execute()

--- a/cmd/group/main.go
+++ b/cmd/group/main.go
@@ -84,11 +84,6 @@ func main() {
 				return flavor_client.PluginClient(callable), nil
 			}
 
-			log.Infoln("Starting plugin")
-
-			log.Infoln("Starting")
-			log.Infoln("Listening on:", listenURL.String())
-
 			_, stopped, err := util.StartServer(listenURL.String(), group_server.PluginServer(
 				group.NewGroupPlugin(
 					instancePluginLookup,

--- a/docs/tutorial.md
+++ b/docs/tutorial.md
@@ -9,20 +9,23 @@ All InfraKit plugins will by default open the unix socket located at /run/infrak
 exists on your host:
 
 ```shell
-$ mkdir -p /run/infrakit/plugins/
-$ chmod 777 /run/infrakit/plugins
+# Make sure directory exists for plugins to discover each other (default is: /run/infrakit/plugins/)
+$ mkdir -p /$TMPDIR/infrakit/plugins/
 ```
 
 Start the default Group plugin
 
+**_NOTE:_** You can set the listen url as an env variale via `export INFRAKIT_PLUGINS_DIR="/$TMPDIR/infrakit/plugins/"` instead of passing it as a flag. The default socket will be used, unless the `--name` flag is passed, when the env variable is set. 
+
 ```shell
+$ export INFRAKIT_PLUGINS_DIR="/$TMPDIR/infrakit/plugins/"
 $ build/infrakit-group-default --log 5
 INFO[0000] Starting discovery
-DEBU[0000] Opening: /run/infrakit/plugins
+DEBU[0000] Opening: /$TMPDIR/infrakit/plugins
 INFO[0000] Starting plugin
 INFO[0000] Starting
-INFO[0000] Listening on: unix:///run/infrakit/plugins/group.sock
-INFO[0000] listener protocol= unix addr= /run/infrakit/plugins/group.sock err= <nil>
+INFO[0000] Listening on: unix:///$TMPDIR/infrakit/plugins/group.sock
+INFO[0000] listener protocol= unix addr= /$TMPDIR/infrakit/plugins/group.sock err= <nil>
 ```
 
 Start the file Instance plugin
@@ -31,9 +34,9 @@ Start the file Instance plugin
 $ mkdir -p tutorial
 $ build/infrakit-instance-file --log 5 --dir ./tutorial/
 INFO[0000] Starting plugin
-INFO[0000] Listening on: unix:///run/infrakit/plugins/instance-file.sock
+INFO[0000] Listening on: unix:///$TMPDIR/infrakit/plugins/instance-file.sock
 DEBU[0000] file instance plugin. dir= ./tutorial/
-INFO[0000] listener protocol= unix addr= /run/infrakit/plugins/instance-file.sock err= <nil>
+INFO[0000] listener protocol= unix addr= /$TMPDIR/infrakit/plugins/instance-file.sock err= <nil>
 ```
 Note the directory `./tutorial` where the plugin will store the instances as they are provisioned.
 We can look at the files here to see what's being created and how they are configured.
@@ -43,8 +46,8 @@ Start the vanilla Flavor plugin
 ```shell
 $ build/infrakit-flavor-vanilla --log 5
 INFO[0000] Starting plugin
-INFO[0000] Listening on: unix:///run/infrakit/plugins/flavor-vanilla.sock
-INFO[0000] listener protocol= unix addr= /run/infrakit/plugins/flavor-vanilla.sock err= <nil>
+INFO[0000] Listening on: unix:///$TMPDIR/infrakit/plugins/flavor-vanilla.sock
+INFO[0000] listener protocol= unix addr= /$TMPDIR/infrakit/plugins/flavor-vanilla.sock err= <nil>
 ```
 
 Show the plugins:
@@ -53,9 +56,9 @@ Show the plugins:
 $ build/infrakit plugin ls
 Plugins:
 NAME                    LISTEN
-flavor-vanilla          unix:///run/infrakit/plugins/flavor-vanilla.sock
-group                   unix:///run/infrakit/plugins/group.sock
-instance-file           unix:///run/infrakit/plugins/instance-file.sock
+flavor-vanilla          unix:///$TMPDIR/infrakit/plugins/flavor-vanilla.sock
+group                   unix:///$TMPDIR/infrakit/plugins/group.sock
+instance-file           unix:///$TMPDIR/infrakit/plugins/instance-file.sock
 ```
 
 Note the names of the plugin.  We will use the names in the `--name` flag of the plugin CLI to refer to them.
@@ -206,7 +209,7 @@ watching cattle
 
 **_NOTE:_** You can also specify a file name to load from instead of using stdin, like this:
 
-```
+```shell
 $ build/infrakit group --name group watch group.json
 ```
 
@@ -340,7 +343,7 @@ drwxr-xr-x  36 davidchung  staff  1224 Sep 28 16:39 ..
 -rw-r--r--   1 davidchung  staff   654 Sep 28 16:40 instance-1475106036 <-- new instance
 ```
 
-We see that 3 new instance has been created to replace the three removed, to match our
+We see that 3 new instance have been created to replace the three removed, to match our
 original specification of 10 instances.
 
 Finally, let's clean up:
@@ -349,12 +352,36 @@ Finally, let's clean up:
 $ build/infrakit group --name group destroy cattle
 ```
 
-This concludes our quick tutorial.  In this tutorial we have
+This concludes our quick tutorial.  In this tutorial we:
   + Started the plugins and learned to access them
-  + Created a configuration for a group we want to watch
-  + See the instances created to match the specifications
-  + Updated the configurations of the group and scale up the group
+  + Created a configuration for a group we wanted to watch
+  + Verified the instances created matched the specifications
+  + Updated the configurations of the group and scaled up the group
   + Reviewed the proposed changes
-  + Apply the update across the group
-  + Removed some instances and see that the group self-healed
+  + Applied the update across the group
+  + Removed some instances and observed that the group self-healed
+  + Destroyed the group
+-rw-r--r--   1 davidchung  staff   654 Sep 28 16:35 instance-1475105736
+-rw-r--r--   1 davidchung  staff   654 Sep 28 16:40 instance-1475106016 <-- new instance
+-rw-r--r--   1 davidchung  staff   654 Sep 28 16:40 instance-1475106026 <-- new instance
+-rw-r--r--   1 davidchung  staff   654 Sep 28 16:40 instance-1475106036 <-- new instance
+```
+
+We see that 3 new instance have been created to replace the three removed, to match our
+original specification of 10 instances.
+
+Finally, let's clean up:
+
+```
+$ build/infrakit group --name group destroy cattle
+```
+
+This concludes our quick tutorial.  In this tutorial we:
+  + Started the plugins and learned to access them
+  + Created a configuration for a group we wanted to watch
+  + Verified the instances created matched the specifications
+  + Updated the configurations of the group and scaled up the group
+  + Reviewed the proposed changes
+  + Applied the update across the group
+  + Removed some instances and observed that the group self-healed
   + Destroyed the group

--- a/docs/tutorial.md
+++ b/docs/tutorial.md
@@ -5,38 +5,19 @@ To illustrate the concept of working with Group, Flavor, and Instance plugins, w
   + The `file` instance plugin - to provision instances by writing files to disk
   + The `vanilla` flavor plugin - to provide context/ flavor to the configuration of the instances
 
-<<<<<<< HEAD
-All InfraKit plugins will by default open the unix socket located at /run/infrakit/plugins. Make sure this directory
-exists on your host:
-
-```shell
-# Make sure directory exists for plugins to discover each other (default is: /run/infrakit/plugins/)
-$ mkdir -p /$TMPDIR/infrakit/plugins/
-```
-=======
-It may be helpful to familiarize yourself with [plugin discovery](README.md#plugin-discovery) if you have not already
+It may be helpful to familiarize yourself with [plugin discovery](../README.md#plugin-discovery) if you have not already
 done so.
->>>>>>> 2fcf1a30dce8922f160a131bbc34849ab4ee51a8
 
 Start the default Group plugin
 
-**_NOTE:_** You can set the listen url as an env variale via `export INFRAKIT_PLUGINS_DIR="/$TMPDIR/infrakit/plugins/"` instead of passing it as a flag. The default socket will be used, unless the `--name` flag is passed, when the env variable is set. 
+**_NOTE:_** You can set the listen url as an env variale via `export INFRAKIT_PLUGINS_DIR="$TMPDIR/infrakit/plugins/"` instead of passing it as a flag. The default socket will be used, unless the `--name` flag is passed, when the env variable is set. 
 
 ```shell
-$ export INFRAKIT_PLUGINS_DIR="/$TMPDIR/infrakit/plugins/"
+$ export INFRAKIT_PLUGINS_DIR="$TMPDIR/infrakit/plugins/"
 $ build/infrakit-group-default --log 5
-<<<<<<< HEAD
-INFO[0000] Starting discovery
-DEBU[0000] Opening: /$TMPDIR/infrakit/plugins
-INFO[0000] Starting plugin
-INFO[0000] Starting
-INFO[0000] Listening on: unix:///$TMPDIR/infrakit/plugins/group.sock
-INFO[0000] listener protocol= unix addr= /$TMPDIR/infrakit/plugins/group.sock err= <nil>
-=======
-DEBU[0000] Opening: /run/infrakit/plugins
-INFO[0000] Listening on: unix:///run/infrakit/plugins/group.sock
-INFO[0000] listener protocol= unix addr= /run/infrakit/plugins/group.sock err= <nil>
->>>>>>> 2fcf1a30dce8922f160a131bbc34849ab4ee51a8
+DEBU[0000] Opening: /var/folders/kl/4fm2zyxs3_5dd869x992dvvw0000gn/T/infrakit/plugins
+INFO[0000] Listening on: unix:///var/folders/kl/4fm2zyxs3_5dd869x992dvvw0000gn/T/infrakit/plugins/group.sock
+INFO[0000] listener protocol= unix addr= /var/folders/kl/4fm2zyxs3_5dd869x992dvvw0000gn/T/infrakit/plugins/group.sock err= <nil>
 ```
 
 Start the file Instance plugin
@@ -44,14 +25,9 @@ Start the file Instance plugin
 ```shell
 $ mkdir -p tutorial
 $ build/infrakit-instance-file --log 5 --dir ./tutorial/
-<<<<<<< HEAD
-INFO[0000] Starting plugin
-INFO[0000] Listening on: unix:///$TMPDIR/infrakit/plugins/instance-file.sock
-=======
-INFO[0000] Listening on: unix:///run/infrakit/plugins/instance-file.sock
->>>>>>> 2fcf1a30dce8922f160a131bbc34849ab4ee51a8
+INFO[0000] Listening on: unix:///var/folders/kl/4fm2zyxs3_5dd869x992dvvw0000gn/T/infrakit/plugins/instance-file.sock
 DEBU[0000] file instance plugin. dir= ./tutorial/
-INFO[0000] listener protocol= unix addr= /$TMPDIR/infrakit/plugins/instance-file.sock err= <nil>
+INFO[0000] listener protocol= unix addr= /var/folders/kl/4fm2zyxs3_5dd869x992dvvw0000gn/T/infrakit/plugins/instance-file.sock err= <nil>
 ```
 Note the directory `./tutorial` where the plugin will store the instances as they are provisioned.
 We can look at the files here to see what's being created and how they are configured.
@@ -60,14 +36,8 @@ Start the vanilla Flavor plugin
 
 ```shell
 $ build/infrakit-flavor-vanilla --log 5
-<<<<<<< HEAD
-INFO[0000] Starting plugin
-INFO[0000] Listening on: unix:///$TMPDIR/infrakit/plugins/flavor-vanilla.sock
-INFO[0000] listener protocol= unix addr= /$TMPDIR/infrakit/plugins/flavor-vanilla.sock err= <nil>
-=======
-INFO[0000] Listening on: unix:///run/infrakit/plugins/flavor-vanilla.sock
-INFO[0000] listener protocol= unix addr= /run/infrakit/plugins/flavor-vanilla.sock err= <nil>
->>>>>>> 2fcf1a30dce8922f160a131bbc34849ab4ee51a8
+INFO[0000] Listening on: unix:///var/folders/kl/4fm2zyxs3_5dd869x992dvvw0000gn/T/infrakit/plugins/flavor-vanilla.sock
+INFO[0000] listener protocol= unix addr= /var/folders/kl/4fm2zyxs3_5dd869x992dvvw0000gn/T/infrakit/plugins/flavor-vanilla.sock err= <nil>
 ```
 
 Show the plugins:
@@ -76,9 +46,9 @@ Show the plugins:
 $ build/infrakit plugin ls
 Plugins:
 NAME                    LISTEN
-flavor-vanilla          unix:///$TMPDIR/infrakit/plugins/flavor-vanilla.sock
-group                   unix:///$TMPDIR/infrakit/plugins/group.sock
-instance-file           unix:///$TMPDIR/infrakit/plugins/instance-file.sock
+flavor-vanilla          unix:///var/folders/kl/4fm2zyxs3_5dd869x992dvvw0000gn/T/infrakit/plugins/flavor-vanilla.sock
+group                   unix:///var/folders/kl/4fm2zyxs3_5dd869x992dvvw0000gn/T/infrakit/plugins/group.sock
+instance-file           unix:///var/folders/kl/4fm2zyxs3_5dd869x992dvvw0000gn/T/infrakit/plugins/instance-file.sock
 ```
 
 Note the names of the plugin.  We will use the names in the `--name` flag of the plugin CLI to refer to them.

--- a/docs/tutorial.md
+++ b/docs/tutorial.md
@@ -361,27 +361,3 @@ This concludes our quick tutorial.  In this tutorial we:
   + Applied the update across the group
   + Removed some instances and observed that the group self-healed
   + Destroyed the group
--rw-r--r--   1 davidchung  staff   654 Sep 28 16:35 instance-1475105736
--rw-r--r--   1 davidchung  staff   654 Sep 28 16:40 instance-1475106016 <-- new instance
--rw-r--r--   1 davidchung  staff   654 Sep 28 16:40 instance-1475106026 <-- new instance
--rw-r--r--   1 davidchung  staff   654 Sep 28 16:40 instance-1475106036 <-- new instance
-```
-
-We see that 3 new instance have been created to replace the three removed, to match our
-original specification of 10 instances.
-
-Finally, let's clean up:
-
-```
-$ build/infrakit group --name group destroy cattle
-```
-
-This concludes our quick tutorial.  In this tutorial we:
-  + Started the plugins and learned to access them
-  + Created a configuration for a group we wanted to watch
-  + Verified the instances created matched the specifications
-  + Updated the configurations of the group and scaled up the group
-  + Reviewed the proposed changes
-  + Applied the update across the group
-  + Removed some instances and observed that the group self-healed
-  + Destroyed the group

--- a/example/flavor/swarm/main.go
+++ b/example/flavor/swarm/main.go
@@ -11,6 +11,7 @@ import (
 	"github.com/docker/infrakit/plugin/util"
 	flavor_plugin "github.com/docker/infrakit/spi/http/flavor"
 	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
 )
 
 var (
@@ -30,7 +31,8 @@ var (
 func main() {
 
 	logLevel := len(log.AllLevels) - 2
-	listen := "unix:///run/infrakit/plugins/flavor-swarm.sock"
+	listen := "unix:///run/infrakit/plugins/"
+	sock := "flavor-swarm.sock"
 
 	tlsOptions := tlsconfig.Options{}
 	host := "unix:///var/run/docker.sock"
@@ -91,7 +93,11 @@ func main() {
 		},
 	})
 
-	cmd.PersistentFlags().StringVar(&listen, "listen", listen, "listen address (unix or tcp) for the control endpoint")
+	cmd.PersistentFlags().String("listen", listen, "listen address (unix or tcp) for the control endpoint")
+	viper.BindEnv("listen", "INFRAKIT_PLUGINS_LISTEN")
+	viper.BindPFlag("listen", cmd.PersistentFlags().Lookup("listen"))
+	cmd.PersistentFlags().String("sock", sock, "listen socket for the control endpoint")
+	viper.BindPFlag("sock", cmd.PersistentFlags().Lookup("sock"))
 	cmd.PersistentFlags().IntVar(&logLevel, "log", logLevel, "Logging level. 0 is least verbose. Max is 5")
 
 	cmd.PersistentFlags().StringVar(&host, "host", host, "Docker host")

--- a/example/flavor/vanilla/main.go
+++ b/example/flavor/vanilla/main.go
@@ -32,8 +32,8 @@ var (
 func main() {
 
 	logLevel := len(log.AllLevels) - 2
-	listen := "unix:///run/infrakit/plugins/"
-	sock := "flavor-vanilla.sock"
+	discoveryDir := "/run/infrakit/plugins/"
+	name := "flavor-vanilla"
 
 	cmd := &cobra.Command{
 		Use:   os.Args[0],
@@ -51,17 +51,14 @@ func main() {
 				return nil
 			}
 
-			listen = viper.GetString("listen")
-			sock = viper.GetString("sock")
+			discoveryDir = viper.GetString("discovery")
+			name = viper.GetString("name")
+			listen := fmt.Sprintf("unix://%s/%s.sock", path.Clean(discoveryDir), name)
 
 			// parse the listen string
 			listenURL, err := url.Parse(listen)
 			if err != nil {
 				return err
-			}
-
-			if listenURL.Scheme == "unix" {
-				listenURL.Path = path.Join(listenURL.Path, sock)
 			}
 
 			log.Infoln("Starting plugin")
@@ -98,11 +95,13 @@ func main() {
 		},
 	})
 
-	cmd.Flags().String("listen", listen, "listen address (unix or tcp) for the control endpoint")
-	viper.BindEnv("listen", "INFRAKIT_PLUGINS_LISTEN")
-	viper.BindPFlag("listen", cmd.Flags().Lookup("listen"))
-	cmd.Flags().String("sock", sock, "listen socket for the control endpoint")
-	viper.BindPFlag("sock", cmd.Flags().Lookup("sock"))
+	cmd.Flags().String("discovery", discoveryDir, "Dir discovery path for plugin discovery")
+	// Bind Pflags for cmd passed
+	viper.BindEnv("discovery", "INFRAKIT_PLUGINS_DIR")
+	viper.BindPFlag("discovery", cmd.Flags().Lookup("discovery"))
+	cmd.Flags().String("name", name, "listen socket name for the control endpoint")
+	// Bind Pflags for cmd passed
+	viper.BindPFlag("name", cmd.Flags().Lookup("name"))
 	cmd.Flags().IntVar(&logLevel, "log", logLevel, "Logging level. 0 is least verbose. Max is 5")
 
 	err := cmd.Execute()

--- a/example/flavor/zookeeper/main.go
+++ b/example/flavor/zookeeper/main.go
@@ -10,6 +10,7 @@ import (
 	"github.com/docker/infrakit/plugin/util"
 	flavor_plugin "github.com/docker/infrakit/spi/http/flavor"
 	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
 )
 
 var (
@@ -29,7 +30,8 @@ var (
 func main() {
 
 	logLevel := len(log.AllLevels) - 2
-	listen := "unix:///run/infrakit/plugins/flavor-zookeeper.sock"
+	listen := "unix:///run/infrakit/plugins/"
+	sock := "flavor-zookeeper.sock"
 
 	cmd := &cobra.Command{
 		Use:   os.Args[0],
@@ -81,7 +83,11 @@ func main() {
 		},
 	})
 
-	cmd.Flags().StringVar(&listen, "listen", listen, "listen address (unix or tcp) for the control endpoint")
+	cmd.Flags().String("listen", listen, "listen address (unix or tcp) for the control endpoint")
+	viper.BindEnv("listen", "INFRAKIT_PLUGINS_LISTEN")
+	viper.BindPFlag("listen", cmd.Flags().Lookup("listen"))
+	cmd.Flags().String("sock", sock, "listen socket for the control endpoint")
+	viper.BindPFlag("sock", cmd.Flags().Lookup("sock"))
 	cmd.Flags().IntVar(&logLevel, "log", logLevel, "Logging level. 0 is least verbose. Max is 5")
 
 	err := cmd.Execute()

--- a/example/instance/terraform/main.go
+++ b/example/instance/terraform/main.go
@@ -3,13 +3,16 @@ package main
 import (
 	"encoding/json"
 	"fmt"
+	"net/url"
 	"os"
 	"os/exec"
+	"path"
 
 	log "github.com/Sirupsen/logrus"
 	"github.com/docker/infrakit/plugin/util"
 	instance_plugin "github.com/docker/infrakit/spi/http/instance"
 	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
 )
 
 var (
@@ -39,7 +42,8 @@ func main() {
 	mustHaveTerraform()
 
 	logLevel := len(log.AllLevels) - 2
-	listen := "unix:///run/infrakit/plugins/instance-terraform.sock"
+	listen := "unix:///run/infrakit/plugins/"
+	sock := "instance-terraform.sock"
 	dir := os.TempDir()
 
 	cmd := &cobra.Command{
@@ -57,10 +61,23 @@ func main() {
 				return nil
 			}
 
-			log.Infoln("Starting plugin")
-			log.Infoln("Listening on:", listen)
+			listen = viper.GetString("listen")
+			sock = viper.GetString("sock")
 
-			_, stopped, err := util.StartServer(listen, instance_plugin.PluginServer(
+			// parse the listen string
+			listenURL, err := url.Parse(listen)
+			if err != nil {
+				return err
+			}
+
+			if listenURL.Scheme == "unix" {
+				listenURL.Path = path.Join(listenURL.Path, sock)
+			}
+
+			log.Infoln("Starting plugin")
+			log.Infoln("Listening on:", listenURL.String())
+
+			_, stopped, err := util.StartServer(listenURL.String(), instance_plugin.PluginServer(
 				NewTerraformInstancePlugin(dir)))
 
 			if err != nil {
@@ -92,7 +109,11 @@ func main() {
 		},
 	})
 
-	cmd.Flags().StringVar(&listen, "listen", listen, "listen address (unix or tcp) for the control endpoint")
+	cmd.Flags().String("listen", listen, "listen address (unix or tcp) for the control endpoint")
+	viper.BindEnv("listen", "INFRAKIT_PLUGINS_LISTEN")
+	viper.BindPFlag("listen", cmd.Flags().Lookup("listen"))
+	cmd.Flags().String("sock", sock, "listen socket for the control endpoint")
+	viper.BindPFlag("sock", cmd.Flags().Lookup("sock"))
 	cmd.Flags().IntVar(&logLevel, "log", logLevel, "Logging level. 0 is least verbose. Max is 5")
 	cmd.Flags().StringVar(&dir, "dir", dir, "Dir for storing the files")
 

--- a/example/instance/terraform/main.go
+++ b/example/instance/terraform/main.go
@@ -42,8 +42,8 @@ func main() {
 	mustHaveTerraform()
 
 	logLevel := len(log.AllLevels) - 2
-	listen := "unix:///run/infrakit/plugins/"
-	sock := "instance-terraform.sock"
+	discoveryDir := "/run/infrakit/plugins/"
+	name := "instance-terraform"
 	dir := os.TempDir()
 
 	cmd := &cobra.Command{
@@ -61,17 +61,14 @@ func main() {
 				return nil
 			}
 
-			listen = viper.GetString("listen")
-			sock = viper.GetString("sock")
+			discoveryDir = viper.GetString("discovery")
+			name = viper.GetString("name")
+			listen := fmt.Sprintf("unix://%s/%s.sock", path.Clean(discoveryDir), name)
 
 			// parse the listen string
 			listenURL, err := url.Parse(listen)
 			if err != nil {
 				return err
-			}
-
-			if listenURL.Scheme == "unix" {
-				listenURL.Path = path.Join(listenURL.Path, sock)
 			}
 
 			log.Infoln("Starting plugin")
@@ -109,11 +106,12 @@ func main() {
 		},
 	})
 
-	cmd.Flags().String("listen", listen, "listen address (unix or tcp) for the control endpoint")
-	viper.BindEnv("listen", "INFRAKIT_PLUGINS_LISTEN")
-	viper.BindPFlag("listen", cmd.Flags().Lookup("listen"))
-	cmd.Flags().String("sock", sock, "listen socket for the control endpoint")
-	viper.BindPFlag("sock", cmd.Flags().Lookup("sock"))
+	cmd.Flags().String("discovery", discoveryDir, "Dir discovery path for plugin discovery")
+	// Bind Pflags for cmd passed
+	viper.BindEnv("discovery", "INFRAKIT_PLUGINS_DIR")
+	viper.BindPFlag("discovery", cmd.Flags().Lookup("discovery"))
+	cmd.Flags().String("name", name, "listen socket name for the control endpoint")
+	viper.BindPFlag("name", cmd.Flags().Lookup("name"))
 	cmd.Flags().IntVar(&logLevel, "log", logLevel, "Logging level. 0 is least verbose. Max is 5")
 	cmd.Flags().StringVar(&dir, "dir", dir, "Dir for storing the files")
 

--- a/example/instance/vagrant/main.go
+++ b/example/instance/vagrant/main.go
@@ -3,7 +3,6 @@ package main
 import (
 	"encoding/json"
 	"fmt"
-	"net/url"
 	"os"
 	"path"
 
@@ -48,28 +47,11 @@ func main() {
 			}
 			log.SetLevel(log.AllLevels[logLevel])
 
-<<<<<<< HEAD
-			if c.Use == "version" {
-				return nil
-			}
-
 			discoveryDir = viper.GetString("discovery")
 			name = viper.GetString("name")
 			listen := fmt.Sprintf("unix://%s/%s.sock", path.Clean(discoveryDir), name)
 
-			// parse the listen string
-			listenURL, err := url.Parse(listen)
-			if err != nil {
-				return err
-			}
-
-			log.Infoln("Starting plugin")
-			log.Infoln("Listening on:", listenURL.String())
-
-			_, stopped, err := util.StartServer(listenURL.String(), instance_plugin.PluginServer(vagrant.NewVagrantPlugin(dir)))
-=======
 			_, stopped, err := util.StartServer(listen, instance_plugin.PluginServer(vagrant.NewVagrantPlugin(dir)))
->>>>>>> 2fcf1a30dce8922f160a131bbc34849ab4ee51a8
 
 			if err != nil {
 				log.Error(err)
@@ -101,7 +83,7 @@ func main() {
 	// Bind Pflags for cmd passed
 	viper.BindEnv("discovery", "INFRAKIT_PLUGINS_DIR")
 	viper.BindPFlag("discovery", cmd.Flags().Lookup("discovery"))
-	cmd.Flags().String("name", name, "listen socket name for the control endpoint")
+	cmd.Flags().String("name", name, "Plugin name to advertise for the control endpoint")
 	cmd.Flags().IntVar(&logLevel, "log", logLevel, "Logging level. 0 is least verbose. Max is 5")
 	cmd.Flags().StringVar(&dir, "dir", dir, "Vagrant directory")
 

--- a/example/instance/vagrant/main.go
+++ b/example/instance/vagrant/main.go
@@ -3,13 +3,16 @@ package main
 import (
 	"encoding/json"
 	"fmt"
+	"net/url"
 	"os"
+	"path"
 
 	log "github.com/Sirupsen/logrus"
 	"github.com/docker/infrakit/plugin/instance/vagrant"
 	"github.com/docker/infrakit/plugin/util"
 	instance_plugin "github.com/docker/infrakit/spi/http/instance"
 	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
 )
 
 var (
@@ -29,7 +32,8 @@ var (
 func main() {
 
 	logLevel := len(log.AllLevels) - 2
-	listen := "unix:///run/infrakit/plugins/instance-vagrant.sock"
+	listen := "unix:///run/infrakit/plugins/"
+	sock := "instance-vagrant.sock"
 	dir, _ := os.Getwd()
 
 	cmd := &cobra.Command{
@@ -48,10 +52,23 @@ func main() {
 				return nil
 			}
 
-			log.Infoln("Starting plugin")
-			log.Infoln("Listening on:", listen)
+			listen = viper.GetString("listen")
+			sock = viper.GetString("sock")
 
-			_, stopped, err := util.StartServer(listen, instance_plugin.PluginServer(vagrant.NewVagrantPlugin(dir)))
+			// parse the listen string
+			listenURL, err := url.Parse(listen)
+			if err != nil {
+				return err
+			}
+
+			if listenURL.Scheme == "unix" {
+				listenURL.Path = path.Join(listenURL.Path, sock)
+			}
+
+			log.Infoln("Starting plugin")
+			log.Infoln("Listening on:", listenURL.String())
+
+			_, stopped, err := util.StartServer(listenURL.String(), instance_plugin.PluginServer(vagrant.NewVagrantPlugin(dir)))
 
 			if err != nil {
 				log.Error(err)
@@ -82,7 +99,10 @@ func main() {
 		},
 	})
 
-	cmd.Flags().StringVar(&listen, "listen", listen, "listen address (unix or tcp) for the control endpoint")
+	cmd.Flags().String("listen", listen, "listen address (unix or tcp) for the control endpoint")
+	viper.BindEnv("listen", "INFRAKIT_PLUGINS_LISTEN")
+	viper.BindPFlag("listen", cmd.PersistentFlags().Lookup("listen"))
+	cmd.Flags().String("sock", sock, "listen socket for the control endpoint")
 	cmd.Flags().IntVar(&logLevel, "log", logLevel, "Logging level. 0 is least verbose. Max is 5")
 	cmd.Flags().StringVar(&dir, "dir", dir, "Vagrant directory")
 

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -233,6 +233,12 @@
 			"revisionTime": "2016-09-15T15:31:01Z"
 		},
 		{
+			"checksumSHA1": "c95O+eiZqqbHBDb8oy+RqzUBzRg=",
+			"path": "github.com/spf13/viper",
+			"revision": "382f87b929b84ce13e9c8a375a4b217f224e6c65",
+			"revisionTime": "2016-09-26T15:04:02Z"
+		},
+		{
 			"checksumSHA1": "iydUphwYqZRq3WhstEdGsbvBAKs=",
 			"path": "github.com/stretchr/testify/assert",
 			"revision": "d77da356e56a7428ad25149ca77381849a6a5232",

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -148,6 +148,12 @@
 			"revisionTime": "2016-09-08T21:06:52Z"
 		},
 		{
+			"checksumSHA1": "e2o/P8ZZ8Iz+um6/nyLUEg7S2H8=",
+			"path": "github.com/fsnotify/fsnotify",
+			"revision": "944cff21b3baf3ced9a880365682152ba577d348",
+			"revisionTime": "2016-10-05T04:06:20Z"
+		},
+		{
 			"checksumSHA1": "JSHl8b3nI8EWvzm+uyrIqj2Hiu4=",
 			"path": "github.com/golang/mock/gomock",
 			"revision": "bd3c8e81be01eef76d4b503f5e687d2d1354d2d9",
@@ -166,10 +172,76 @@
 			"revisionTime": "2016-08-01T17:00:46Z"
 		},
 		{
+			"checksumSHA1": "8OPDk+bKyRGJoKcS4QNw9F7dpE8=",
+			"path": "github.com/hashicorp/hcl",
+			"revision": "ef8133da8cda503718a74741312bf50821e6de79",
+			"revisionTime": "2016-09-16T13:01:00Z"
+		},
+		{
+			"checksumSHA1": "67DfevLBglV52Y2eAuhFc/xQni0=",
+			"path": "github.com/hashicorp/hcl/hcl/ast",
+			"revision": "ef8133da8cda503718a74741312bf50821e6de79",
+			"revisionTime": "2016-09-16T13:01:00Z"
+		},
+		{
+			"checksumSHA1": "l2oQxBsZRwn6eZjf+whXr8c9+8c=",
+			"path": "github.com/hashicorp/hcl/hcl/parser",
+			"revision": "ef8133da8cda503718a74741312bf50821e6de79",
+			"revisionTime": "2016-09-16T13:01:00Z"
+		},
+		{
+			"checksumSHA1": "lgR7PSAZ0RtvAc9OCtCnNsF/x8g=",
+			"path": "github.com/hashicorp/hcl/hcl/scanner",
+			"revision": "ef8133da8cda503718a74741312bf50821e6de79",
+			"revisionTime": "2016-09-16T13:01:00Z"
+		},
+		{
+			"checksumSHA1": "JlZmnzqdmFFyb1+2afLyR3BOE/8=",
+			"path": "github.com/hashicorp/hcl/hcl/strconv",
+			"revision": "ef8133da8cda503718a74741312bf50821e6de79",
+			"revisionTime": "2016-09-16T13:01:00Z"
+		},
+		{
+			"checksumSHA1": "c6yprzj06ASwCo18TtbbNNBHljA=",
+			"path": "github.com/hashicorp/hcl/hcl/token",
+			"revision": "ef8133da8cda503718a74741312bf50821e6de79",
+			"revisionTime": "2016-09-16T13:01:00Z"
+		},
+		{
+			"checksumSHA1": "jQ45CCc1ed/nlV7bbSnx6z72q1M=",
+			"path": "github.com/hashicorp/hcl/json/parser",
+			"revision": "ef8133da8cda503718a74741312bf50821e6de79",
+			"revisionTime": "2016-09-16T13:01:00Z"
+		},
+		{
+			"checksumSHA1": "YdvFsNOMSWMLnY6fcliWQa0O5Fw=",
+			"path": "github.com/hashicorp/hcl/json/scanner",
+			"revision": "ef8133da8cda503718a74741312bf50821e6de79",
+			"revisionTime": "2016-09-16T13:01:00Z"
+		},
+		{
+			"checksumSHA1": "fNlXQCQEnb+B3k5UDL/r15xtSJY=",
+			"path": "github.com/hashicorp/hcl/json/token",
+			"revision": "ef8133da8cda503718a74741312bf50821e6de79",
+			"revisionTime": "2016-09-16T13:01:00Z"
+		},
+		{
 			"checksumSHA1": "KQhA4EQp4Ldwj9nJZnEURlE6aQw=",
 			"path": "github.com/kr/fs",
 			"revision": "2788f0dbd16903de03cb8186e5c7d97b69ad387b",
 			"revisionTime": "2013-11-06T22:25:44Z"
+		},
+		{
+			"checksumSHA1": "S6PDDQMYaKwLDIP/NsRYb4FRAqQ=",
+			"path": "github.com/magiconair/properties",
+			"revision": "0723e352fa358f9322c938cc2dadda874e9151a9",
+			"revisionTime": "2016-09-08T09:36:58Z"
+		},
+		{
+			"checksumSHA1": "LUrnGREfnifW4WDMaavmc9MlLI0=",
+			"path": "github.com/mitchellh/mapstructure",
+			"revision": "ca63d7c062ee3c9f34db231e352b60012b4fd0c1",
+			"revisionTime": "2016-08-08T18:12:53Z"
 		},
 		{
 			"checksumSHA1": "aCtmlyAgau9n0UHs8Pk+3xfIaVk=",
@@ -182,6 +254,18 @@
 			"path": "github.com/opencontainers/runc/libcontainer/user",
 			"revision": "ce5d8cf94124a683af6a874f343375d3ec9230b4",
 			"revisionTime": "2016-09-20T16:57:39Z"
+		},
+		{
+			"checksumSHA1": "8Y05Pz7onrQPcVWW6JStSsYRh6E=",
+			"path": "github.com/pelletier/go-buffruneio",
+			"revision": "df1e16fde7fc330a0ca68167c23bf7ed6ac31d6d",
+			"revisionTime": "2016-01-24T19:35:03Z"
+		},
+		{
+			"checksumSHA1": "CtI2rBQw2rxHNIU+a0rcAf29Sco=",
+			"path": "github.com/pelletier/go-toml",
+			"revision": "45932ad32dfdd20826f5671da37a5f3ce9f26a8d",
+			"revisionTime": "2016-09-20T07:07:15Z"
 		},
 		{
 			"checksumSHA1": "Hky3u+8Rqum+wB5BHMj0A8ZmT4g=",
@@ -221,10 +305,22 @@
 			"revisionTime": "2016-09-19T21:01:14Z"
 		},
 		{
+			"checksumSHA1": "M4qI7Ul0vf2uj3fF69DvRnwqfd0=",
+			"path": "github.com/spf13/cast",
+			"revision": "2580bc98dc0e62908119e4737030cc2fdfc45e4c",
+			"revisionTime": "2016-09-26T08:42:49Z"
+		},
+		{
 			"checksumSHA1": "fEGgcE+iSzLkxdrbRj7j/vV7a7E=",
 			"path": "github.com/spf13/cobra",
 			"revision": "9c28e4bbd74e5c3ed7aacbc552b2cab7cfdfe744",
 			"revisionTime": "2016-08-30T17:49:25Z"
+		},
+		{
+			"checksumSHA1": "dkruahfhuLXXuyeCuRpsWlcRK+8=",
+			"path": "github.com/spf13/jwalterweatherman",
+			"revision": "33c24e77fb80341fe7130ee7c594256ff08ccc46",
+			"revisionTime": "2016-03-01T12:00:06Z"
 		},
 		{
 			"checksumSHA1": "b1FgvXRMwcr3D1litcrDNxgowBw=",
@@ -339,6 +435,12 @@
 			"path": "golang.org/x/text/unicode/norm",
 			"revision": "a7c023693a94aedd6b6df43ae7526bfe9d2b7d22",
 			"revisionTime": "2016-09-22T05:42:04Z"
+		},
+		{
+			"checksumSHA1": "12GqsW8PiRPnezDDy0v4brZrndM=",
+			"path": "gopkg.in/yaml.v2",
+			"revision": "a5b47d31c556af34a302ce5d659e6fea44d90de0",
+			"revisionTime": "2016-09-28T15:37:09Z"
 		}
 	],
 	"rootPath": "github.com/docker/infrakit"


### PR DESCRIPTION
Added support for env vars to define the Listen/tcp endpoint. This is especially useful when going through the tutorial and wanting to create the endpoint in say the `/tmp` dir, which does not require escalated privileges.

Introduces the env var `INFRAKIT_PLUGINS_DIR`.

Updated the tutorial to reflect some wording changes and the ability to point the listening socket to the `/tmp` dir of choice along with setting the plugin dir for the `cli` to use.

cc @chungers @wfarner 