### PR TITLE
Add missing comma to zk example

### DIFF
--- a/example/flavor/zookeeper/vagrant-zk-example.json
+++ b/example/flavor/zookeeper/vagrant-zk-example.json
@@ -6,7 +6,7 @@
             "Properties": {
                 "Box": "bento/ubuntu-16.04"
             }
-        }
+        },
         "Flavor" : {
             "Plugin": "flavor-zookeeper",
             "Properties": {


### PR DESCRIPTION
Not sure if you want these sorts of small bugfixes, or if you planning on doing an overhaul of the repo at some point. Let me know, having fun either way.

Original error:

```
$ infrakit/cli group --name group watch example/flavor/zookeeper/vagrant-zk-example.json
Error: invalid character '"' after object key:value pair
Usage:
  infrakit/cli group watch <group configuration> [flags]

Global Flags:
      --dir string    Dir path for plugin discovery (default "/run/infrakit/plugins")
      --log int       Logging level. 0 is least verbose. Max is 5 (default 4)
      --name string   Name of plugin (default "group")

ERRO[0000] invalid character '"' after object key:value pair
```