### PR TITLE
use a less platform specific example to run nginx

### DIFF
--- a/docs/tutorial.md
+++ b/docs/tutorial.md
@@ -91,9 +91,8 @@ For the Vanilla Flavor Plugin, we have the spec:
 {
     "Size": 5,
     "UserData": [
-        "sudo apt-get update -y",
-        "sudo apt-get install -y nginx",
-        "sudo service nginx start"
+        "docker pull nginx:alpine",
+        "docker run -d -p 80:80 nginx-alpine"
     ],
     "Labels": {
         "tier": "web",
@@ -140,11 +139,9 @@ Putting everything together, we have the configuration to give to the default Gr
             "Properties": {
                 "Size": 5,
                 "UserData": [
-                    "sudo apt-get update -y",
-                    "sudo apt-get install -y nginx",
-                    "sudo service nginx start"
+                    "docker pull nginx:alpine",
+                    "docker run -d -p 80:80 nginx-alpine"
                 ],
-
                 "Labels": {
                     "tier": "web",
                     "project": "infrakit"
@@ -187,9 +184,8 @@ $ infrakit/cli group --name group watch <<EOF
             "Properties": {
                 "Size": 5,
                 "UserData": [
-                    "sudo apt-get update -y",
-                    "sudo apt-get install -y nginx",
-                    "sudo service nginx start"
+                    "docker pull nginx:alpine",
+                    "docker run -d -p 80:80 nginx-alpine"
                 ],
                 "Labels": {
                     "tier": "web",
@@ -252,9 +248,8 @@ Now let's update the configuration by changing the size of the group and a prope
             "Properties": {
                 "Size": 10,
                 "UserData": [
-                    "sudo apt-get update -y",
-                    "sudo apt-get install -y nginx",
-                    "sudo service nginx start"
+                    "docker pull nginx:alpine",
+                    "docker run -d -p 80:80 nginx-alpine"
                 ],
                 "Labels": {
                     "tier": "web",


### PR DESCRIPTION
This one improves the tutorial a bit by using Docker to spin up the example Nginx. We might assume that people interested in InfraKit are already Docker infected ;-)

Signed-off-by: Tobias Gesellchen <tobias@gesellix.de>
