### PR TITLE
Build: rename "infrakit" target to "binaries"

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ endif
 
 .PHONY: clean all fmt vet lint build test vendor-sync containers
 .DEFAULT: all
-all: clean fmt vet lint build test infrakit
+all: clean fmt vet lint build test binaries
 
 ci: fmt vet lint vendor-sync vendor-check coverage
 
@@ -53,7 +53,7 @@ clean:
 	-mkdir -p ./infrakit
 	-rm -rf ./infrakit/*
 
-infrakit: clean build
+binaries: clean build
 	@echo "+ $@"
 	@for bin in $(BINARIES); do \
 	  go build -o ./infrakit/$$( echo $${bin} | awk -F '/' '{print $$NF}') \

--- a/README.md
+++ b/README.md
@@ -148,7 +148,7 @@ $ make ci
 
 ### Binaries
 ```shell
-$ make -k infrakit
+$ make binaries
 ```
 This will create a directory, `infrakit` in the project directory.  The executables can be found here.
 Currently, several binaries are available. More detailed documentations can be found here

--- a/cmd/cli/README.md
+++ b/cmd/cli/README.md
@@ -9,7 +9,7 @@ exposed as verbs and configuration JSON can be read from local file or standard 
 
 ## Building
 
-When you do `make -k all` in the top level directory, the CLI binary will be built and can be
+When you do `make binaries` in the top level directory, the CLI binary will be built and can be
 found as `./infrakit/cli` from the project's top level directory.
 
 ## Usage

--- a/cmd/group/README.md
+++ b/cmd/group/README.md
@@ -9,7 +9,7 @@ the properties of the physical resource (Instance plugin) and semantics or natur
 
 ## Building
 
-When you do `make -k all` in the top level directory, the CLI binary will be built and can be
+When you do `make binaries` in the top level directory, the CLI binary will be built and can be
 found as `./infrakit/cli` from the project's top level directory.
 
 ## Usage

--- a/example/flavor/vanilla/README.md
+++ b/example/flavor/vanilla/README.md
@@ -110,7 +110,7 @@ Or with assigned ID's:
 
 ## Building
 
-When you do `make -k all` in the top level directory, the CLI binary will be built and can be
+When you do `make binaries` in the top level directory, the CLI binary will be built and can be
 found as `./infrakit/cli` from the project's top level directory.
 
 ## Usage

--- a/example/flavor/zookeeper/README.md
+++ b/example/flavor/zookeeper/README.md
@@ -5,7 +5,7 @@ This is a plugin for handling Zookeeper ensemble.
 
 ## Building
 
-When you do `make -k all` in the top level directory, the CLI binary will be built and can be
+When you do `make binaries` in the top level directory, the CLI binary will be built and can be
 found as `./infrakit/cli` from the project's top level directory.
 
 ## Usage

--- a/example/instance/file/README.md
+++ b/example/instance/file/README.md
@@ -6,7 +6,7 @@ to disk as `provision`.  It is useful for testing and debugging.
 
 ## Building
 
-When you do `make -k all` in the top level directory, the CLI binary will be built and can be
+When you do `make binaries` in the top level directory, the CLI binary will be built and can be
 found as `./infrakit/cli` from the project's top level directory.
 
 ## Usage

--- a/example/instance/terraform/README.md
+++ b/example/instance/terraform/README.md
@@ -106,7 +106,7 @@ and update its state.
  
 ## Building
 
-When you do `make -k all` in the top level directory, the CLI binary will be built and can be
+When you do `make binaries` in the top level directory, the CLI binary will be built and can be
 found as `./infrakit/cli` from the project's top level directory.
 
 ## Usage


### PR DESCRIPTION
This also makes 2 changes to docs:
- remove the `-k` option to make, as i think we should generally fail-fast on binary builds
- use the `binaries` target to allow users to avoid running tests