### PR TITLE
Use build/ for binaries rather than infrakit/

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,7 +7,7 @@
 coverage.txt
 
 # Build binaries
-infrakit/*
+build/
 
 # Vendored sources.  These are synced during the build by govendor.
 vendor/*/

--- a/Makefile
+++ b/Makefile
@@ -50,13 +50,13 @@ build: vendor-sync
 
 clean:
 	@echo "+ $@"
-	-mkdir -p ./infrakit
-	-rm -rf ./infrakit/*
+	rm -rf build
+	mkdir -p build
 
 binaries: clean build
 	@echo "+ $@"
 	@for bin in $(BINARIES); do \
-	  go build -o ./infrakit/$$( echo $${bin} | awk -F '/' '{print $$NF}') \
+	  go build -o build/$$( echo $${bin} | awk -F '/' '{print $$NF}') \
 		 -ldflags "-X main.Version=$(VERSION) -X main.Revision=$(REVISION)" $${bin} || exit 1; \
 	done
 

--- a/Makefile
+++ b/Makefile
@@ -23,7 +23,6 @@ AUTHORS: .mailmap .git/HEAD
 # Package list
 PKGS_AND_MOCKS := $(shell go list ./... | grep -v /vendor)
 PKGS := $(shell echo $(PKGS_AND_MOCKS) | tr ' ' '\n' | grep -v /mock$)
-BINARIES := $(shell go list ./cmd/... ./example/... | grep -v /vendor)
 
 vet:
 	@echo "+ $@"
@@ -53,13 +52,24 @@ clean:
 	rm -rf build
 	mkdir -p build
 
-binaries: clean build
-	@echo "+ $@"
-	@for bin in $(BINARIES); do \
-	  go build -o build/$$( echo $${bin} | awk -F '/' '{print $$NF}') \
-		 -ldflags "-X main.Version=$(VERSION) -X main.Revision=$(REVISION)" $${bin} || exit 1; \
-	done
+define build_binary
+	go build -o build/$(1) -ldflags "-X main.Version=$(VERSION) -X main.Revision=$(REVISION)" $(2)
+endef
 
+binaries: clean
+	@echo "+ $@"
+ifneq (,$(findstring .m,$(VERSION)))
+	@echo "\nWARNING - repository contains uncommitted changes, tagging binaries as dirty\n"
+endif
+
+	$(call build_binary,infrakit,github.com/docker/infrakit/cmd/cli)
+	$(call build_binary,infrakit-group-default,github.com/docker/infrakit/cmd/group)
+	$(call build_binary,infrakit-flavor-swarm,github.com/docker/infrakit/example/flavor/swarm)
+	$(call build_binary,infrakit-flavor-vanilla,github.com/docker/infrakit/example/flavor/vanilla)
+	$(call build_binary,infrakit-flavor-zookeeper,github.com/docker/infrakit/example/flavor/zookeeper)
+	$(call build_binary,infrakit-instance-file,github.com/docker/infrakit/example/instance/file)
+	$(call build_binary,infrakit-instance-terraform,github.com/docker/infrakit/example/instance/terraform)
+	$(call build_binary,infrakit-instance-vagrant,github.com/docker/infrakit/example/instance/vagrant)
 
 install: vendor-sync
 	@echo "+ $@"

--- a/README.md
+++ b/README.md
@@ -150,17 +150,16 @@ $ make ci
 ```shell
 $ make binaries
 ```
-This will create a directory, `infrakit` in the project directory.  The executables can be found here.
-Currently, several binaries are available. More detailed documentations can be found here
-
-  + [`infrakit/cli`](./cmd/cli/README.md), the command line interface
-  + [`infrakit/group`](./cmd/group/README.md), the default [group plugin](./spi/group)
-  + [`infrakit/file`](./example/instance/file), an instance plugin using files
-  + [`infrakit/terraform`](./example/instance/terraform), an instance plugin integrating [Terraform](https://www.terraform.io)
-  + [`infrakit/vagrant`](./example/instance/vagrant), an instance plugin using vagrant
-  + [`infrakit/vanilla`](./example/flavor/vanilla), a flavor plugin for plain vanilla set up with user data and labels
-  + [`infrakit/zookeeper`](./example/flavor/zookeeper), a flavor plugin for zookeeper ensemble members
-  + [`infrakit/swarm`](./example/flavor/swarm), a flavor plugin for Docker Swarm managers and workers.
+Executables will be placed in the `build` directory.
+Currently, several binaries are available:
+  + [`build/cli`](./cmd/cli/README.md), the command line interface
+  + [`build/group`](./cmd/group/README.md), the default [group plugin](./spi/group)
+  + [`build/file`](./example/instance/file), an instance plugin using files
+  + [`build/terraform`](./example/instance/terraform), an instance plugin integrating [Terraform](https://www.terraform.io)
+  + [`build/vagrant`](./example/instance/vagrant), an instance plugin using vagrant
+  + [`build/vanilla`](./example/flavor/vanilla), a flavor plugin for plain vanilla set up with user data and labels
+  + [`build/zookeeper`](./example/flavor/zookeeper), a flavor plugin for zookeeper ensemble members
+  + [`build/swarm`](./example/flavor/swarm), a flavor plugin for Docker Swarm managers and workers.
 
 
 ## Examples
@@ -291,7 +290,7 @@ _file_ instance plugins running but with different names and configurations (for
 what they _provision_ or the content they write to disk).  For example:
 
 ```
-$ infrakit/file --listen=unix:///run/infrakit/plugins/another-file.sock --dir=./test
+$ build/file --listen=unix:///run/infrakit/plugins/another-file.sock --dir=./test
 INFO[0000] Starting plugin
 INFO[0000] Listening on: unix:///run/infrakit/plugins/another-file.sock
 INFO[0000] listener protocol= unix addr= /run/infrakit/plugins/another-file.sock err= <nil>
@@ -300,7 +299,7 @@ INFO[0000] listener protocol= unix addr= /run/infrakit/plugins/another-file.sock
 List the plugins using the CLI subcommand `plugin`:
 
 ```shell
-$ infrakit/cli plugin ls
+$ build/cli plugin ls
 Plugins:
 NAME                    LISTEN
 instance-file           unix:///run/infrakit/plugins/instance-file.sock
@@ -310,7 +309,7 @@ another-file            unix:///run/infrakit/plugins/another-file.sock
 For each binary, you can find out more about it by using the `version` verb in the command line. For example:
 
 ```shell
-$ infrakit/group version
+$ build/group version
 {
     "name": "GroupPlugin",
     "revision": "75d7f4dbc17dbc48aadb9a4abfd87d57fbd7e1f8",

--- a/README.md
+++ b/README.md
@@ -150,16 +150,16 @@ $ make ci
 ```shell
 $ make binaries
 ```
-Executables will be placed in the `build` directory.
+Executables will be placed in the `./build` directory.
 Currently, several binaries are available:
-  + [`build/cli`](./cmd/cli/README.md), the command line interface
-  + [`build/group`](./cmd/group/README.md), the default [group plugin](./spi/group)
-  + [`build/file`](./example/instance/file), an instance plugin using files
-  + [`build/terraform`](./example/instance/terraform), an instance plugin integrating [Terraform](https://www.terraform.io)
-  + [`build/vagrant`](./example/instance/vagrant), an instance plugin using vagrant
-  + [`build/vanilla`](./example/flavor/vanilla), a flavor plugin for plain vanilla set up with user data and labels
-  + [`build/zookeeper`](./example/flavor/zookeeper), a flavor plugin for zookeeper ensemble members
-  + [`build/swarm`](./example/flavor/swarm), a flavor plugin for Docker Swarm managers and workers.
+  + [`build/infrakit`](./cmd/cli/README.md), the command line interface
+  + [`build/infrakit-group-default`](./cmd/group/README.md), the default [Group plugin](./spi/group)
+  + [`build/infrakit-instance-file`](./example/instance/file), an Instance plugin using dummy files to represent instances
+  + [`build/infrakit-instance-terraform`](./example/instance/terraform), an Instance plugin integrating [Terraform](https://www.terraform.io)
+  + [`build/infrakit-instance-vagrant`](./example/instance/vagrant), an Instance plugin using [Vagrant](https://www.vagrantup.com/)
+  + [`build/infrakit-flavor-vanilla`](./example/flavor/vanilla), a Flavor plugin for plain vanilla set up with user data and labels
+  + [`build/infrakit-flavor-zookeeper`](./example/flavor/zookeeper), a Flavor plugin for [Apache ZooKeeper](https://zookeeper.apache.org/) ensemble members
+  + [`build/infrakit-flavor-swarm`](./example/flavor/swarm), a Flavor plugin for Docker in [Swarm mode](https://docs.docker.com/engine/swarm/).
 
 
 ## Examples
@@ -290,26 +290,18 @@ _file_ instance plugins running but with different names and configurations (for
 what they _provision_ or the content they write to disk).  For example:
 
 ```
-$ build/file --listen=unix:///run/infrakit/plugins/another-file.sock --dir=./test
+$ build/infrakit-instance-file --listen=unix:///run/infrakit/plugins/another-file.sock --dir=./test
 INFO[0000] Starting plugin
 INFO[0000] Listening on: unix:///run/infrakit/plugins/another-file.sock
 INFO[0000] listener protocol= unix addr= /run/infrakit/plugins/another-file.sock err= <nil>
 ```
 
-List the plugins using the CLI subcommand `plugin`:
-
-```shell
-$ build/cli plugin ls
-Plugins:
-NAME                    LISTEN
-instance-file           unix:///run/infrakit/plugins/instance-file.sock
-another-file            unix:///run/infrakit/plugins/another-file.sock
-```
+You can use the CLI to see which plugins are [discoverable](cmd/cli/README.md#list-plugins).
 
 For each binary, you can find out more about it by using the `version` verb in the command line. For example:
 
 ```shell
-$ build/group version
+$ build/infrakit-group-default version
 {
     "name": "GroupPlugin",
     "revision": "75d7f4dbc17dbc48aadb9a4abfd87d57fbd7e1f8",

--- a/cmd/cli/README.md
+++ b/cmd/cli/README.md
@@ -9,17 +9,16 @@ exposed as verbs and configuration JSON can be read from local file or standard 
 
 ## Building
 
-When you do `make binaries` in the top level directory, the CLI binary will be built and can be
-found as `./build/cli` from the project's top level directory.
+Begin by building plugin [binaries](../../README.md#binaries).
 
 ## Usage
 
 ```
-$ build/cli -h
+$ build/infrakit -h
 infrakit cli
 
 Usage:
-  build/cli [command]
+  build/infrakit [command]
 
 Available Commands:
   flavor      Access flavor plugin
@@ -32,7 +31,7 @@ Flags:
       --dir string   Dir path for plugin discovery (default "/run/infrakit/plugins")
       --log int      Logging level. 0 is least verbose. Max is 5 (default 4)
 
-Use "build/cli [command] --help" for more information about a command.
+Use "build/infrakit [command] --help" for more information about a command.
 ```
 
 ### Default Directory for Plugin Discovery
@@ -48,7 +47,7 @@ chmod 777 /run/infrakit/plugins
 ### List Plugins
 
 ```
-$ build/cli plugin ls
+$ build/infrakit plugin ls
 Plugins:
 NAME                	LISTEN
 flavor-swarm        	unix:///run/infrakit/plugins/flavor-swarm.sock
@@ -70,11 +69,11 @@ You can access the following plugins and their methods via command line:
 ### Working with Instance Plugin
 
 ```
-$ build/cli instance -h
+$ build/infrakit instance -h
 Access instance plugin
 
 Usage:
-  build/cli instance [command]
+  build/infrakit instance [command]
 
 Available Commands:
   describe    describe the instances
@@ -89,7 +88,7 @@ Global Flags:
       --dir string   Dir path for plugin discovery (default "/run/infrakit/plugins")
       --log int      Logging level. 0 is least verbose. Max is 5 (default 4)
 
-Use "build/cli instance [command] --help" for more information about a command.
+Use "build/infrakit instance [command] --help" for more information about a command.
 ```
 
 For example, using the plugin `instance-file` as an example:
@@ -97,7 +96,7 @@ For example, using the plugin `instance-file` as an example:
 `describe` calls the `DescribeInstances` endpoint of the plugin:
 
 ```
-$ build/cli instance --name instance-file describe
+$ build/infrakit instance --name instance-file describe
 ID                            	LOGICAL                       	TAGS
 instance-1474850397           	  -                           	group=test,instanceType=small
 instance-1474850412           	  -                           	group=test2,instanceType=small
@@ -107,7 +106,7 @@ instance-1474851747           	logic2                        	instanceType=small
 Validate - send the config JSON via stdin:
 
 ```
-$ build/cli instance --name instance-file validate << EOF
+$ build/infrakit instance --name instance-file validate << EOF
 > {
 >     "Properties" : {
 >         "version" : "v0.0.1",
@@ -143,7 +142,7 @@ validate:ok
 Provision - send via stdin:
 
 ```
-$ build/cli instance --name instance-file provision << EOF
+$ build/infrakit instance --name instance-file provision << EOF
 > {
 >     "Properties" : {
 >         "version" : "v0.0.1",
@@ -179,7 +178,7 @@ instance-1474873473
 List instances
 
 ```
-$ build/cli instance --name instance-file describe
+$ build/infrakit instance --name instance-file describe
 ID                            	LOGICAL                       	TAGS
 instance-1474850397           	  -                           	group=test,instanceType=small
 instance-1474850412           	  -                           	group=test2,instanceType=small
@@ -189,18 +188,18 @@ instance-1474873473           	logic2                        	group=test2,instan
 Destroy
 
 ```
-$ build/cli instance --name instance-file destroy instance-1474873473
+$ build/infrakit instance --name instance-file destroy instance-1474873473
 destroyed instance-1474873473
 ```
 
 ### Working with Group Plugin
 
 ```
-$ build/cli group -h
+$ build/infrakit group -h
 Access group plugin
 
 Usage:
-  build/cli group [command]
+  build/infrakit group [command]
 
 Available Commands:
   describe    describe update (describe - or describe filename)
@@ -218,17 +217,17 @@ Global Flags:
       --dir string   Dir path for plugin discovery (default "/run/infrakit/plugins")
       --log int      Logging level. 0 is least verbose. Max is 5 (default 4)
 
-Use "build/cli group [command] --help" for more information about a command.
+Use "build/infrakit group [command] --help" for more information about a command.
 ```
 
 ### Working with Flavor Plugin
 
 ```
-$ build/cli flavor -h
+$ build/infrakit flavor -h
 Access flavor plugin
 
 Usage:
-  build/cli flavor [command]
+  build/infrakit flavor [command]
 
 Available Commands:
   healthy     checks for health
@@ -242,5 +241,5 @@ Global Flags:
       --dir string   Dir path for plugin discovery (default "/run/infrakit/plugins")
       --log int      Logging level. 0 is least verbose. Max is 5 (default 4)
 
-Use "build/cli flavor [command] --help" for more information about a command.
+Use "build/infrakit flavor [command] --help" for more information about a command.
 ```

--- a/cmd/cli/README.md
+++ b/cmd/cli/README.md
@@ -10,16 +10,16 @@ exposed as verbs and configuration JSON can be read from local file or standard 
 ## Building
 
 When you do `make binaries` in the top level directory, the CLI binary will be built and can be
-found as `./infrakit/cli` from the project's top level directory.
+found as `./build/cli` from the project's top level directory.
 
 ## Usage
 
 ```
-$ ./infrakit/cli -h
+$ build/cli -h
 infrakit cli
 
 Usage:
-  ./infrakit/cli [command]
+  build/cli [command]
 
 Available Commands:
   flavor      Access flavor plugin
@@ -32,7 +32,7 @@ Flags:
       --dir string   Dir path for plugin discovery (default "/run/infrakit/plugins")
       --log int      Logging level. 0 is least verbose. Max is 5 (default 4)
 
-Use "./infrakit/cli [command] --help" for more information about a command.
+Use "build/cli [command] --help" for more information about a command.
 ```
 
 ### Default Directory for Plugin Discovery
@@ -48,7 +48,7 @@ chmod 777 /run/infrakit/plugins
 ### List Plugins
 
 ```
-$ ./infrakit/cli plugin ls
+$ build/cli plugin ls
 Plugins:
 NAME                	LISTEN
 flavor-swarm        	unix:///run/infrakit/plugins/flavor-swarm.sock
@@ -70,11 +70,11 @@ You can access the following plugins and their methods via command line:
 ### Working with Instance Plugin
 
 ```
-$ ./infrakit/cli instance -h
+$ build/cli instance -h
 Access instance plugin
 
 Usage:
-  ./infrakit/cli instance [command]
+  build/cli instance [command]
 
 Available Commands:
   describe    describe the instances
@@ -89,7 +89,7 @@ Global Flags:
       --dir string   Dir path for plugin discovery (default "/run/infrakit/plugins")
       --log int      Logging level. 0 is least verbose. Max is 5 (default 4)
 
-Use "./infrakit/cli instance [command] --help" for more information about a command.
+Use "build/cli instance [command] --help" for more information about a command.
 ```
 
 For example, using the plugin `instance-file` as an example:
@@ -97,7 +97,7 @@ For example, using the plugin `instance-file` as an example:
 `describe` calls the `DescribeInstances` endpoint of the plugin:
 
 ```
-./infrakit/cli instance --name instance-file describe
+$ build/cli instance --name instance-file describe
 ID                            	LOGICAL                       	TAGS
 instance-1474850397           	  -                           	group=test,instanceType=small
 instance-1474850412           	  -                           	group=test2,instanceType=small
@@ -107,7 +107,7 @@ instance-1474851747           	logic2                        	instanceType=small
 Validate - send the config JSON via stdin:
 
 ```
-$ ./infrakit/cli instance --name instance-file validate << EOF
+$ build/cli instance --name instance-file validate << EOF
 > {
 >     "Properties" : {
 >         "version" : "v0.0.1",
@@ -143,7 +143,7 @@ validate:ok
 Provision - send via stdin:
 
 ```
-$ ./infrakit/cli instance --name instance-file provision << EOF
+$ build/cli instance --name instance-file provision << EOF
 > {
 >     "Properties" : {
 >         "version" : "v0.0.1",
@@ -179,7 +179,7 @@ instance-1474873473
 List instances
 
 ```
-$ ./infrakit/cli instance --name instance-file describe
+$ build/cli instance --name instance-file describe
 ID                            	LOGICAL                       	TAGS
 instance-1474850397           	  -                           	group=test,instanceType=small
 instance-1474850412           	  -                           	group=test2,instanceType=small
@@ -189,18 +189,18 @@ instance-1474873473           	logic2                        	group=test2,instan
 Destroy
 
 ```
-$ ./infrakit/cli instance --name instance-file destroy instance-1474873473
+$ build/cli instance --name instance-file destroy instance-1474873473
 destroyed instance-1474873473
 ```
 
 ### Working with Group Plugin
 
 ```
-$ ./infrakit/cli group -h
+$ build/cli group -h
 Access group plugin
 
 Usage:
-  ./infrakit/cli group [command]
+  build/cli group [command]
 
 Available Commands:
   describe    describe update (describe - or describe filename)
@@ -218,17 +218,17 @@ Global Flags:
       --dir string   Dir path for plugin discovery (default "/run/infrakit/plugins")
       --log int      Logging level. 0 is least verbose. Max is 5 (default 4)
 
-Use "./infrakit/cli group [command] --help" for more information about a command.
+Use "build/cli group [command] --help" for more information about a command.
 ```
 
 ### Working with Flavor Plugin
 
 ```
-./infrakit/cli flavor -h
+$ build/cli flavor -h
 Access flavor plugin
 
 Usage:
-  ./infrakit/cli flavor [command]
+  build/cli flavor [command]
 
 Available Commands:
   healthy     checks for health
@@ -242,5 +242,5 @@ Global Flags:
       --dir string   Dir path for plugin discovery (default "/run/infrakit/plugins")
       --log int      Logging level. 0 is least verbose. Max is 5 (default 4)
 
-Use "./infrakit/cli flavor [command] --help" for more information about a command.
+Use "build/cli flavor [command] --help" for more information about a command.
 ```

--- a/cmd/group/README.md
+++ b/cmd/group/README.md
@@ -9,18 +9,17 @@ the properties of the physical resource (Instance plugin) and semantics or natur
 
 ## Building
 
-When you do `make binaries` in the top level directory, the CLI binary will be built and can be
-found as `./build/cli` from the project's top level directory.
+Begin by building plugin [binaries](../../README.md#binaries).
 
 ## Usage
 
 ```
-$ build/group -h
+$ build/infrakit-group-default -h
 Group server
 
 Usage:
-  build/group [flags]
-  build/group [command]
+  build/infrakit-group-default [flags]
+  build/infrakit-group-default [command]
 
 Available Commands:
   version     print build version information
@@ -30,14 +29,14 @@ Flags:
       --log int                  Logging level. 0 is least verbose. Max is 5 (default 4)
       --poll-interval duration   Group polling interval (default 10s)
 
-Use "build/group [command] --help" for more information about a command.
+Use "build/infrakit-group-default [command] --help" for more information about a command.
 ```
 
 The plugin can be started without any arguments and will default to using unix socket in
 `/run/infrakit/plugins` for communications with the CLI and other plugins:
 
 ```
-$ build/group --log=5
+$ build/infrakit-group-default --log=5
 INFO[0000] Starting discovery
 DEBU[0000] Opening: /run/infrakit/plugins
 DEBU[0000] Discovered plugin at unix:///run/infrakit/plugins/flavor-swarm.sock

--- a/cmd/group/README.md
+++ b/cmd/group/README.md
@@ -10,17 +10,17 @@ the properties of the physical resource (Instance plugin) and semantics or natur
 ## Building
 
 When you do `make binaries` in the top level directory, the CLI binary will be built and can be
-found as `./infrakit/cli` from the project's top level directory.
+found as `./build/cli` from the project's top level directory.
 
 ## Usage
 
 ```
-$ ./infrakit/group -h
+$ build/group -h
 Group server
 
 Usage:
-  ./infrakit/group [flags]
-  ./infrakit/group [command]
+  build/group [flags]
+  build/group [command]
 
 Available Commands:
   version     print build version information
@@ -30,14 +30,14 @@ Flags:
       --log int                  Logging level. 0 is least verbose. Max is 5 (default 4)
       --poll-interval duration   Group polling interval (default 10s)
 
-Use "./infrakit/group [command] --help" for more information about a command.
+Use "build/group [command] --help" for more information about a command.
 ```
 
 The plugin can be started without any arguments and will default to using unix socket in
 `/run/infrakit/plugins` for communications with the CLI and other plugins:
 
 ```
-$ ./infrakit/group --log=5
+$ build/group --log=5
 INFO[0000] Starting discovery
 DEBU[0000] Opening: /run/infrakit/plugins
 DEBU[0000] Discovered plugin at unix:///run/infrakit/plugins/flavor-swarm.sock

--- a/docs/tutorial.md
+++ b/docs/tutorial.md
@@ -15,7 +15,7 @@ $ chmod 777 /run/infrakit/plugins
 Start the group plugin
 
 ```shell
-$ infrakit/group --log 5
+$ build/group --log 5
 INFO[0000] Starting discovery
 DEBU[0000] Opening: /run/infrakit/plugins
 INFO[0000] Starting plugin
@@ -28,7 +28,7 @@ Start the file instance plugin
 
 ```shell
 $ mkdir -p tutorial
-$ infrakit/file --log 5 --dir ./tutorial/
+$ build/file --log 5 --dir ./tutorial/
 INFO[0000] Starting plugin
 INFO[0000] Listening on: unix:///run/infrakit/plugins/instance-file.sock
 DEBU[0000] file instance plugin. dir= ./tutorial/
@@ -40,7 +40,7 @@ We can look at the files here to see what's being created and how they are confi
 Start the vanilla flavor plugin
 
 ```shell
-$ infrakit/vanilla --log 5
+$ build/vanilla --log 5
 INFO[0000] Starting plugin
 INFO[0000] Listening on: unix:///run/infrakit/plugins/flavor-vanilla.sock
 INFO[0000] listener protocol= unix addr= /run/infrakit/plugins/flavor-vanilla.sock err= <nil>
@@ -49,7 +49,7 @@ INFO[0000] listener protocol= unix addr= /run/infrakit/plugins/flavor-vanilla.so
 Show the plugins:
 
 ```shell
-$ infrakit/cli plugin ls
+$ build/cli plugin ls
 Plugins:
 NAME                    LISTEN
 flavor-vanilla          unix:///run/infrakit/plugins/flavor-vanilla.sock
@@ -164,7 +164,7 @@ some criteria.
 Checking for the instances via the CLI:
 
 ```shell
-$ infrakit/cli instance --name instance-file describe
+$ build/cli instance --name instance-file describe
 ID                              LOGICAL                         TAGS
 
 ```
@@ -172,7 +172,7 @@ ID                              LOGICAL                         TAGS
 Let's tell the group plugin to `watch` our group by providing the group plugin with the configuration:
 
 ```shell
-$ infrakit/cli group --name group watch <<EOF
+$ build/cli group --name group watch <<EOF
 {
     "ID": "cattle",
     "Properties": {
@@ -206,7 +206,7 @@ watching cattle
 **_NOTE:_** You can also specify a file name to load from instead of using stdin, like this:
 
 ```
-$ infrakit/cli group --name group watch group.json
+$ build/cli group --name group watch group.json
 ```
 
 The group plugin is responsible for ensuring that the infrastructure state matches with your specifications.  Since we
@@ -214,7 +214,7 @@ started out with nothing, it will create 5 instances and maintain that state by 
 
 
 ```shell
-$ infrakit/cli group --name group inspect cattle
+$ build/cli group --name group inspect cattle
 ID                              LOGICAL         TAGS
 instance-1475104926           	  -             infrakit.config_sha=Y23cKqyRpkQ_M60vIq7CufFmQWk=,infrakit.group=cattle,project=infrakit,tier=web
 instance-1475104936           	  -             infrakit.config_sha=Y23cKqyRpkQ_M60vIq7CufFmQWk=,infrakit.group=cattle,project=infrakit,tier=web
@@ -226,7 +226,7 @@ instance-1475104966           	  -             infrakit.config_sha=Y23cKqyRpkQ_M
 The Instance Plugin can also report instances, it will report all instances across all groups (not just `cattle`).
 
 ```shell
-$ infrakit/cli instance --name instance-file describe
+$ build/cli instance --name instance-file describe
 ID                              LOGICAL         TAGS
 instance-1475104926           	  -             infrakit.config_sha=Y23cKqyRpkQ_M60vIq7CufFmQWk=,infrakit.group=cattle,project=infrakit,tier=web
 instance-1475104936           	  -             infrakit.config_sha=Y23cKqyRpkQ_M60vIq7CufFmQWk=,infrakit.group=cattle,project=infrakit,tier=web
@@ -282,7 +282,7 @@ $ diff group.json group2.json
 Before we do an update, we can see what the proposed changes are:
 
 ```
-$ infrakit/cli group --name group describe group2.json 
+$ build/cli group --name group describe group2.json 
 cattle : Performs a rolling update on 5 instances, then adds 5 instances to increase the group size to 10
 ```
 
@@ -292,7 +292,7 @@ be created.
 Let's apply the new config:
 
 ```shell
-$ infrakit/cli group --name group update group2.json 
+$ build/cli group --name group update group2.json 
 
 # ..... wait a bit...
 update cattle completed
@@ -300,7 +300,7 @@ update cattle completed
 Now we can check:
 
 ```shell
-$ infrakit/cli group --name group inspect cattle
+$ build/cli group --name group inspect cattle
 ID                              LOGICAL         TAGS
 instance-1475105646           	  -             infrakit.config_sha=BXedrwY0GdZlHhgHmPAzxTN4oHM=,infrakit.group=cattle,project=infrakit,tier=web
 instance-1475105656           	  -             infrakit.config_sha=BXedrwY0GdZlHhgHmPAzxTN4oHM=,infrakit.group=cattle,project=infrakit,tier=web
@@ -345,7 +345,7 @@ original specification of 10 instances.
 Finally, let's clean up:
 
 ```
-$ infrakit/cli group --name group destroy cattle
+$ build/cli group --name group destroy cattle
 ```
 
 This concludes our quick tutorial.  In this tutorial we have

--- a/docs/tutorial.md
+++ b/docs/tutorial.md
@@ -5,17 +5,18 @@ To illustrate the concept of working with Group, Flavor, and Instance plugins, w
   + The `file` instance plugin - to provision instances by writing files to disk
   + The `vanilla` flavor plugin - to provide context/ flavor to the configuration of the instances
 
-All InfraKit plugins will by default open the unix socket located at /run/infrakit/plugins. Make sure this directory exists on your host:
+All InfraKit plugins will by default open the unix socket located at /run/infrakit/plugins. Make sure this directory
+exists on your host:
 
 ```shell
 $ mkdir -p /run/infrakit/plugins/
 $ chmod 777 /run/infrakit/plugins
 ```
 
-Start the group plugin
+Start the default Group plugin
 
 ```shell
-$ build/group --log 5
+$ build/infrakit-group-default --log 5
 INFO[0000] Starting discovery
 DEBU[0000] Opening: /run/infrakit/plugins
 INFO[0000] Starting plugin
@@ -24,11 +25,11 @@ INFO[0000] Listening on: unix:///run/infrakit/plugins/group.sock
 INFO[0000] listener protocol= unix addr= /run/infrakit/plugins/group.sock err= <nil>
 ```
 
-Start the file instance plugin
+Start the file Instance plugin
 
 ```shell
 $ mkdir -p tutorial
-$ build/file --log 5 --dir ./tutorial/
+$ build/infrakit-instance-file --log 5 --dir ./tutorial/
 INFO[0000] Starting plugin
 INFO[0000] Listening on: unix:///run/infrakit/plugins/instance-file.sock
 DEBU[0000] file instance plugin. dir= ./tutorial/
@@ -37,10 +38,10 @@ INFO[0000] listener protocol= unix addr= /run/infrakit/plugins/instance-file.soc
 Note the directory `./tutorial` where the plugin will store the instances as they are provisioned.
 We can look at the files here to see what's being created and how they are configured.
 
-Start the vanilla flavor plugin
+Start the vanilla Flavor plugin
 
 ```shell
-$ build/vanilla --log 5
+$ build/infrakit-flavor-vanilla --log 5
 INFO[0000] Starting plugin
 INFO[0000] Listening on: unix:///run/infrakit/plugins/flavor-vanilla.sock
 INFO[0000] listener protocol= unix addr= /run/infrakit/plugins/flavor-vanilla.sock err= <nil>
@@ -49,7 +50,7 @@ INFO[0000] listener protocol= unix addr= /run/infrakit/plugins/flavor-vanilla.so
 Show the plugins:
 
 ```shell
-$ build/cli plugin ls
+$ build/infrakit plugin ls
 Plugins:
 NAME                    LISTEN
 flavor-vanilla          unix:///run/infrakit/plugins/flavor-vanilla.sock
@@ -164,7 +165,7 @@ some criteria.
 Checking for the instances via the CLI:
 
 ```shell
-$ build/cli instance --name instance-file describe
+$ build/infrakit instance --name instance-file describe
 ID                              LOGICAL                         TAGS
 
 ```
@@ -172,7 +173,7 @@ ID                              LOGICAL                         TAGS
 Let's tell the group plugin to `watch` our group by providing the group plugin with the configuration:
 
 ```shell
-$ build/cli group --name group watch <<EOF
+$ build/infrakit group --name group watch <<EOF
 {
     "ID": "cattle",
     "Properties": {
@@ -206,7 +207,7 @@ watching cattle
 **_NOTE:_** You can also specify a file name to load from instead of using stdin, like this:
 
 ```
-$ build/cli group --name group watch group.json
+$ build/infrakit group --name group watch group.json
 ```
 
 The group plugin is responsible for ensuring that the infrastructure state matches with your specifications.  Since we
@@ -214,7 +215,7 @@ started out with nothing, it will create 5 instances and maintain that state by 
 
 
 ```shell
-$ build/cli group --name group inspect cattle
+$ build/infrakit group --name group inspect cattle
 ID                              LOGICAL         TAGS
 instance-1475104926           	  -             infrakit.config_sha=Y23cKqyRpkQ_M60vIq7CufFmQWk=,infrakit.group=cattle,project=infrakit,tier=web
 instance-1475104936           	  -             infrakit.config_sha=Y23cKqyRpkQ_M60vIq7CufFmQWk=,infrakit.group=cattle,project=infrakit,tier=web
@@ -226,7 +227,7 @@ instance-1475104966           	  -             infrakit.config_sha=Y23cKqyRpkQ_M
 The Instance Plugin can also report instances, it will report all instances across all groups (not just `cattle`).
 
 ```shell
-$ build/cli instance --name instance-file describe
+$ build/infrakit instance --name instance-file describe
 ID                              LOGICAL         TAGS
 instance-1475104926           	  -             infrakit.config_sha=Y23cKqyRpkQ_M60vIq7CufFmQWk=,infrakit.group=cattle,project=infrakit,tier=web
 instance-1475104936           	  -             infrakit.config_sha=Y23cKqyRpkQ_M60vIq7CufFmQWk=,infrakit.group=cattle,project=infrakit,tier=web
@@ -282,7 +283,7 @@ $ diff group.json group2.json
 Before we do an update, we can see what the proposed changes are:
 
 ```
-$ build/cli group --name group describe group2.json 
+$ build/infrakit group --name group describe group2.json 
 cattle : Performs a rolling update on 5 instances, then adds 5 instances to increase the group size to 10
 ```
 
@@ -292,7 +293,7 @@ be created.
 Let's apply the new config:
 
 ```shell
-$ build/cli group --name group update group2.json 
+$ build/infrakit group --name group update group2.json 
 
 # ..... wait a bit...
 update cattle completed
@@ -300,7 +301,7 @@ update cattle completed
 Now we can check:
 
 ```shell
-$ build/cli group --name group inspect cattle
+$ build/infrakit group --name group inspect cattle
 ID                              LOGICAL         TAGS
 instance-1475105646           	  -             infrakit.config_sha=BXedrwY0GdZlHhgHmPAzxTN4oHM=,infrakit.group=cattle,project=infrakit,tier=web
 instance-1475105656           	  -             infrakit.config_sha=BXedrwY0GdZlHhgHmPAzxTN4oHM=,infrakit.group=cattle,project=infrakit,tier=web
@@ -345,7 +346,7 @@ original specification of 10 instances.
 Finally, let's clean up:
 
 ```
-$ build/cli group --name group destroy cattle
+$ build/infrakit group --name group destroy cattle
 ```
 
 This concludes our quick tutorial.  In this tutorial we have

--- a/example/flavor/vanilla/README.md
+++ b/example/flavor/vanilla/README.md
@@ -111,17 +111,17 @@ Or with assigned ID's:
 ## Building
 
 When you do `make binaries` in the top level directory, the CLI binary will be built and can be
-found as `./infrakit/cli` from the project's top level directory.
+found as `./build/cli` from the project's top level directory.
 
 ## Usage
 
 ```
-$ infrakit/vanilla -h
+$ build/vanilla -h
 Vanilla flavor plugin
 
 Usage:
-  infrakit/vanilla [flags]
-  infrakit/vanilla [command]
+  build/vanilla [flags]
+  build/vanilla [command]
 
 Available Commands:
   version     print build version information
@@ -130,7 +130,7 @@ Flags:
       --listen string   listen address (unix or tcp) for the control endpoint (default "unix:///run/infrakit/plugins/flavor-vanilla.sock")
       --log int         Logging level. 0 is least verbose. Max is 5 (default 4)
 
-Use "infrakit/vanilla [command] --help" for more information about a command.
+Use "build/vanilla [command] --help" for more information about a command.
 ```
 
 ## Example
@@ -139,7 +139,7 @@ This plugin will be called whenever you use a Flavor plugin and reference the pl
 in your config JSON.  For instance, you may start up this plugin as `french-vanilla`:
 
 ```shell
-$ infrakit/vanilla --listen=unix:///run/infrakit/plugins/french-vanilla.sock
+$ build/vanilla --listen=unix:///run/infrakit/plugins/french-vanilla.sock
 INFO[0000] Starting plugin                              
 INFO[0000] Listening on: unix:///run/infrakit/plugins/french-vanilla.sock 
 INFO[0000] listener protocol= unix addr= /run/infrakit/plugins/french-vanilla.sock err= <nil> 
@@ -182,7 +182,7 @@ Then when you watch a group with the config above (`cattle`), the cattle will be
 Watch this group....
 
 ```
-$ infrakit/cli group --name group watch << EOF
+$ build/cli group --name group watch << EOF
 > {
 >     "ID": "cattle",
 >     "Properties": {

--- a/example/flavor/vanilla/README.md
+++ b/example/flavor/vanilla/README.md
@@ -110,18 +110,17 @@ Or with assigned ID's:
 
 ## Building
 
-When you do `make binaries` in the top level directory, the CLI binary will be built and can be
-found as `./build/cli` from the project's top level directory.
+Begin by building plugin [binaries](../../../README.md#binaries).
 
 ## Usage
 
 ```
-$ build/vanilla -h
+$ build/infrakit-flavor-vanilla -h
 Vanilla flavor plugin
 
 Usage:
-  build/vanilla [flags]
-  build/vanilla [command]
+  build/infrakit-flavor-vanilla [flags]
+  build/infrakit-flavor-vanilla [command]
 
 Available Commands:
   version     print build version information
@@ -130,7 +129,7 @@ Flags:
       --listen string   listen address (unix or tcp) for the control endpoint (default "unix:///run/infrakit/plugins/flavor-vanilla.sock")
       --log int         Logging level. 0 is least verbose. Max is 5 (default 4)
 
-Use "build/vanilla [command] --help" for more information about a command.
+Use "build/infrakit-flavor-vanilla [command] --help" for more information about a command.
 ```
 
 ## Example
@@ -139,7 +138,7 @@ This plugin will be called whenever you use a Flavor plugin and reference the pl
 in your config JSON.  For instance, you may start up this plugin as `french-vanilla`:
 
 ```shell
-$ build/vanilla --listen=unix:///run/infrakit/plugins/french-vanilla.sock
+$ build/infrakit-flavor-vanilla --listen=unix:///run/infrakit/plugins/french-vanilla.sock
 INFO[0000] Starting plugin                              
 INFO[0000] Listening on: unix:///run/infrakit/plugins/french-vanilla.sock 
 INFO[0000] listener protocol= unix addr= /run/infrakit/plugins/french-vanilla.sock err= <nil> 
@@ -182,7 +181,7 @@ Then when you watch a group with the config above (`cattle`), the cattle will be
 Watch this group....
 
 ```
-$ build/cli group --name group watch << EOF
+$ build/infrakit group --name group watch << EOF
 > {
 >     "ID": "cattle",
 >     "Properties": {

--- a/example/flavor/zookeeper/README.md
+++ b/example/flavor/zookeeper/README.md
@@ -6,17 +6,17 @@ This is a plugin for handling Zookeeper ensemble.
 ## Building
 
 When you do `make binaries` in the top level directory, the CLI binary will be built and can be
-found as `./infrakit/cli` from the project's top level directory.
+found as `./build/cli` from the project's top level directory.
 
 ## Usage
 
 ```
-$ ./infrakit/zookeeper -h
+$ build/zookeeper -h
 Zookeeper flavor plugin
 
 Usage:
-  ./infrakit/zookeeper [flags]
-  ./infrakit/zookeeper [command]
+  build/zookeeper [flags]
+  build/zookeeper [command]
 
 Available Commands:
   version     print build version information
@@ -25,7 +25,7 @@ Flags:
       --listen string   listen address (unix or tcp) for the control endpoint (default "unix:///run/infrakit/plugins/flavor-zookeeper.sock")
       --log int         Logging level. 0 is least verbose. Max is 5 (default 4)
 
-Use "./infrakit/zookeeper [command] --help" for more information about a command.
+Use "build/zookeeper [command] --help" for more information about a command.
 ```
 
 ## Test
@@ -33,7 +33,7 @@ Use "./infrakit/zookeeper [command] --help" for more information about a command
 Start the [vagrant instance plugin](/example/instance/vagrant):
 
 ```
-$ infrakit/vagrant
+$ build/vagrant
 INFO[0000] Starting plugin
 INFO[0000] Listening on: unix:///run/infrakit/plugins/instance-vagrant.sock
 INFO[0000] listener protocol= unix addr= /run/infrakit/plugins/instance-vagrant.sock err= <nil>
@@ -42,7 +42,7 @@ INFO[0000] listener protocol= unix addr= /run/infrakit/plugins/instance-vagrant.
 Start the [Group plugin](/cmd/group):
 
 ```
-$ ./infrakit/group --log=5
+$ build/group --log=5
 INFO[0000] Starting discovery
 DEBU[0000] Opening: /run/infrakit/plugins
 DEBU[0000] Discovered plugin at unix:///run/infrakit/plugins/flavor-swarm.sock
@@ -57,7 +57,7 @@ INFO[0000] listener protocol= unix addr= /run/infrakit/plugins/group.sock err= <
 Start Zookeeper flavor plugin:
 
 ```
-$ ./infrakit/zookeeper
+$ build/zookeeper
 INFO[0000] Starting plugin
 INFO[0000] Listening on: unix:///run/infrakit/plugins/flavor-zookeeper.sock
 INFO[0000] listener protocol= unix addr= /run/infrakit/plugins/flavor-zookeeper.sock err= <nil>
@@ -66,7 +66,7 @@ INFO[0000] listener protocol= unix addr= /run/infrakit/plugins/flavor-zookeeper.
 Check everything's running:
 
 ```
-$ ./infrakit/cli plugin ls
+$ build/cli plugin ls
 Plugins:
 NAME                	LISTEN
 flavor-zookeeper    	unix:///run/infrakit/plugins/flavor-zookeeper.sock
@@ -100,6 +100,6 @@ Here's a JSON for the group we'd like to see [vagrant-zk-example.json](./vagrant
 Now tell the group plugin to watch the zk group, create if necessary:
 
 ```
-infrakit/cli group --name group watch ./vagrant-zk-example.json
+$ build/cli group --name group watch ./vagrant-zk-example.json
 watching zk
 ```

--- a/example/flavor/zookeeper/README.md
+++ b/example/flavor/zookeeper/README.md
@@ -5,18 +5,17 @@ This is a plugin for handling Zookeeper ensemble.
 
 ## Building
 
-When you do `make binaries` in the top level directory, the CLI binary will be built and can be
-found as `./build/cli` from the project's top level directory.
+Begin by building plugin [binaries](../../README.md#binaries).
 
 ## Usage
 
 ```
-$ build/zookeeper -h
+$ build/infrakit-flavor-zookeeper -h
 Zookeeper flavor plugin
 
 Usage:
-  build/zookeeper [flags]
-  build/zookeeper [command]
+  build/infrakit-flavor-zookeeper [flags]
+  build/infrakit-flavor-zookeeper [command]
 
 Available Commands:
   version     print build version information
@@ -25,7 +24,7 @@ Flags:
       --listen string   listen address (unix or tcp) for the control endpoint (default "unix:///run/infrakit/plugins/flavor-zookeeper.sock")
       --log int         Logging level. 0 is least verbose. Max is 5 (default 4)
 
-Use "build/zookeeper [command] --help" for more information about a command.
+Use "build/infrakit-flavor-zookeeper [command] --help" for more information about a command.
 ```
 
 ## Test
@@ -33,7 +32,7 @@ Use "build/zookeeper [command] --help" for more information about a command.
 Start the [vagrant instance plugin](/example/instance/vagrant):
 
 ```
-$ build/vagrant
+$ build/infrakit-instance-vagrant
 INFO[0000] Starting plugin
 INFO[0000] Listening on: unix:///run/infrakit/plugins/instance-vagrant.sock
 INFO[0000] listener protocol= unix addr= /run/infrakit/plugins/instance-vagrant.sock err= <nil>
@@ -42,7 +41,7 @@ INFO[0000] listener protocol= unix addr= /run/infrakit/plugins/instance-vagrant.
 Start the [Group plugin](/cmd/group):
 
 ```
-$ build/group --log=5
+$ build/infrakit-group-default --log=5
 INFO[0000] Starting discovery
 DEBU[0000] Opening: /run/infrakit/plugins
 DEBU[0000] Discovered plugin at unix:///run/infrakit/plugins/flavor-swarm.sock
@@ -57,22 +56,13 @@ INFO[0000] listener protocol= unix addr= /run/infrakit/plugins/group.sock err= <
 Start Zookeeper flavor plugin:
 
 ```
-$ build/zookeeper
+$ build/infrakit-flavor-zookeeper
 INFO[0000] Starting plugin
 INFO[0000] Listening on: unix:///run/infrakit/plugins/flavor-zookeeper.sock
 INFO[0000] listener protocol= unix addr= /run/infrakit/plugins/flavor-zookeeper.sock err= <nil>
 ```
 
-Check everything's running:
-
-```
-$ build/cli plugin ls
-Plugins:
-NAME                	LISTEN
-flavor-zookeeper    	unix:///run/infrakit/plugins/flavor-zookeeper.sock
-group               	unix:///run/infrakit/plugins/group.sock
-instance-vagrant    	unix:///run/infrakit/plugins/instance-vagrant.sock
-```
+Be sure to verify that the plugin is [discoverable](../../../cmd/cli/README.md#list-plugins).
 
 Here's a JSON for the group we'd like to see [vagrant-zk-example.json](./vagrant-zk-example.json):
 
@@ -100,6 +90,6 @@ Here's a JSON for the group we'd like to see [vagrant-zk-example.json](./vagrant
 Now tell the group plugin to watch the zk group, create if necessary:
 
 ```
-$ build/cli group --name group watch ./vagrant-zk-example.json
+$ build/infrakit group --name group watch ./vagrant-zk-example.json
 watching zk
 ```

--- a/example/instance/file/README.md
+++ b/example/instance/file/README.md
@@ -6,18 +6,17 @@ to disk as `provision`.  It is useful for testing and debugging.
 
 ## Building
 
-When you do `make binaries` in the top level directory, the CLI binary will be built and can be
-found as `./build/cli` from the project's top level directory.
+Begin by building plugin [binaries](../../README.md#binaries).
 
 ## Usage
 
 ```
-$ build/file -h
+$ build/infrakit-instance-file -h
 File instance plugin
 
 Usage:
-  build/file [flags]
-  build/file [command]
+  build/infrakit-instance-file [flags]
+  build/infrakit-instance-file [command]
 
 Available Commands:
   version     print build version information
@@ -27,14 +26,14 @@ Flags:
       --listen string   listen address (unix or tcp) for the control endpoint (default "unix:///run/infrakit/plugins/instance-file.sock")
       --log int         Logging level. 0 is least verbose. Max is 5 (default 4)
 
-Use "build/file [command] --help" for more information about a command.
+Use "build/infrakit-instance-file [command] --help" for more information about a command.
 ```
 
 The plugin can be started without any arguments and will default to using unix socket in
 `/run/infrakit/plugins` for communications with the CLI and other plugins:
 
 ```
-$ build/file --dir=./test
+$ build/infrakit-instance-file --dir=./test
 INFO[0000] Starting plugin
 INFO[0000] Listening on: unix:///run/infrakit/plugins/instance-file.sock
 INFO[0000] listener protocol= unix addr= /run/infrakit/plugins/instance-file.sock err= <nil>
@@ -44,24 +43,16 @@ This starts the plugin using `./test` as directory and `instance-file` as name.
 
 You can give the another plugin instance a different name via the `listen` flag:
 ```
-$ build/file --listen=unix:///run/infrakit/plugins/another-file.sock --dir=./test
+$ build/infrakit-instance-file --listen=unix:///run/infrakit/plugins/another-file.sock --dir=./test
 INFO[0000] Starting plugin
 INFO[0000] Listening on: unix:///run/infrakit/plugins/another-file.sock
 INFO[0000] listener protocol= unix addr= /run/infrakit/plugins/another-file.sock err= <nil>
 ```
 
-Using the CLI, it you can see
+Be sure to verify that the plugin is [discoverable](../../../cmd/cli/README.md#list-plugins).
 
-```
-$ build/cli plugin ls
-Plugins:
-NAME                	LISTEN
-group               	unix:///run/infrakit/plugins/group.sock
-instance-file       	unix:///run/infrakit/plugins/instance-file.sock
-another-file        	unix:///run/infrakit/plugins/another-file.sock
-flavor-zookeeper    	unix:///run/infrakit/plugins/flavor-zookeeper.sock
-```
-Note that there are two file instance plugins running now with different names.
+Note that there should be two file instance plugins running now with different names
+(`instance-file`, and `another-file`).
 
 
 ### Default Directory for Plugin Discovery

--- a/example/instance/file/README.md
+++ b/example/instance/file/README.md
@@ -7,17 +7,17 @@ to disk as `provision`.  It is useful for testing and debugging.
 ## Building
 
 When you do `make binaries` in the top level directory, the CLI binary will be built and can be
-found as `./infrakit/cli` from the project's top level directory.
+found as `./build/cli` from the project's top level directory.
 
 ## Usage
 
 ```
-$ ./infrakit/file -h
+$ build/file -h
 File instance plugin
 
 Usage:
-  ./infrakit/file [flags]
-  ./infrakit/file [command]
+  build/file [flags]
+  build/file [command]
 
 Available Commands:
   version     print build version information
@@ -27,14 +27,14 @@ Flags:
       --listen string   listen address (unix or tcp) for the control endpoint (default "unix:///run/infrakit/plugins/instance-file.sock")
       --log int         Logging level. 0 is least verbose. Max is 5 (default 4)
 
-Use "./infrakit/file [command] --help" for more information about a command.
+Use "build/file [command] --help" for more information about a command.
 ```
 
 The plugin can be started without any arguments and will default to using unix socket in
 `/run/infrakit/plugins` for communications with the CLI and other plugins:
 
 ```
-$ ./infrakit/file --dir=./test
+$ build/file --dir=./test
 INFO[0000] Starting plugin
 INFO[0000] Listening on: unix:///run/infrakit/plugins/instance-file.sock
 INFO[0000] listener protocol= unix addr= /run/infrakit/plugins/instance-file.sock err= <nil>
@@ -44,7 +44,7 @@ This starts the plugin using `./test` as directory and `instance-file` as name.
 
 You can give the another plugin instance a different name via the `listen` flag:
 ```
-$ ./infrakit/file --listen=unix:///run/infrakit/plugins/another-file.sock --dir=./test
+$ build/file --listen=unix:///run/infrakit/plugins/another-file.sock --dir=./test
 INFO[0000] Starting plugin
 INFO[0000] Listening on: unix:///run/infrakit/plugins/another-file.sock
 INFO[0000] listener protocol= unix addr= /run/infrakit/plugins/another-file.sock err= <nil>
@@ -53,7 +53,7 @@ INFO[0000] listener protocol= unix addr= /run/infrakit/plugins/another-file.sock
 Using the CLI, it you can see
 
 ```
-$ ./infrakit/cli plugin ls
+$ build/cli plugin ls
 Plugins:
 NAME                	LISTEN
 group               	unix:///run/infrakit/plugins/group.sock

--- a/example/instance/terraform/README.md
+++ b/example/instance/terraform/README.md
@@ -107,17 +107,17 @@ and update its state.
 ## Building
 
 When you do `make binaries` in the top level directory, the CLI binary will be built and can be
-found as `./infrakit/cli` from the project's top level directory.
+found as `./build/cli` from the project's top level directory.
 
 ## Usage
 
 ```
-$ infrakit/terraform -h
+$ build/terraform -h
 Terraform instance plugin
 
 Usage:
-  infrakit/terraform [flags]
-  infrakit/terraform [command]
+  build/terraform [flags]
+  build/terraform [command]
 
 Available Commands:
   version     print build version information
@@ -127,7 +127,7 @@ Flags:
       --listen string   listen address (unix or tcp) for the control endpoint (default "unix:///run/infrakit/plugins/instance-terraform.sock")
       --log int         Logging level. 0 is least verbose. Max is 5 (default 4)
 
-Use "infrakit/terraform [command] --help" for more information about a command.
+Use "build/terraform [command] --help" for more information about a command.
 ```
 
 The plugin requires a `dir` directory that will be used to contain the `tfstate` and `tf.json`
@@ -138,7 +138,7 @@ As usual, you can give this plugin a different name by the URL (`unix:///plugins
 when starting the plugin.  However you name it, it is still an InstancePlugin:
 
 ```
-$ infrakit/terraform version
+$ build/terraform version
 {
     "name": "TerraformInstance",
     "revision": "5999abffa5c10d4c9b9953459829dadea93d7ba4",
@@ -164,7 +164,7 @@ See the [CLI Doc](/cmd/cli/README.md) for details on accessing the instance plug
 Start the plugin:
 
 ```
-$ infrakit/terraform --log 5 --dir=./example/instance/terraform/aws-two-tier/
+$ build/terraform --log 5 --dir=./example/instance/terraform/aws-two-tier/
 INFO[0000] Starting plugin
 INFO[0000] Listening on: unix:///run/infrakit/plugins/instance-terraform.sock
 DEBU[0000] terraform instance plugin. dir= ./example/instance/terraform/aws-two-tier/
@@ -174,7 +174,7 @@ INFO[0000] listener protocol= unix addr= /run/infrakit/plugins/instance-terrafor
 Check that you can see it:
 
 ```
-$ infrakit/cli plugin ls
+$ build/cli plugin ls
 Plugins:
 NAME                	LISTEN
 instance-terraform  	unix:///run/infrakit/plugins/instance-terraform.sock
@@ -204,7 +204,7 @@ $ cat example/instance/terraform/aws-two-tier/instance-plugin-properties.json
         }
     }
 }
-$ infrakit/cli instance --name instance-terraform validate example/instance/terraform/aws-two-tier/instance-plugin-properties.json
+$ build/cli instance --name instance-terraform validate example/instance/terraform/aws-two-tier/instance-plugin-properties.json
 validate:ok
 ```
 
@@ -235,14 +235,14 @@ $ cat example/instance/terraform/aws-two-tier/instance-plugin-spec.json
     },
     "Init" : "#!/bin/sh; sudo apt-get -y update; sudo apt-get -y install nginx; sudo service nginx start"
 }
-$ infrakit/cli instance --name instance-terraform provision example/instance/terraform/aws-two-tier/instance-plugin-spec.json
+$ build/cli instance --name instance-terraform provision example/instance/terraform/aws-two-tier/instance-plugin-spec.json
 instance-1475004829
 ```
 
 Now list them.
 
 ```
-$ infrakit/cli instance --name instance-terraform describe
+$ build/cli instance --name instance-terraform describe
 ID                            	LOGICAL                       	TAGS
 instance-1475004829           	  -                           	other=values,provisioner=infrakit-terraform-example,InstancePlugin=terraform,Name=instance-1475004829,Tier=web
 ```
@@ -255,9 +255,9 @@ In AWS Console you can filter by tag `provisioner` with value `infrakit-terrafor
 Now destroy the instance:
 
 ```
-$ infrakit/cli instance --name instance-terraform destroy instance-1475004829
+$ build/cli instance --name instance-terraform destroy instance-1475004829
 destroyed instance-1475004829
-$ infrakit/cli instance --name instance-terraform describe
+$ build/cli instance --name instance-terraform describe
 ID                            	LOGICAL                       	TAGS
 ```
 

--- a/example/instance/terraform/README.md
+++ b/example/instance/terraform/README.md
@@ -106,18 +106,17 @@ and update its state.
  
 ## Building
 
-When you do `make binaries` in the top level directory, the CLI binary will be built and can be
-found as `./build/cli` from the project's top level directory.
+Begin by building plugin [binaries](../../README.md#binaries).
 
 ## Usage
 
 ```
-$ build/terraform -h
+$ build/infrakit-instance-terraform -h
 Terraform instance plugin
 
 Usage:
-  build/terraform [flags]
-  build/terraform [command]
+  build/infrakit-instance-terraform [flags]
+  build/infrakit-instance-terraform [command]
 
 Available Commands:
   version     print build version information
@@ -127,7 +126,7 @@ Flags:
       --listen string   listen address (unix or tcp) for the control endpoint (default "unix:///run/infrakit/plugins/instance-terraform.sock")
       --log int         Logging level. 0 is least verbose. Max is 5 (default 4)
 
-Use "build/terraform [command] --help" for more information about a command.
+Use "build/infrakit-instance-terraform [command] --help" for more information about a command.
 ```
 
 The plugin requires a `dir` directory that will be used to contain the `tfstate` and `tf.json`
@@ -138,7 +137,7 @@ As usual, you can give this plugin a different name by the URL (`unix:///plugins
 when starting the plugin.  However you name it, it is still an InstancePlugin:
 
 ```
-$ build/terraform version
+$ build/infrakit-instance-terraform version
 {
     "name": "TerraformInstance",
     "revision": "5999abffa5c10d4c9b9953459829dadea93d7ba4",
@@ -164,23 +163,14 @@ See the [CLI Doc](/cmd/cli/README.md) for details on accessing the instance plug
 Start the plugin:
 
 ```
-$ build/terraform --log 5 --dir=./example/instance/terraform/aws-two-tier/
+$ build/infrakit-instance-terraform --log 5 --dir=./example/instance/terraform/aws-two-tier/
 INFO[0000] Starting plugin
 INFO[0000] Listening on: unix:///run/infrakit/plugins/instance-terraform.sock
 DEBU[0000] terraform instance plugin. dir= ./example/instance/terraform/aws-two-tier/
 INFO[0000] listener protocol= unix addr= /run/infrakit/plugins/instance-terraform.sock err= <nil>
 ```
 
-Check that you can see it:
-
-```
-$ build/cli plugin ls
-Plugins:
-NAME                	LISTEN
-instance-terraform  	unix:///run/infrakit/plugins/instance-terraform.sock
-group               	unix:///run/infrakit/plugins/group.sock
-instance-file       	unix:///run/infrakit/plugins/instance-file.sock
-```
+Be sure to verify that the plugin is [discoverable](../../../cmd/cli/README.md#list-plugins).
 
 Now lets try to validate something.  Instead of reading from stdin we are loading from a file
 to avoid problems with bad bash substitution beacuse Terrafrom configs use `$` to indicate variables.
@@ -204,7 +194,7 @@ $ cat example/instance/terraform/aws-two-tier/instance-plugin-properties.json
         }
     }
 }
-$ build/cli instance --name instance-terraform validate example/instance/terraform/aws-two-tier/instance-plugin-properties.json
+$ build/infrakit instance --name instance-terraform validate example/instance/terraform/aws-two-tier/instance-plugin-properties.json
 validate:ok
 ```
 
@@ -235,14 +225,14 @@ $ cat example/instance/terraform/aws-two-tier/instance-plugin-spec.json
     },
     "Init" : "#!/bin/sh; sudo apt-get -y update; sudo apt-get -y install nginx; sudo service nginx start"
 }
-$ build/cli instance --name instance-terraform provision example/instance/terraform/aws-two-tier/instance-plugin-spec.json
+$ build/infrakit instance --name instance-terraform provision example/instance/terraform/aws-two-tier/instance-plugin-spec.json
 instance-1475004829
 ```
 
 Now list them.
 
 ```
-$ build/cli instance --name instance-terraform describe
+$ build/infrakit instance --name instance-terraform describe
 ID                            	LOGICAL                       	TAGS
 instance-1475004829           	  -                           	other=values,provisioner=infrakit-terraform-example,InstancePlugin=terraform,Name=instance-1475004829,Tier=web
 ```
@@ -255,9 +245,9 @@ In AWS Console you can filter by tag `provisioner` with value `infrakit-terrafor
 Now destroy the instance:
 
 ```
-$ build/cli instance --name instance-terraform destroy instance-1475004829
+$ build/infrakit instance --name instance-terraform destroy instance-1475004829
 destroyed instance-1475004829
-$ build/cli instance --name instance-terraform describe
+$ build/infrakit instance --name instance-terraform describe
 ID                            	LOGICAL                       	TAGS
 ```
 

--- a/example/instance/terraform/cattle_demo.md
+++ b/example/instance/terraform/cattle_demo.md
@@ -54,23 +54,23 @@ From the top level directory of the project:
 
 ```shell
 # The instance plugin:
-$ build/terraform --log 5 --dir $(pwd)/example/instance/terraform/aws-two-tier/
+$ build/infrakit-instance-terraform --log 5 --dir $(pwd)/example/instance/terraform/aws-two-tier/
 ```
 
 ```shell
 # The group plugin
-$ build/group --log 5
+$ build/infrakit-group-default --log 5
 ```
 
 ```shell
 # The vanilla flavor
-$ build/vanilla --log 5
+$ build/infrakit-flavor-vanilla --log 5
 ```
 
 ## 3. List all the instances
 
 ```shell
-$ build/cli instance --name=instance-terraform describe
+$ build/infrakit instance --name=instance-terraform describe
 ID                                                LOGICAL                               TAGS
 # no instances
 ```
@@ -79,7 +79,7 @@ ID                                                LOGICAL                       
 Using the JSON we showed above, start watching this group:
 
 ```shell
-$ build/cli group watch example/instance/terraform/aws-two-tier/group.json
+$ build/infrakit group watch example/instance/terraform/aws-two-tier/group.json
 watching terraform_demo
 ```
 The group plugin starts to create new instances to match the specification.
@@ -88,7 +88,7 @@ these instances ![instances](images/1.png)
 
 ## 5. List members
 ```shell
-$ build/cli group inspect terraform_demo
+$ build/infrakit group inspect terraform_demo
 ID                              LOGICAL                         TAGS
 instance-1475601644               -                             Name=instance-1475601644,Tier=web,infrakit.config_sha=BmjtnDnrqBvGHm05Nin3Vb66NaA=,infrakit.group=terraform_demo,provisioner=infrakit-terraform-demo
 instance-1475601645               -                             Name=instance-1475601645,Tier=web,infrakit.config_sha=BmjtnDnrqBvGHm05Nin3Vb66NaA=,infrakit.group=terraform_demo,provisioner=infrakit-terraform-demo
@@ -103,21 +103,21 @@ Let's change the size to 8 and the instance type to `t2.nano`.
 Before we run we can check to see what will be done:
 
 ```shell
-$ build/cli group describe example/instance/terraform/aws-two-tier/group.json
+$ build/infrakit group describe example/instance/terraform/aws-two-tier/group.json
 terraform_demo : Performs a rolling update on 5 instances, then adds 3 instances to increase the group size to 8
 ```
 
 Looks good.  Let's commit:
 
 ```shell
-$ build/cli group update example/instance/terraform/aws-two-tier/group.json
+$ build/infrakit group update example/instance/terraform/aws-two-tier/group.json
 update terraform_demo completed
 ```
 
 ## 7. Check on the group:
 
 ```shell
-$ build/cli group inspect terraform_demo
+$ build/infrakit group inspect terraform_demo
 ID                              LOGICAL                         TAGS
 instance-1475602365               -                             Name=instance-1475602365,Tier=web,infrakit.config_sha=NP0kIk4bVoojdRZsRGC0XKTrrUs=,infrakit.group=terraform_demo,provisioner=infrakit-terraform-demo
 instance-1475602374               -                             Name=instance-1475602374,Tier=web,infrakit.config_sha=NP0kIk4bVoojdRZsRGC0XKTrrUs=,infrakit.group=terraform_demo,provisioner=infrakit-terraform-demo
@@ -139,6 +139,6 @@ You can also try to remove some instances and see that the group size will be re
 We are done with the demo, remove the resources...
 
 ```shell
-$ build/cli group destroy terraform_demo
+$ build/infrakit group destroy terraform_demo
 destroy terraform_demo initiated
 ```

--- a/example/instance/terraform/cattle_demo.md
+++ b/example/instance/terraform/cattle_demo.md
@@ -54,23 +54,23 @@ From the top level directory of the project:
 
 ```shell
 # The instance plugin:
-$ ./infrakit/terraform --log 5 --dir $(pwd)/example/instance/terraform/aws-two-tier/
+$ build/terraform --log 5 --dir $(pwd)/example/instance/terraform/aws-two-tier/
 ```
 
 ```shell
 # The group plugin
-$ infrakit/group --log 5
+$ build/group --log 5
 ```
 
 ```shell
 # The vanilla flavor
-$ ./infrakit/vanilla --log 5
+$ build/vanilla --log 5
 ```
 
 ## 3. List all the instances
 
 ```shell
-$ infrakit/cli instance --name=instance-terraform describe
+$ build/cli instance --name=instance-terraform describe
 ID                                                LOGICAL                               TAGS
 # no instances
 ```
@@ -79,7 +79,7 @@ ID                                                LOGICAL                       
 Using the JSON we showed above, start watching this group:
 
 ```shell
-$ infrakit/cli group watch example/instance/terraform/aws-two-tier/group.json
+$ build/cli group watch example/instance/terraform/aws-two-tier/group.json
 watching terraform_demo
 ```
 The group plugin starts to create new instances to match the specification.
@@ -88,7 +88,7 @@ these instances ![instances](images/1.png)
 
 ## 5. List members
 ```shell
-$ infrakit/cli group inspect terraform_demo
+$ build/cli group inspect terraform_demo
 ID                              LOGICAL                         TAGS
 instance-1475601644               -                             Name=instance-1475601644,Tier=web,infrakit.config_sha=BmjtnDnrqBvGHm05Nin3Vb66NaA=,infrakit.group=terraform_demo,provisioner=infrakit-terraform-demo
 instance-1475601645               -                             Name=instance-1475601645,Tier=web,infrakit.config_sha=BmjtnDnrqBvGHm05Nin3Vb66NaA=,infrakit.group=terraform_demo,provisioner=infrakit-terraform-demo
@@ -103,21 +103,21 @@ Let's change the size to 8 and the instance type to `t2.nano`.
 Before we run we can check to see what will be done:
 
 ```shell
-$ infrakit/cli group describe example/instance/terraform/aws-two-tier/group.json
+$ build/cli group describe example/instance/terraform/aws-two-tier/group.json
 terraform_demo : Performs a rolling update on 5 instances, then adds 3 instances to increase the group size to 8
 ```
 
 Looks good.  Let's commit:
 
 ```shell
-$ infrakit/cli group update example/instance/terraform/aws-two-tier/group.json
+$ build/cli group update example/instance/terraform/aws-two-tier/group.json
 update terraform_demo completed
 ```
 
 ## 7. Check on the group:
 
 ```shell
-$ infrakit/cli group inspect terraform_demo
+$ build/cli group inspect terraform_demo
 ID                              LOGICAL                         TAGS
 instance-1475602365               -                             Name=instance-1475602365,Tier=web,infrakit.config_sha=NP0kIk4bVoojdRZsRGC0XKTrrUs=,infrakit.group=terraform_demo,provisioner=infrakit-terraform-demo
 instance-1475602374               -                             Name=instance-1475602374,Tier=web,infrakit.config_sha=NP0kIk4bVoojdRZsRGC0XKTrrUs=,infrakit.group=terraform_demo,provisioner=infrakit-terraform-demo
@@ -139,6 +139,6 @@ You can also try to remove some instances and see that the group size will be re
 We are done with the demo, remove the resources...
 
 ```shell
-$ infrakit/cli group destroy terraform_demo
+$ build/cli group destroy terraform_demo
 destroy terraform_demo initiated
 ```


### PR DESCRIPTION
This will make it more natural to maintain a conventional binary directory to use across this and other InfraKit-related repositories.

Signed-off-by: Bill Farner <bill@docker.com>