### PR TITLE
Centralize docs for getting usage and version information

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,6 +161,7 @@ Currently, several binaries are available:
   + [`build/infrakit-flavor-zookeeper`](./example/flavor/zookeeper), a Flavor plugin for [Apache ZooKeeper](https://zookeeper.apache.org/) ensemble members
   + [`build/infrakit-flavor-swarm`](./example/flavor/swarm), a Flavor plugin for Docker in [Swarm mode](https://docs.docker.com/engine/swarm/).
 
+All provided binaries have a `help` subcommand to get usage and a `version` subcommand to identify the build revision.
 
 ## Examples
 There are a few examples of _InfraKit_ plugins:
@@ -272,17 +273,13 @@ specification.
 
 ## Plugin Discovery
 
-_InfraKit_ plugins collaborate with each other to accomplish a set of objectives.  Therefore, they
-need to be able to talk to one another.  While many different discovery methods are available, this
-toolkit implements a simple file-based discovery system the names of the unix socket files in a common
-directory represents the _name_ of the plugin.
+Multiple _InfraKit_ plugins are typically used together to support a declared configuration.  These plugins discover
+each other by looking for plugin files in a common plugin directory, and communicate via well-defined HTTP APIs.
 
-By default the common directory for unix sockets is located at `/run/infrakit/plugins`.
-Make sure this directory exists on your host:
-
-```
-mkdir -p /run/infrakit/plugins
-chmod 777 /run/infrakit/plugins
+The default plugin directory for unix sockets is located at `/run/infrakit/plugins`.  Make sure this directory exists:
+```shell
+$ mkdir -p /run/infrakit/plugins
+$ chmod 777 /run/infrakit/plugins
 ```
 
 Note that a plugin's name is separate from the _type_ of the plugin, so it's possible to have two

--- a/cmd/cli/README.md
+++ b/cmd/cli/README.md
@@ -11,39 +11,6 @@ exposed as verbs and configuration JSON can be read from local file or standard 
 
 Begin by building plugin [binaries](../../README.md#binaries).
 
-## Usage
-
-```
-$ build/infrakit -h
-infrakit cli
-
-Usage:
-  build/infrakit [command]
-
-Available Commands:
-  flavor      Access flavor plugin
-  group       Access group plugin
-  instance    Access instance plugin
-  plugin      Manage plugins
-  version     Print build version information
-
-Flags:
-      --dir string   Dir path for plugin discovery (default "/run/infrakit/plugins")
-      --log int      Logging level. 0 is least verbose. Max is 5 (default 4)
-
-Use "build/infrakit [command] --help" for more information about a command.
-```
-
-### Default Directory for Plugin Discovery
-
-All InfraKit plugins will by default open the unix socket located at `/run/infrakit/plugins`.
-Make sure this directory exists on your host:
-
-```
-mkdir -p /run/infrakit/plugins
-chmod 777 /run/infrakit/plugins
-```
-
 ### List Plugins
 
 ```
@@ -68,30 +35,7 @@ You can access the following plugins and their methods via command line:
 
 ### Working with Instance Plugin
 
-```
-$ build/infrakit instance -h
-Access instance plugin
-
-Usage:
-  build/infrakit instance [command]
-
-Available Commands:
-  describe    describe the instances
-  destroy     destroy the resource
-  provision   provision the resource instance
-  validate    validate input
-
-Flags:
-      --name string   Name of plugin
-
-Global Flags:
-      --dir string   Dir path for plugin discovery (default "/run/infrakit/plugins")
-      --log int      Logging level. 0 is least verbose. Max is 5 (default 4)
-
-Use "build/infrakit instance [command] --help" for more information about a command.
-```
-
-For example, using the plugin `instance-file` as an example:
+Using the plugin `instance-file` as an example:
 
 `describe` calls the `DescribeInstances` endpoint of the plugin:
 
@@ -190,56 +134,4 @@ Destroy
 ```
 $ build/infrakit instance --name instance-file destroy instance-1474873473
 destroyed instance-1474873473
-```
-
-### Working with Group Plugin
-
-```
-$ build/infrakit group -h
-Access group plugin
-
-Usage:
-  build/infrakit group [command]
-
-Available Commands:
-  describe    describe update (describe - or describe filename)
-  destroy     destroy the group
-  inspect     inspect the group
-  stop        stop updating the group
-  unwatch     unwatch the group
-  update      update group (update < file or update filename)
-  watch       watch the group
-
-Flags:
-      --name string   Name of plugin
-
-Global Flags:
-      --dir string   Dir path for plugin discovery (default "/run/infrakit/plugins")
-      --log int      Logging level. 0 is least verbose. Max is 5 (default 4)
-
-Use "build/infrakit group [command] --help" for more information about a command.
-```
-
-### Working with Flavor Plugin
-
-```
-$ build/infrakit flavor -h
-Access flavor plugin
-
-Usage:
-  build/infrakit flavor [command]
-
-Available Commands:
-  healthy     checks for health
-  prepare     prepare the provision data
-  validate    validate input
-
-Flags:
-      --name string   Name of plugin
-
-Global Flags:
-      --dir string   Dir path for plugin discovery (default "/run/infrakit/plugins")
-      --log int      Logging level. 0 is least verbose. Max is 5 (default 4)
-
-Use "build/infrakit flavor [command] --help" for more information about a command.
 ```

--- a/cmd/group/README.md
+++ b/cmd/group/README.md
@@ -7,32 +7,11 @@ the properties of the physical resource (Instance plugin) and semantics or natur
 (Flavor plugin).
 
 
-## Building
+## Running
 
 Begin by building plugin [binaries](../../README.md#binaries).
 
-## Usage
-
-```
-$ build/infrakit-group-default -h
-Group server
-
-Usage:
-  build/infrakit-group-default [flags]
-  build/infrakit-group-default [command]
-
-Available Commands:
-  version     print build version information
-
-Flags:
-      --listen string            listen address (unix or tcp) for the control endpoint (default "unix:///run/infrakit/plugins/group.sock")
-      --log int                  Logging level. 0 is least verbose. Max is 5 (default 4)
-      --poll-interval duration   Group polling interval (default 10s)
-
-Use "build/infrakit-group-default [command] --help" for more information about a command.
-```
-
-The plugin can be started without any arguments and will default to using unix socket in
+The plugin may be started without any arguments and will default to using unix socket in
 `/run/infrakit/plugins` for communications with the CLI and other plugins:
 
 ```
@@ -47,15 +26,3 @@ INFO[0000] Starting
 INFO[0000] Listening on: unix:///run/infrakit/plugins/group.sock
 INFO[0000] listener protocol= unix addr= /run/infrakit/plugins/group.sock err= <nil>
 ```
-
-### Default Directory for Plugin Discovery
-
-All InfraKit plugins will by default open the unix socket located at `/run/infrakit/plugins`.
-Make sure this directory exists on your host:
-
-```
-mkdir -p /run/infrakit/plugins
-chmod 777 /run/infrakit/plugins
-```
-
-See the [CLI Doc](../cli/README.md) for details on accessing the group plugin via CLI.

--- a/docs/tutorial.md
+++ b/docs/tutorial.md
@@ -5,13 +5,8 @@ To illustrate the concept of working with Group, Flavor, and Instance plugins, w
   + The `file` instance plugin - to provision instances by writing files to disk
   + The `vanilla` flavor plugin - to provide context/ flavor to the configuration of the instances
 
-All InfraKit plugins will by default open the unix socket located at /run/infrakit/plugins. Make sure this directory
-exists on your host:
-
-```shell
-$ mkdir -p /run/infrakit/plugins/
-$ chmod 777 /run/infrakit/plugins
-```
+It may be helpful to familiarize yourself with [plugin discovery](README.md#plugin-discovery) if you have not already
+done so.
 
 Start the default Group plugin
 

--- a/example/flavor/vanilla/README.md
+++ b/example/flavor/vanilla/README.md
@@ -178,8 +178,7 @@ Then in your JSON config for the default group plugin, you would reference it by
 ```
 Then when you watch a group with the config above (`cattle`), the cattle will be `french-vanilla` flavored.
 
-Watch this group....
-
+Watch this group:
 ```
 $ build/infrakit group --name group watch << EOF
 > {

--- a/example/flavor/zookeeper/README.md
+++ b/example/flavor/zookeeper/README.md
@@ -3,31 +3,9 @@ InfraKit Flavor Plugin - Zookeeper
 
 This is a plugin for handling Zookeeper ensemble.
 
-## Building
+## Running
 
-Begin by building plugin [binaries](../../README.md#binaries).
-
-## Usage
-
-```
-$ build/infrakit-flavor-zookeeper -h
-Zookeeper flavor plugin
-
-Usage:
-  build/infrakit-flavor-zookeeper [flags]
-  build/infrakit-flavor-zookeeper [command]
-
-Available Commands:
-  version     print build version information
-
-Flags:
-      --listen string   listen address (unix or tcp) for the control endpoint (default "unix:///run/infrakit/plugins/flavor-zookeeper.sock")
-      --log int         Logging level. 0 is least verbose. Max is 5 (default 4)
-
-Use "build/infrakit-flavor-zookeeper [command] --help" for more information about a command.
-```
-
-## Test
+Begin by building plugin [binaries](../../../README.md#binaries).
 
 Start the [vagrant instance plugin](/example/instance/vagrant):
 

--- a/example/instance/file/README.md
+++ b/example/instance/file/README.md
@@ -6,28 +6,9 @@ to disk as `provision`.  It is useful for testing and debugging.
 
 ## Building
 
-Begin by building plugin [binaries](../../README.md#binaries).
+Begin by building plugin [binaries](../../../README.md#binaries).
 
 ## Usage
-
-```
-$ build/infrakit-instance-file -h
-File instance plugin
-
-Usage:
-  build/infrakit-instance-file [flags]
-  build/infrakit-instance-file [command]
-
-Available Commands:
-  version     print build version information
-
-Flags:
-      --dir string      Dir for storing the files (default "/var/folders/rq/g0cj3y7n511c10p2kbz5q33w0000gn/T/")
-      --listen string   listen address (unix or tcp) for the control endpoint (default "unix:///run/infrakit/plugins/instance-file.sock")
-      --log int         Logging level. 0 is least verbose. Max is 5 (default 4)
-
-Use "build/infrakit-instance-file [command] --help" for more information about a command.
-```
 
 The plugin can be started without any arguments and will default to using unix socket in
 `/run/infrakit/plugins` for communications with the CLI and other plugins:
@@ -53,16 +34,5 @@ Be sure to verify that the plugin is [discoverable](../../../cmd/cli/README.md#l
 
 Note that there should be two file instance plugins running now with different names
 (`instance-file`, and `another-file`).
-
-
-### Default Directory for Plugin Discovery
-
-All InfraKit plugins will by default open the unix socket located at `/run/infrakit/plugins`.
-Make sure this directory exists on your host:
-
-```
-mkdir -p /run/infrakit/plugins
-chmod 777 /run/infrakit/plugins
-```
 
 See the [CLI Doc](/cmd/cli/README.md) for details on accessing the instance plugin via CLI.

--- a/example/instance/terraform/README.md
+++ b/example/instance/terraform/README.md
@@ -5,8 +5,8 @@ This is a proof of concept Instance Plugin based on [Terraform](https://www.terr
 In this concept, InfraKit provides the active group management while Terraform performs the
 functions of resource provisioning.
 
-This poc is adapted from the [`aws-two-tier`](https://github.com/hashicorp/terraform/tree/master/examples/aws-two-tier) example from the Terraform project.
-There are some minor changes:
+This poc is adapted from the [`aws-two-tier`](https://github.com/hashicorp/terraform/tree/master/examples/aws-two-tier)
+example from the Terraform project. There are some minor changes:
 
   + Variables that required on-screen user interaction (for setting public keys) have been removed
   and replaced with the `key_name` parameter in the provisioning config.
@@ -104,32 +104,11 @@ and update its state.  When an instance is removed, Terraform will do the same b
 and update its state.
 
  
-## Building
+## Running
 
-Begin by building plugin [binaries](../../README.md#binaries).
+Begin by building plugin [binaries](../../../README.md#binaries).
 
-## Usage
-
-```
-$ build/infrakit-instance-terraform -h
-Terraform instance plugin
-
-Usage:
-  build/infrakit-instance-terraform [flags]
-  build/infrakit-instance-terraform [command]
-
-Available Commands:
-  version     print build version information
-
-Flags:
-      --dir string      Dir for storing the files (default "/var/folders/rq/g0cj3y7n511c10p2kbz5q33w0000gn/T/")
-      --listen string   listen address (unix or tcp) for the control endpoint (default "unix:///run/infrakit/plugins/instance-terraform.sock")
-      --log int         Logging level. 0 is least verbose. Max is 5 (default 4)
-
-Use "build/infrakit-instance-terraform [command] --help" for more information about a command.
-```
-
-The plugin requires a `dir` directory that will be used to contain the `tfstate` and `tf.json`
+The plugin requires a directory (`--dir`) that will be used to contain the `tfstate` and `tf.json`
 files.  It also checks to make sure it can call `terraform`.
 Install Terraform [here](https://www.terraform.io/downloads.html) if you haven't done so.
 
@@ -146,19 +125,7 @@ $ build/infrakit-instance-terraform version
   }
 ```
 
-### Default Directory for Plugin Discovery
-
-All InfraKit plugins will by default open the unix socket located at `/run/infrakit/plugins`.
-Make sure this directory exists on your host:
-
-```
-mkdir -p /run/infrakit/plugins
-chmod 777 /run/infrakit/plugins
-```
-
 See the [CLI Doc](/cmd/cli/README.md) for details on accessing the instance plugin via CLI.
-
-## Using
 
 Start the plugin:
 


### PR DESCRIPTION
This is following a general theme of centralizing docs on behavior that we strive to keep consistent.  In particular with usage output, i think it's useful to inform the user how to get it; but omit it from documentation as it adds bulk and will be challenging to keep up-to-date.