### PR TITLE
Vanilla plugin: avoid spurious Init newline

### DIFF
--- a/plugin/flavor/vanilla/flavor.go
+++ b/plugin/flavor/vanilla/flavor.go
@@ -48,7 +48,9 @@ func (f vanillaFlavor) Prepare(flavor json.RawMessage, instance instance.Spec) (
 
 	// Merge UserData into Init
 	lines := []string{}
-	lines = append(lines, instance.Init)
+	if instance.Init != "" {
+		lines = append(lines, instance.Init)
+	}
 	lines = append(lines, s.UserData...)
 
 	instance.Init = strings.Join(lines, "\n")


### PR DESCRIPTION
In the case of setting up AWS user-data, this initial newline breaks cloud-init parsing, resulting in obscure errors.

Signed-off-by: Bill Farner <wfarner@apache.org>