### PR TITLE
CLI: only accept configs by path name rather than stdin

### DIFF
--- a/cmd/cli/README.md
+++ b/cmd/cli/README.md
@@ -21,7 +21,7 @@ instance-file       	~/.infrakit/plugins/instance-file
 ```
 
 Once you know the plugins by name, you can make calls to them.  For example, the instance plugin
-`instance-file` is a pPlugin that "provisions" instances by writing the instructions to
+`instance-file` is a Plugin that "provisions" instances by writing the instructions to
 a file in a local directory.
 
 You can access the following plugins and their methods via command line:

--- a/cmd/cli/README.md
+++ b/cmd/cli/README.md
@@ -1,11 +1,8 @@
 InfraKit CLI
 ============
 
-This is a CLI for working with various infrakit plugins.  In the simplest form, an InfraKit plugin
-is simply a daemon that communicates over unix domain sockets.  InfraKit plugins can find each
-other by the socket files in a common directory.  The CLI uses the common directory as a discovery
-mechanism and offers various subcommands for working with plugins. In general, plugin methods are
-exposed as verbs and configuration JSON can be read from local file or standard input.
+This is a developer CLI for working with various _InfraKit_ plugins.  The CLI offers several subcommands for working
+with plugins. In general, plugin methods are exposed as verbs and configuration JSON can be read from local file.
 
 ## Building
 
@@ -24,7 +21,7 @@ instance-file       	~/.infrakit/plugins/instance-file
 ```
 
 Once you know the plugins by name, you can make calls to them.  For example, the instance plugin
-`instance-file` is a simple plugin that "provisions" an instance by writing the instructions to
+`instance-file` is a pPlugin that "provisions" instances by writing the instructions to
 a file in a local directory.
 
 You can access the following plugins and their methods via command line:
@@ -37,89 +34,35 @@ You can access the following plugins and their methods via command line:
 
 Using the plugin `instance-file` as an example:
 
-`describe` calls the `DescribeInstances` endpoint of the plugin:
+### Validate
 
 ```
-$ build/infrakit instance --name instance-file describe
-ID                            	LOGICAL                       	TAGS
-instance-1474850397           	  -                           	group=test,instanceType=small
-instance-1474850412           	  -                           	group=test2,instanceType=small
-instance-1474851747           	logic2                        	instanceType=small,group=test2
-```
+$ cat << EOF > instance.json
+{
+    "Properties": {
+        "version": "v0.0.1"
+    },
+    "Tags": {
+        "instanceType": "small",
+        "group": "test2"
+    },
+    "Init": "#!/bin/sh\napt-get install -y wget",
+    "LogicalID": "logic2"
+}
+EOF
 
-Validate - send the config JSON via stdin:
-
-```
-$ build/infrakit instance --name instance-file validate << EOF
-> {
->     "Properties" : {
->         "version" : "v0.0.1",
->         "groups" : {
->             "managers" : {
->                 "driver" : "infrakit/quorum"
->             },
->             "small" : {
->                 "driver" : "infrakit/scaler",
->                 "properties" : {
->                     "size" : 3
->                 }
->             },
->             "large" : {
->                 "driver" : "infrakit/scaler",
->                 "properties" : {
->                     "size" : 3
->                 }
->             }
->         }
->     },
->     "Tags" : {
->         "instanceType" : "small",
->         "group" : "test2"
->     },
->     "Init" : "#!/bin/sh\napt-get install -y wget",
->     "LogicalID" : "logic2"
-> }
-> EOF
+$ build/infrakit instance --name instance-file instance.json
 validate:ok
 ```
 
-Provision - send via stdin:
+### Provision
 
 ```
-$ build/infrakit instance --name instance-file provision << EOF
-> {
->     "Properties" : {
->         "version" : "v0.0.1",
->         "groups" : {
->             "managers" : {
->                 "driver" : "infrakit/quorum"
->             },
->             "small" : {
->                 "driver" : "infrakit/scaler",
->                 "properties" : {
->                     "size" : 3
->                 }
->             },
->             "large" : {
->                 "driver" : "infrakit/scaler",
->                 "properties" : {
->                     "size" : 3
->                 }
->             }
->         }
->     },
->     "Tags" : {
->         "instanceType" : "small",
->         "group" : "test2"
->     },
->     "Init" : "#!/bin/sh\napt-get install -y wget",
->     "LogicalID" : "logic2"
-> }
-> EOF
+$ build/infrakit instance --name instance-file provision instance.json
 instance-1474873473
 ```
 
-List instances
+### List instances
 
 ```
 $ build/infrakit instance --name instance-file describe
@@ -129,7 +72,8 @@ instance-1474850412           	  -                           	group=test2,instan
 instance-1474851747           	logic2                        	group=test2,instanceType=small
 instance-1474873473           	logic2                        	group=test2,instanceType=small
 ```
-Destroy
+
+### Destroy
 
 ```
 $ build/infrakit instance --name instance-file destroy instance-1474873473

--- a/cmd/cli/group.go
+++ b/cmd/cli/group.go
@@ -2,15 +2,16 @@ package main
 
 import (
 	"encoding/json"
-	"errors"
 	"fmt"
-	"sort"
-	"strings"
-
+	log "github.com/Sirupsen/logrus"
 	"github.com/docker/infrakit/discovery"
 	"github.com/docker/infrakit/spi/group"
 	group_plugin "github.com/docker/infrakit/spi/http/group"
 	"github.com/spf13/cobra"
+	"io/ioutil"
+	"os"
+	"sort"
+	"strings"
 )
 
 const (
@@ -45,10 +46,19 @@ func groupPluginCommand(plugins func() discovery.Plugins) *cobra.Command {
 		RunE: func(cmd *cobra.Command, args []string) error {
 			assertNotNil("no plugin", groupPlugin)
 
-			buff := getInput(args)
-			spec := group.Spec{}
-			err := json.Unmarshal(buff, &spec)
+			if len(args) != 1 {
+				cmd.Usage()
+				os.Exit(1)
+			}
+
+			buff, err := ioutil.ReadFile(args[0])
 			if err != nil {
+				log.Error(err)
+				os.Exit(1)
+			}
+
+			spec := group.Spec{}
+			if err := json.Unmarshal(buff, &spec); err != nil {
 				return err
 			}
 
@@ -61,13 +71,14 @@ func groupPluginCommand(plugins func() discovery.Plugins) *cobra.Command {
 	}
 
 	unwatch := &cobra.Command{
-		Use:   "unwatch [group ID]",
+		Use:   "unwatch <group ID>",
 		Short: "unwatch a group",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			assertNotNil("no plugin", groupPlugin)
 
-			if len(args) == 0 {
-				return errors.New("missing id")
+			if len(args) != 0 {
+				cmd.Usage()
+				os.Exit(1)
 			}
 
 			groupID := group.ID(args[0])
@@ -81,13 +92,14 @@ func groupPluginCommand(plugins func() discovery.Plugins) *cobra.Command {
 	}
 
 	inspect := &cobra.Command{
-		Use:   "inspect [group ID]",
+		Use:   "inspect <group ID>",
 		Short: "inspect a group",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			assertNotNil("no plugin", groupPlugin)
 
-			if len(args) == 0 {
-				return errors.New("missing id")
+			if len(args) != 1 {
+				cmd.Usage()
+				os.Exit(1)
 			}
 
 			groupID := group.ID(args[0])
@@ -115,15 +127,24 @@ func groupPluginCommand(plugins func() discovery.Plugins) *cobra.Command {
 	}
 
 	describe := &cobra.Command{
-		Use:   "describe",
-		Short: "describe update (describe - or describe filename)",
+		Use:   "describe <group configuration file>",
+		Short: "describes the steps to perform an update",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			assertNotNil("no plugin", groupPlugin)
 
-			buff := getInput(args)
-			spec := group.Spec{}
-			err := json.Unmarshal(buff, &spec)
+			if len(args) != 1 {
+				cmd.Usage()
+				os.Exit(1)
+			}
+
+			buff, err := ioutil.ReadFile(args[0])
 			if err != nil {
+				log.Error(err)
+				os.Exit(1)
+			}
+
+			spec := group.Spec{}
+			if err := json.Unmarshal(buff, &spec); err != nil {
 				return err
 			}
 
@@ -141,10 +162,19 @@ func groupPluginCommand(plugins func() discovery.Plugins) *cobra.Command {
 		RunE: func(cmd *cobra.Command, args []string) error {
 			assertNotNil("no plugin", groupPlugin)
 
-			buff := getInput(args)
-			spec := group.Spec{}
-			err := json.Unmarshal(buff, &spec)
+			if len(args) != 1 {
+				cmd.Usage()
+				os.Exit(1)
+			}
+
+			buff, err := ioutil.ReadFile(args[0])
 			if err != nil {
+				log.Error(err)
+				os.Exit(1)
+			}
+
+			spec := group.Spec{}
+			if err := json.Unmarshal(buff, &spec); err != nil {
 				return err
 			}
 
@@ -158,13 +188,14 @@ func groupPluginCommand(plugins func() discovery.Plugins) *cobra.Command {
 	}
 
 	stop := &cobra.Command{
-		Use:   "stop [group ID]",
+		Use:   "stop <group ID>",
 		Short: "stop updating a group",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			assertNotNil("no plugin", groupPlugin)
 
-			if len(args) == 0 {
-				return errors.New("missing id")
+			if len(args) != 1 {
+				cmd.Usage()
+				os.Exit(1)
 			}
 
 			groupID := group.ID(args[0])
@@ -178,13 +209,14 @@ func groupPluginCommand(plugins func() discovery.Plugins) *cobra.Command {
 	}
 
 	destroy := &cobra.Command{
-		Use:   "destroy [group ID]",
+		Use:   "destroy <group ID>",
 		Short: "destroy a group",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			assertNotNil("no plugin", groupPlugin)
 
-			if len(args) == 0 {
-				return errors.New("missing id")
+			if len(args) != 1 {
+				cmd.Usage()
+				os.Exit(1)
 			}
 
 			groupID := group.ID(args[0])

--- a/cmd/cli/main.go
+++ b/cmd/cli/main.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"errors"
-	"io/ioutil"
 	"os"
 
 	log "github.com/Sirupsen/logrus"
@@ -51,24 +50,4 @@ func assertNotNil(message string, f interface{}) {
 		log.Error(errors.New(message))
 		os.Exit(1)
 	}
-}
-
-func getInput(args []string) []byte {
-	input := os.Stdin
-	if len(args) > 0 {
-		i, err := os.Open(args[0])
-		if err != nil {
-			log.Error(err)
-			os.Exit(1)
-		}
-		input = i
-	}
-
-	buff, err := ioutil.ReadAll(input)
-	if err != nil {
-		log.Error(err)
-		os.Exit(1)
-	}
-
-	return buff
 }

--- a/cmd/group/README.md
+++ b/cmd/group/README.md
@@ -14,7 +14,7 @@ Begin by building plugin [binaries](../../README.md#binaries).
 The plugin may be started without any arguments and will default to using unix socket in
 `~/.infrakit/plugins` for communications with the CLI and other plugins:
 
-```
+```shell
 $ build/infrakit-group-default
 INFO[0000] Listening at: ~/.infrakit/plugins/group
 ```

--- a/example/flavor/vanilla/README.md
+++ b/example/flavor/vanilla/README.md
@@ -20,7 +20,7 @@ the plugin.  This plugin simply applies the static configuration.
 ## Schema
 
 Here's a skeleton of this Plugin's schema:
-```
+```json
 {
     "Size" : 0,
     "LogicalIDs": [],
@@ -38,7 +38,7 @@ The supported fields are:
 * `Labels`: a string-string mapping of keys and values to add as Instance Tags
 
 Here's an example Group configuration using the default [infrakit/group](/cmd/group) Plugin and the Vanilla Plugin:
-```
+```json
 {
     "ID": "cattle",
     "Properties": {
@@ -65,7 +65,7 @@ Here's an example Group configuration using the default [infrakit/group](/cmd/gr
 ```
 
 Or with assigned IDs:
-```
+```json
 {
     "ID": "named-cattle",
     "Properties": {

--- a/example/flavor/zookeeper/README.md
+++ b/example/flavor/zookeeper/README.md
@@ -12,21 +12,21 @@ Begin by building plugin [binaries](../../../README.md#binaries).
 
 Start the [vagrant instance plugin](/example/instance/vagrant):
 
-```
+```shell
 $ build/infrakit-instance-vagrant
 INFO[0000] Listening at: ~/.infrakit/plugins/instance-vagrant
 ```
 
 Start the [Group plugin](/cmd/group):
 
-```
+```shell
 $ build/infrakit-group-default
 INFO[0000] Listening at: ~/.infrakit/plugins/group
 ```
 
 Start Zookeeper flavor plugin:
 
-```
+```shell
 $ build/infrakit-flavor-zookeeper
 INFO[0000] Listening at: ~/.infrakit/plugins/flavor-zookeeper
 ```
@@ -35,7 +35,7 @@ Be sure to verify that the plugin is [discoverable](../../../cmd/cli/README.md#l
 
 Here's a JSON for the group we'd like to see [vagrant-zk-example.json](./vagrant-zk-example.json):
 
-```
+```json
 {
     "ID": "zk",
     "Properties": {
@@ -58,7 +58,7 @@ Here's a JSON for the group we'd like to see [vagrant-zk-example.json](./vagrant
 
 Now tell the group plugin to watch the zk group, create if necessary:
 
-```
+```shell
 $ build/infrakit group watch ./vagrant-zk-example.json
 watching zk
 ```

--- a/example/instance/file/README.md
+++ b/example/instance/file/README.md
@@ -1,7 +1,6 @@
 InfraKit Instance Plugin - File
 ===============================
 
-
 A [reference](../../../README.md#reference-implementations) implementation of an Instance Plugin that can accept any
 configuration and writes the configuration to disk as `provision`.  It is useful for testing and debugging.
 
@@ -14,7 +13,7 @@ Begin by building plugin [binaries](../../../README.md#binaries).
 The plugin can be started without any arguments and will default to using unix socket in
 `~/.infrakit/plugins` for communications with the CLI and other plugins:
 
-```
+```shell
 $ build/infrakit-instance-file --dir=./test
 INFO[0000] Listening at: ~/.infrakit/plugins/instance-file
 ```
@@ -22,7 +21,7 @@ INFO[0000] Listening at: ~/.infrakit/plugins/instance-file
 This starts the plugin using `./test` as directory and `instance-file` as name.
 
 You can give the another plugin instance a different name via the `listen` flag:
-```
+```shell
 $ build/infrakit-instance-file --name=another-file --dir=./test
 INFO[0000] Listening at: ~/.infrakit/plugins/another-file
 ```

--- a/example/instance/terraform/README.md
+++ b/example/instance/terraform/README.md
@@ -36,7 +36,7 @@ This directory contains a `main.tf` that builds a VPC with subnet on AWS.  EC2 i
 (or `aws_instance` resource) are then added to the config as separate files when the plugin provisions
 the resource.  For an EC2 instance this is a valid `.tf.json`:
 
-```
+```json
 {
     "resource": {
       "aws_instance": {
@@ -67,7 +67,7 @@ Terraform's configuration schema requires user assignment of names for individua
 InfraKit operates on groups of them.  So we changed the JSON format slightly to require only the
 resource type name (e.g. `aws_instance`).  This is the spec for the instance plugin:
 
-```
+```json
 {
     "Properties" : {
         "type" : "aws_instance",
@@ -116,7 +116,7 @@ See the [CLI Doc](/cmd/cli/README.md) for details on accessing the instance plug
 
 Start the plugin:
 
-```
+```shell
 $ build/infrakit-instance-terraform --dir=./example/instance/terraform/aws-two-tier/
 INFO[0000] Listening at: ~/.infrakit/plugins/instance-terraform
 ```
@@ -126,7 +126,7 @@ Be sure to verify that the plugin is [discoverable](../../../cmd/cli/README.md#l
 Now lets try to validate something.  Instead of reading from stdin we are loading from a file
 to avoid problems with bad bash substitution beacuse Terrafrom configs use `$` to indicate variables.
 
-```
+```shell
 $ cat example/instance/terraform/aws-two-tier/instance-plugin-properties.json
 {
     "type" : "aws_instance",
@@ -151,7 +151,7 @@ validate:ok
 
 Now we can provision:
 
-```
+```shell
 $ cat example/instance/terraform/aws-two-tier/instance-plugin-spec.json
 {
     "Properties" : {
@@ -182,7 +182,7 @@ instance-1475004829
 
 Now list them.
 
-```
+```shell
 $ build/infrakit instance --name instance-terraform describe
 ID                            	LOGICAL                       	TAGS
 instance-1475004829           	  -                           	other=values,provisioner=infrakit-terraform-example,InstancePlugin=terraform,Name=instance-1475004829,Tier=web
@@ -195,7 +195,7 @@ In AWS Console you can filter by tag `provisioner` with value `infrakit-terrafor
 
 Now destroy the instance:
 
-```
+```shell
 $ build/infrakit instance --name instance-terraform destroy instance-1475004829
 destroyed instance-1475004829
 $ build/infrakit instance --name instance-terraform describe


### PR DESCRIPTION
Additionally, remove CLI support for interacting with Flavor and Instance plugins.  Rationale being that Flavor and Instance plugins are akin to 'private' APIs that we shouldn't steer folks towards.  Instead we should build tooling around the first-class public APIs, which in this case revolve around Groups.  Once i had removed these features, the `cmd/cli/README.md` didn't seem necessary in addition to `README.md` and `docs/tutorial.md`.

Closes #217

Signed-off-by: Bill Farner <bill@docker.com>