### PR TITLE
Allow override of git revision

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,8 +2,8 @@
 PREFIX?=$(shell pwd -L)
 
 # Used to populate version variable in main package.
-VERSION=$(shell git describe --match 'v[0-9]*' --dirty='.m' --always)
-REVISION=$(shell git rev-list -1 HEAD)
+VERSION?=$(shell git describe --match 'v[0-9]*' --dirty='.m' --always)
+REVISION?=$(shell git rev-list -1 HEAD)
 
 # Allow turning off function inlining and variable registerization
 ifeq (${DISABLE_OPTIMIZATION},true)


### PR DESCRIPTION
Needed when vendoring infrakit and other use cases.

Otherwise when vendored I get the git tags of the parent project.

Signed-off-by: Justin Cormack <justin.cormack@docker.com>
