### PR TITLE
Add a script to test the tutorial command sequence

### DIFF
--- a/cmd/cli/group.go
+++ b/cmd/cli/group.go
@@ -91,6 +91,7 @@ func groupPluginCommand(plugins func() discovery.Plugins) *cobra.Command {
 		},
 	}
 
+	var quiet bool
 	inspect := &cobra.Command{
 		Use:   "inspect <group ID>",
 		Short: "inspect a group",
@@ -106,7 +107,9 @@ func groupPluginCommand(plugins func() discovery.Plugins) *cobra.Command {
 			desc, err := groupPlugin.InspectGroup(groupID)
 
 			if err == nil {
-				fmt.Printf("%-30s\t%-30s\t%-s\n", "ID", "LOGICAL", "TAGS")
+				if !quiet {
+					fmt.Printf("%-30s\t%-30s\t%-s\n", "ID", "LOGICAL", "TAGS")
+				}
 				for _, d := range desc.Instances {
 					logical := "  -   "
 					if d.LogicalID != nil {
@@ -125,6 +128,7 @@ func groupPluginCommand(plugins func() discovery.Plugins) *cobra.Command {
 			return err
 		},
 	}
+	inspect.Flags().BoolVarP(&quiet, "quiet", "q", false, "Print rows without column headers")
 
 	describe := &cobra.Command{
 		Use:   "describe <group configuration file>",
@@ -150,7 +154,7 @@ func groupPluginCommand(plugins func() discovery.Plugins) *cobra.Command {
 
 			desc, err := groupPlugin.DescribeUpdate(spec)
 			if err == nil {
-				fmt.Println(spec.ID, ":", desc)
+				fmt.Println(desc)
 			}
 			return err
 		},

--- a/cmd/cli/instance.go
+++ b/cmd/cli/instance.go
@@ -112,6 +112,7 @@ func instancePluginCommand(plugins func() discovery.Plugins) *cobra.Command {
 	}
 
 	tags := []string{}
+	var quiet bool
 	describe := &cobra.Command{
 		Use:   "describe",
 		Short: "describe the instances",
@@ -131,7 +132,9 @@ func instancePluginCommand(plugins func() discovery.Plugins) *cobra.Command {
 			desc, err := instancePlugin.DescribeInstances(filter)
 			if err == nil {
 
-				fmt.Printf("%-30s\t%-30s\t%-s\n", "ID", "LOGICAL", "TAGS")
+				if !quiet {
+					fmt.Printf("%-30s\t%-30s\t%-s\n", "ID", "LOGICAL", "TAGS")
+				}
 				for _, d := range desc {
 					logical := "  -   "
 					if d.LogicalID != nil {
@@ -152,6 +155,7 @@ func instancePluginCommand(plugins func() discovery.Plugins) *cobra.Command {
 		},
 	}
 	describe.Flags().StringSliceVar(&tags, "tags", tags, "Tags to filter")
+	describe.Flags().BoolVarP(&quiet, "quiet", "q", false, "Print rows without column headers")
 
 	cmd.AddCommand(validate, provision, destroy, describe)
 

--- a/cmd/cli/plugin.go
+++ b/cmd/cli/plugin.go
@@ -13,7 +13,8 @@ func pluginCommand(plugins func() discovery.Plugins) *cobra.Command {
 		Short: "Manage plugins",
 	}
 
-	cmd.AddCommand(&cobra.Command{
+	var quiet bool
+	ls := cobra.Command{
 		Use:   "ls",
 		Short: "List available plugins",
 		RunE: func(c *cobra.Command, args []string) error {
@@ -22,15 +23,19 @@ func pluginCommand(plugins func() discovery.Plugins) *cobra.Command {
 				return err
 			}
 
-			fmt.Println("Plugins:")
-			fmt.Printf("%-20s\t%-s\n", "NAME", "LISTEN")
+			if !quiet {
+				fmt.Printf("%-20s\t%-s\n", "NAME", "LISTEN")
+			}
 			for k, v := range entries {
 				fmt.Printf("%-20s\t%-s\n", k, v.String())
 			}
 
 			return nil
 		},
-	})
+	}
+	ls.Flags().BoolVarP(&quiet, "quiet", "q", false, "Print rows without column headers")
+
+	cmd.AddCommand(&ls)
 
 	return cmd
 }

--- a/docs/cattle.json
+++ b/docs/cattle.json
@@ -1,0 +1,27 @@
+{
+  "ID": "cattle",
+  "Properties": {
+    "Allocation": {
+      "Size": 5
+    },
+    "Instance": {
+      "Plugin": "instance-file",
+      "Properties": {
+        "Note": "Instance properties version 1.0"
+      }
+    },
+    "Flavor": {
+      "Plugin": "flavor-vanilla",
+      "Properties": {
+        "Init": [
+          "docker pull nginx:alpine",
+          "docker run -d -p 80:80 nginx-alpine"
+        ],
+        "Tags": {
+          "tier": "web",
+          "project": "infrakit"
+        }
+      }
+    }
+  }
+}

--- a/docs/cattle2.json
+++ b/docs/cattle2.json
@@ -1,0 +1,27 @@
+{
+  "ID": "cattle",
+  "Properties": {
+    "Allocation": {
+      "Size": 10
+    },
+    "Instance": {
+      "Plugin": "instance-file",
+      "Properties": {
+        "Note": "Instance properties version 2.0"
+      }
+    },
+    "Flavor": {
+      "Plugin": "flavor-vanilla",
+      "Properties": {
+        "Init": [
+          "docker pull nginx:alpine",
+          "docker run -d -p 80:80 nginx-alpine"
+        ],
+        "Tags": {
+          "tier": "web",
+          "project": "infrakit"
+        }
+      }
+    }
+  }
+}

--- a/docs/tutorial.md
+++ b/docs/tutorial.md
@@ -158,7 +158,7 @@ $ diff cattle.json cattle2.json
 Before we do an update, we can see what the proposed changes are:
 ```shell
 $ build/infrakit group describe cattle2.json 
-cattle : Performs a rolling update on 5 instances, then adds 5 instances to increase the group size to 10
+Performs a rolling update on 5 instances, then adds 5 instances to increase the group size to 10
 ```
 
 So here 5 instances will be updated via rolling update, while 5 new instances at the new configuration will

--- a/plugin/group/quorum.go
+++ b/plugin/group/quorum.go
@@ -50,6 +50,7 @@ func (q *quorum) Stop() {
 func (q *quorum) Run() {
 	ticker := time.NewTicker(q.pollInterval)
 
+	q.converge()
 	for {
 		select {
 		case <-ticker.C:

--- a/plugin/group/scaler.go
+++ b/plugin/group/scaler.go
@@ -186,6 +186,7 @@ func (s *scaler) Stop() {
 func (s *scaler) Run() {
 	ticker := time.NewTicker(s.pollInterval)
 
+	s.converge()
 	for {
 		select {
 		case <-ticker.C:

--- a/scripts/tutorial_test
+++ b/scripts/tutorial_test
@@ -1,0 +1,88 @@
+#!/usr/bin/env bash
+
+set -o errexit
+set -o nounset
+
+HERE="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+cd "$HERE"
+cd ..
+
+make binaries
+
+cleanup() {
+  kill $(jobs -p)
+  rm -rf tutorial
+}
+trap cleanup EXIT
+
+mkdir -p tutorial
+build/infrakit-instance-file --dir ./tutorial/ &
+build/infrakit-group-default &
+build/infrakit-flavor-vanilla &
+
+sleep 1
+
+expect_exact_output() {
+  message=$1
+  cmd=$2
+  expected_output=$3
+
+  echo -n "$1: "
+  if [ "$($2)" = "$3" ]
+  then
+    echo 'PASS'
+  else
+    echo 'FAIL'
+    exit 1
+  fi
+}
+
+expect_output_lines() {
+  message=$1
+  cmd=$2
+  expected_lines=$3
+
+  echo -n "$1: "
+  if [ "$($2 | wc -l)" -eq "$3" ]
+  then
+    echo 'PASS'
+  else
+    echo 'FAIL'
+    exit 1
+  fi
+}
+
+expect_output_lines "3 plugins should be discoverable" "build/infrakit plugin ls -q" "3"
+expect_output_lines "0 instances should exist" "build/infrakit instance describe -q --name instance-file" "0"
+
+build/infrakit group watch docs/cattle.json
+
+echo 'Waiting for group to be provisioned'
+sleep 2
+
+expect_output_lines "5 instances should exist in group" "build/infrakit group inspect cattle -q" "5"
+expect_output_lines "5 instances should exist" "build/infrakit instance describe -q --name instance-file" "5"
+
+expect_exact_output \
+  "Update should roll 5 and scale group to 10" \
+  "build/infrakit group describe docs/cattle2.json" \
+  "Performs a rolling update on 5 instances, then adds 5 instances to increase the group size to 10"
+
+build/infrakit group update docs/cattle2.json
+sleep 20
+
+expect_output_lines "10 instances should exist in group" "build/infrakit group inspect cattle -q" "10"
+
+# Terminate 3 instances.
+pushd tutorial
+  rm $(ls | head -3)
+popd
+
+sleep 20
+
+expect_output_lines "10 instances should exist in group" "build/infrakit group inspect cattle -q" "10"
+
+build/infrakit group destroy cattle
+expect_output_lines "0 instances should exist" "build/infrakit instance describe -q --name instance-file" "0"
+
+echo 'ALL TESTS PASSED'


### PR DESCRIPTION
I've found myself manually doing this to avoid breaking the tutorial when making other changes.  This allows me to be lazy and validate automatically :-)

If this is something we want to formalize, it would be worth including in the `make ci` target.

Signed-off-by: Bill Farner <bill@docker.com>