### PR TITLE
Use flavor.Health as feedback during rolling updates

### DIFF
--- a/cmd/cli/flavor.go
+++ b/cmd/cli/flavor.go
@@ -132,10 +132,21 @@ func flavorPluginCommand(plugins func() discovery.Plugins) *cobra.Command {
 	id := ""
 	logicalID := ""
 	healthy := &cobra.Command{
-		Use:   "healthy",
+		Use:   "healthy <flavor configuration file>",
 		Short: "checks if an instance is considered healthy",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			assertNotNil("no plugin", flavorPlugin)
+
+			if len(args) != 1 {
+				cmd.Usage()
+				os.Exit(1)
+			}
+
+			flavorProperties, err := ioutil.ReadFile(args[0])
+			if err != nil {
+				log.Error(err)
+				os.Exit(1)
+			}
 
 			filter := map[string]string{}
 			for _, t := range tags {
@@ -159,7 +170,7 @@ func flavorPluginCommand(plugins func() discovery.Plugins) *cobra.Command {
 				desc.LogicalID = &logical
 			}
 
-			healthy, err := flavorPlugin.Healthy(desc)
+			healthy, err := flavorPlugin.Healthy(json.RawMessage(flavorProperties), desc)
 			if err == nil {
 				fmt.Printf("%v\n", healthy)
 			}

--- a/example/flavor/combo/flavor.go
+++ b/example/flavor/combo/flavor.go
@@ -34,13 +34,13 @@ func (f flavorCombo) Healthy(flavorProperties json.RawMessage, inst instance.Des
 
 	s := Spec{}
 	if err := json.Unmarshal(flavorProperties, &s); err != nil {
-		return flavor.UnknownHealth, err
+		return flavor.Unknown, err
 	}
 
 	for _, pluginSpec := range s.Flavors {
 		plugin, err := f.flavorPlugins(pluginSpec.Plugin)
 		if err != nil {
-			return flavor.UnknownHealth, err
+			return flavor.Unknown, err
 		}
 
 		health, err := plugin.Healthy(types.RawMessage(pluginSpec.Properties), inst)

--- a/example/flavor/combo/flavor.go
+++ b/example/flavor/combo/flavor.go
@@ -27,8 +27,29 @@ func (f flavorCombo) Validate(flavorProperties json.RawMessage, allocation types
 	return json.Unmarshal(flavorProperties, &s)
 }
 
-func (f flavorCombo) Healthy(inst instance.Description) (bool, error) {
-	return true, nil
+func (f flavorCombo) Healthy(flavorProperties json.RawMessage, inst instance.Description) (flavor.Health, error) {
+	// The overall health of the flavor combination is taken as the 'lowest common demoninator' of the configured
+	// flavors.  Only flavor.Healthy is reported if all flavors report flavor.Healthy.  flavor.Unhealthy or
+	// flavor.UnknownHealth is returned as soon as any Flavor reports that value.
+
+	s := Spec{}
+	if err := json.Unmarshal(flavorProperties, &s); err != nil {
+		return flavor.UnknownHealth, err
+	}
+
+	for _, pluginSpec := range s.Flavors {
+		plugin, err := f.flavorPlugins(pluginSpec.Plugin)
+		if err != nil {
+			return flavor.UnknownHealth, err
+		}
+
+		health, err := plugin.Healthy(types.RawMessage(pluginSpec.Properties), inst)
+		if err != nil || health != flavor.Healthy {
+			return health, err
+		}
+	}
+
+	return flavor.Healthy, nil
 }
 
 func cloneSpec(spec instance.Spec) instance.Spec {

--- a/mock/plugin/group/group.go
+++ b/mock/plugin/group/group.go
@@ -4,6 +4,7 @@
 package group
 
 import (
+	flavor "github.com/docker/infrakit/spi/flavor"
 	instance "github.com/docker/infrakit/spi/instance"
 	gomock "github.com/golang/mock/gomock"
 )
@@ -43,6 +44,16 @@ func (_m *MockScaled) Destroy(_param0 instance.ID) {
 
 func (_mr *_MockScaledRecorder) Destroy(arg0 interface{}) *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "Destroy", arg0)
+}
+
+func (_m *MockScaled) Health(_param0 instance.Description) flavor.Health {
+	ret := _m.ctrl.Call(_m, "Health", _param0)
+	ret0, _ := ret[0].(flavor.Health)
+	return ret0
+}
+
+func (_mr *_MockScaledRecorder) Health(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "Health", arg0)
 }
 
 func (_m *MockScaled) List() ([]instance.Description, error) {

--- a/mock/spi/flavor/flavor.go
+++ b/mock/spi/flavor/flavor.go
@@ -6,6 +6,7 @@ package instance
 import (
 	json "encoding/json"
 	types "github.com/docker/infrakit/plugin/group/types"
+	flavor "github.com/docker/infrakit/spi/flavor"
 	instance "github.com/docker/infrakit/spi/instance"
 	gomock "github.com/golang/mock/gomock"
 )
@@ -31,15 +32,15 @@ func (_m *MockPlugin) EXPECT() *_MockPluginRecorder {
 	return _m.recorder
 }
 
-func (_m *MockPlugin) Healthy(_param0 instance.Description) (bool, error) {
-	ret := _m.ctrl.Call(_m, "Healthy", _param0)
-	ret0, _ := ret[0].(bool)
+func (_m *MockPlugin) Healthy(_param0 json.RawMessage, _param1 instance.Description) (flavor.Health, error) {
+	ret := _m.ctrl.Call(_m, "Healthy", _param0, _param1)
+	ret0, _ := ret[0].(flavor.Health)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-func (_mr *_MockPluginRecorder) Healthy(arg0 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "Healthy", arg0)
+func (_mr *_MockPluginRecorder) Healthy(arg0, arg1 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "Healthy", arg0, arg1)
 }
 
 func (_m *MockPlugin) Prepare(_param0 json.RawMessage, _param1 instance.Spec, _param2 types.AllocationMethod) (instance.Spec, error) {

--- a/plugin/flavor/swarm/flavor.go
+++ b/plugin/flavor/swarm/flavor.go
@@ -125,13 +125,13 @@ func (s swarmProvisioner) Healthy(flavorProperties json.RawMessage, inst instanc
 
 	nodes, err := s.client.NodeList(context.Background(), docker_types.NodeListOptions{Filter: filter})
 	if err != nil {
-		return flavor.UnknownHealth, err
+		return flavor.Unknown, err
 	}
 
 	switch {
 	case len(nodes) == 0:
 		// The instance may not yet be joined, so we consider the health unknown.
-		return flavor.UnknownHealth, nil
+		return flavor.Unknown, nil
 
 	case len(nodes) == 1:
 		return flavor.Healthy, nil

--- a/plugin/flavor/swarm/flavor_test.go
+++ b/plugin/flavor/swarm/flavor_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/docker/docker/api/types/swarm"
 	mock_client "github.com/docker/infrakit/mock/docker/docker/client"
 	"github.com/docker/infrakit/plugin/group/types"
+	"github.com/docker/infrakit/spi/flavor"
 	"github.com/docker/infrakit/spi/instance"
 	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/require"
@@ -65,9 +66,9 @@ func TestAssociation(t *testing.T) {
 	require.Contains(t, details.Init, nodeInfo.ManagerStatus.Addr)
 
 	// An instance with no association information is considered unhealthy.
-	healthy, err := helper.Healthy(instance.Description{})
+	health, err := helper.Healthy(json.RawMessage("{}"), instance.Description{})
 	require.NoError(t, err)
-	require.False(t, healthy)
+	require.Equal(t, flavor.Unhealthy, health)
 
 	filter, err := filters.FromParam(fmt.Sprintf(`{"label": {"%s=%s": true}}`, associationTag, associationID))
 	require.NoError(t, err)
@@ -75,7 +76,9 @@ func TestAssociation(t *testing.T) {
 		[]swarm.Node{
 			{},
 		}, nil)
-	healthy, err = helper.Healthy(instance.Description{Tags: map[string]string{associationTag: associationID}})
+	health, err = helper.Healthy(
+		json.RawMessage("{}"),
+		instance.Description{Tags: map[string]string{associationTag: associationID}})
 	require.NoError(t, err)
-	require.True(t, healthy)
+	require.Equal(t, flavor.Healthy, health)
 }

--- a/plugin/flavor/vanilla/flavor.go
+++ b/plugin/flavor/vanilla/flavor.go
@@ -32,8 +32,9 @@ func (f vanillaFlavor) Validate(flavorProperties json.RawMessage, allocation typ
 	return json.Unmarshal(flavorProperties, &Spec{})
 }
 
-func (f vanillaFlavor) Healthy(inst instance.Description) (bool, error) {
-	return true, nil
+func (f vanillaFlavor) Healthy(flavorProperties json.RawMessage, inst instance.Description) (flavor.Health, error) {
+	// TODO: We could add support for shell code in the Spec for a command to run for checking health.
+	return flavor.Healthy, nil
 }
 
 func (f vanillaFlavor) Prepare(

--- a/plugin/flavor/zookeeper/flavor.go
+++ b/plugin/flavor/zookeeper/flavor.go
@@ -146,9 +146,9 @@ func generateInitScript(useDocker bool, servers []instance.LogicalID, id instanc
 }
 
 // Healthy determines whether an instance is healthy.
-func (s zkFlavor) Healthy(inst instance.Description) (bool, error) {
+func (s zkFlavor) Healthy(flavorProperties json.RawMessage, inst instance.Description) (flavor.Health, error) {
 	// TODO(wfarner): Implement.
-	return true, nil
+	return flavor.Healthy, nil
 }
 
 func (s zkFlavor) Prepare(

--- a/plugin/group/group.go
+++ b/plugin/group/group.go
@@ -108,11 +108,8 @@ func (p *plugin) WatchGroup(config group.Spec) error {
 	// membership tags but different generation-specific tags.  In practice, we use this the additional tags to
 	// attach a config SHA to instances for config change detection.
 	scaled := &scaledGroup{
-		instancePlugin:   settings.instancePlugin,
-		flavorPlugin:     settings.flavorPlugin,
-		flavorProperties: types.RawMessage(settings.config.Flavor.Properties),
-		memberTags:       map[string]string{groupTag: string(config.ID)},
-		allocation:       settings.config.Allocation,
+		settings:   settings,
+		memberTags: map[string]string{groupTag: string(config.ID)},
 	}
 	scaled.changeSettings(settings)
 
@@ -264,6 +261,7 @@ func (p *plugin) StopUpdate(gid group.ID) error {
 		return fmt.Errorf("Group '%s' is not being updated", gid)
 	}
 
+	log.Infof("Stopping update for group %s", gid)
 	grp.setUpdate(nil)
 	update.Stop()
 

--- a/plugin/group/integration_test.go
+++ b/plugin/group/integration_test.go
@@ -468,7 +468,7 @@ func TestStopUpdate(t *testing.T) {
 	}()
 
 	// Wait for the first health check to ensure the update has begun.
-	<- healthChecksStarted
+	<-healthChecksStarted
 
 	require.NoError(t, grp.StopUpdate(id))
 	close(healthChecksStarted)

--- a/plugin/group/integration_test.go
+++ b/plugin/group/integration_test.go
@@ -448,7 +448,7 @@ func TestStopUpdate(t *testing.T) {
 			}
 
 			// Unknown health will stall the update indefinitely.
-			return flavor.UnknownHealth, nil
+			return flavor.Unknown, nil
 		},
 	}
 	flavorLookup := func(_ string) (flavor.Plugin, error) {

--- a/plugin/group/rollingupdate.go
+++ b/plugin/group/rollingupdate.go
@@ -87,6 +87,9 @@ func (r *rollingupdate) waitUntilQuiesced(pollInterval time.Duration, expectedNe
 			//
 			numHealthy := 0
 			for _, inst := range matching {
+				// TODO(wfarner): More careful thought is needed with respect to blocking and timeouts
+				// here.  This might mean formalizing timeout behavior for different types of RPCs in
+				// the group, and/or documenting the expectations for plugin implementations.
 				switch r.scaled.Health(inst) {
 				case flavor.Healthy:
 					numHealthy++

--- a/plugin/group/rollingupdate.go
+++ b/plugin/group/rollingupdate.go
@@ -2,7 +2,9 @@ package group
 
 import (
 	"errors"
+	"fmt"
 	log "github.com/Sirupsen/logrus"
+	"github.com/docker/infrakit/spi/flavor"
 	"github.com/docker/infrakit/spi/instance"
 	"sort"
 	"time"
@@ -64,19 +66,40 @@ func (r *rollingupdate) waitUntilQuiesced(pollInterval time.Duration, expectedNe
 				return err
 			}
 
+			// The update is only concerned with instances being created in the course of the update.
+			// The health of instances in any other state is irrelevant.  This behavior is important
+			// especially if the previous state of the group is unhealthy and the update is attempting to
+			// restore health.
 			matching, _ := desiredAndUndesiredInstances(instances, r.updatingTo)
 
-			// We are only concerned with the expected number of instances in the desired state.
-			// For example, if the original state of the group was failing to successfully create instances,
-			// old instances may never show up.  We should, however, avoid proceeding if the new instances
-			// are not showing up.
-			if len(matching) >= int(expectedNewInstances) {
+			// Now that we have isolated the instances with the new configuration, check if they are all
+			// healthy.  We do not consider an update successful until the target number of instances are
+			// confirmed healthy.
+			// The following design choices are currently implemented:
+			//
+			//   - the update will continue indefinitely if one or more instances are in the
+			//     flavor.UnknownHealth state.  Operators must stop the update and diagnose the cause.
+			//
+			//   - the update is stopped immediately if any instance enters the flavor.Unhealthy state.
+			//
+			//   - the update will proceed with other instances immediately when the currently-expected
+			//     number of instances are observed in the flavor.Healthy state.
+			//
+			numHealthy := 0
+			for _, inst := range matching {
+				switch r.scaled.Health(inst) {
+				case flavor.Healthy:
+					numHealthy++
+				case flavor.Unhealthy:
+					return fmt.Errorf("Instance %s is unhealthy", inst.ID)
+				}
+			}
+
+			if numHealthy >= int(expectedNewInstances) {
 				return nil
 			}
 
 			log.Info("Waiting for scaler to quiesce")
-
-			// TODO(wfarner): Poll ProvisionHelper.Healthy here.
 
 		case <-r.stop:
 			ticker.Stop()

--- a/plugin/group/scaled.go
+++ b/plugin/group/scaled.go
@@ -88,7 +88,7 @@ func (s *scaledGroup) Health(inst instance.Description) flavor.Health {
 		inst)
 	if err != nil {
 		log.Warnf("Failed to check health of instance %s: %s", inst.ID, err)
-		return flavor.UnknownHealth
+		return flavor.Unknown
 	}
 	return health
 

--- a/plugin/group/scaled.go
+++ b/plugin/group/scaled.go
@@ -1,7 +1,6 @@
 package group
 
 import (
-	"encoding/json"
 	"fmt"
 	log "github.com/Sirupsen/logrus"
 	"github.com/docker/infrakit/plugin/group/types"
@@ -16,6 +15,9 @@ type Scaled interface {
 	// of the instance.
 	CreateOne(id *instance.LogicalID)
 
+	// Health inspects the current health state of an instance.
+	Health(inst instance.Description) flavor.Health
+
 	// Destroy destroys a single instance.
 	Destroy(id instance.ID)
 
@@ -24,70 +26,46 @@ type Scaled interface {
 }
 
 type scaledGroup struct {
-	instancePlugin   instance.Plugin
-	memberTags       map[string]string
-	flavorPlugin     flavor.Plugin
-	flavorProperties json.RawMessage
-	provisionRequest json.RawMessage
-	provisionTags    map[string]string
-	allocation       types.AllocationMethod
-	lock             sync.Mutex
+	settings   groupSettings
+	memberTags map[string]string
+	lock       sync.Mutex
 }
 
 func (s *scaledGroup) changeSettings(settings groupSettings) {
 	s.lock.Lock()
 	defer s.lock.Unlock()
 
-	// TODO(wfarner): Consider supporting changing the plugin names as well.
-	s.flavorProperties = types.RawMessage(settings.config.Flavor.Properties)
-	s.provisionRequest = types.RawMessage(settings.config.Instance.Properties)
+	s.settings = settings
+}
+
+func (s *scaledGroup) CreateOne(logicalID *instance.LogicalID) {
+	s.lock.Lock()
+	defer s.lock.Unlock()
+
 	tags := map[string]string{}
 	for k, v := range s.memberTags {
 		tags[k] = v
 	}
 
 	// Instances are tagged with a SHA of the entire instance configuration to support change detection.
-	tags[configTag] = settings.config.InstanceHash()
-
-	s.provisionTags = tags
-}
-
-func (s *scaledGroup) getSpec(logicalID *instance.LogicalID) (instance.Spec, error) {
-	s.lock.Lock()
-	defer s.lock.Unlock()
+	tags[configTag] = s.settings.config.InstanceHash()
 
 	spec := instance.Spec{
-		Tags:       s.provisionTags,
+		Tags:       tags,
 		LogicalID:  logicalID,
-		Properties: &s.provisionRequest,
+		Properties: s.settings.config.Instance.Properties,
 	}
 
-	if s.flavorPlugin != nil {
-		// Copy tags to prevent concurrency issues if modified.
-		tags := map[string]string{}
-		for k, v := range spec.Tags {
-			tags[k] = v
-		}
-		spec.Tags = tags
-
-		var err error
-		spec, err = s.flavorPlugin.Prepare(s.flavorProperties, spec, s.allocation)
-		if err != nil {
-			return spec, err
-		}
-	}
-
-	return spec, nil
-}
-
-func (s *scaledGroup) CreateOne(logicalID *instance.LogicalID) {
-	spec, err := s.getSpec(logicalID)
+	spec, err := s.settings.flavorPlugin.Prepare(
+		types.RawMessage(s.settings.config.Flavor.Properties),
+		spec,
+		s.settings.config.Allocation)
 	if err != nil {
-		log.Errorf("Pre-provision failed: %s", err)
+		log.Errorf("Failed to Prepare instance: %s", err)
 		return
 	}
 
-	id, err := s.instancePlugin.Provision(spec)
+	id, err := s.settings.instancePlugin.Provision(spec)
 	if err != nil {
 		log.Errorf("Failed to provision: %s", err)
 		return
@@ -101,13 +79,34 @@ func (s *scaledGroup) CreateOne(logicalID *instance.LogicalID) {
 	log.Infof("Created instance %s with tags %v%s", *id, spec.Tags, volumeDesc)
 }
 
+func (s *scaledGroup) Health(inst instance.Description) flavor.Health {
+	s.lock.Lock()
+	defer s.lock.Unlock()
+
+	health, err := s.settings.flavorPlugin.Healthy(
+		types.RawMessage(s.settings.config.Flavor.Properties),
+		inst)
+	if err != nil {
+		log.Warnf("Failed to check health of instance %s: %s", inst.ID, err)
+		return flavor.UnknownHealth
+	}
+	return health
+
+}
+
 func (s *scaledGroup) Destroy(id instance.ID) {
+	s.lock.Lock()
+	defer s.lock.Unlock()
+
 	log.Infof("Destroying instance %s", id)
-	if err := s.instancePlugin.Destroy(id); err != nil {
+	if err := s.settings.instancePlugin.Destroy(id); err != nil {
 		log.Errorf("Failed to destroy %s: %s", id, err)
 	}
 }
 
 func (s *scaledGroup) List() ([]instance.Description, error) {
-	return s.instancePlugin.DescribeInstances(s.memberTags)
+	s.lock.Lock()
+	defer s.lock.Unlock()
+
+	return s.settings.instancePlugin.DescribeInstances(s.memberTags)
 }

--- a/spi/flavor/spi.go
+++ b/spi/flavor/spi.go
@@ -6,6 +6,20 @@ import (
 	"github.com/docker/infrakit/spi/instance"
 )
 
+// Health is an indication of whether the Flavor is functioning properly.
+type Health int
+
+const (
+	// UnknownHealth indicates that the Health cannot currently be confirmed.
+	UnknownHealth Health = iota
+
+	// Healthy indicates that the Flavor is confirmed to be functioning.
+	Healthy
+
+	// Unhealthy indicates that the Flavor is confirmed to not be functioning properly.
+	Unhealthy
+)
+
 // Plugin defines custom behavior for what runs on instances.
 type Plugin interface {
 
@@ -17,6 +31,6 @@ type Plugin interface {
 	// the flavor configuration.
 	Prepare(flavorProperties json.RawMessage, spec instance.Spec, allocation types.AllocationMethod) (instance.Spec, error)
 
-	// Healthy determines whether an instance is healthy.
-	Healthy(inst instance.Description) (bool, error)
+	// Healthy determines the Health of this Flavor on an instance.
+	Healthy(flavorProperties json.RawMessage, inst instance.Description) (Health, error)
 }

--- a/spi/flavor/spi.go
+++ b/spi/flavor/spi.go
@@ -10,8 +10,8 @@ import (
 type Health int
 
 const (
-	// UnknownHealth indicates that the Health cannot currently be confirmed.
-	UnknownHealth Health = iota
+	// Unknown indicates that the Health cannot currently be confirmed.
+	Unknown Health = iota
 
 	// Healthy indicates that the Flavor is confirmed to be functioning.
 	Healthy

--- a/spi/http/flavor/impl_test.go
+++ b/spi/http/flavor/impl_test.go
@@ -210,7 +210,7 @@ func TestFlavorPluginHealthyError(t *testing.T) {
 		DoHealthy: func(flavorProperties json.RawMessage, inst instance.Description) (flavor.Health, error) {
 			inputPropertiesActual <- flavorProperties
 			inputInstanceActual <- inst
-			return flavor.UnknownHealth, errors.New("oh-noes")
+			return flavor.Unknown, errors.New("oh-noes")
 		},
 	}))
 	require.NoError(t, err)


### PR DESCRIPTION
I believe i have taken reasonable and conservative measures to err on the side of safety in the course of an update.  There are many ways to make updating very sophisticated (and complicated), but for a first cut i have erred on the side of safety and simple/predictable behavior.

_Echoing comments on behavior from the source_
Rolling update implementation - ignore health of 'old' instances:
```go
// The update is only concerned with instances being created in the course of the update.
// The health of instances in any other state is irrelevant.  This behavior is important
// especially if the previous state of the group is unhealthy and the update is attempting to
// restore health.
```

Rolling update implementation - handling `Healthy()` results:
```go
// Now that we have isolated the instances with the new configuration, check if they are all
// healthy.  We do not consider an update successful until the target number of instances are
// confirmed healthy.
// The following design choices are currently implemented:
//
//   - the update will continue indefinitely if one or more instances are in the
//     flavor.UnknownHealth state.  Operators must stop the update and diagnose the cause.
//
//   - the update is stopped immediately if any instance enters the flavor.Unhealthy state.
//
//   - the update will proceed with other instances immediately when the currently-expected
//     number of instances are observed in the flavor.Healthy state.
```

Flavor combo `Healthy()` implementation:
```go
// The overall health of the flavor combination is taken as the 'lowest common demoninator' of the configured
// flavors.  Only flavor.Healthy is reported if all flavors report flavor.Healthy.  flavor.Unhealthy or
// flavor.UnknownHealth is returned as soon as any Flavor reports that value.
```

Closes #234

Signed-off-by: Bill Farner <bill@docker.com>