### PR TITLE
Add support for external template to vagrant

### DIFF
--- a/example/instance/vagrant/main.go
+++ b/example/instance/vagrant/main.go
@@ -1,12 +1,13 @@
 package main
 
 import (
+	"os"
+
 	log "github.com/Sirupsen/logrus"
 	"github.com/docker/infrakit/cli"
 	"github.com/docker/infrakit/plugin/instance/vagrant"
 	instance_plugin "github.com/docker/infrakit/spi/http/instance"
 	"github.com/spf13/cobra"
-	"os"
 )
 
 func main() {
@@ -14,6 +15,7 @@ func main() {
 	var name string
 	var logLevel int
 	var dir string
+	var template string
 
 	cmd := &cobra.Command{
 		Use:   os.Args[0],
@@ -21,7 +23,7 @@ func main() {
 		Run: func(c *cobra.Command, args []string) {
 
 			cli.SetLogLevel(logLevel)
-			cli.RunPlugin(name, instance_plugin.PluginServer(vagrant.NewVagrantPlugin(dir)))
+			cli.RunPlugin(name, instance_plugin.PluginServer(vagrant.NewVagrantPlugin(dir, template)))
 		},
 	}
 
@@ -35,6 +37,7 @@ func main() {
 		os.Exit(1)
 	}
 	cmd.Flags().StringVar(&dir, "dir", defaultDir, "Vagrant directory")
+	cmd.Flags().StringVar(&template, "template", template, "Vagrant Template file")
 
 	if err := cmd.Execute(); err != nil {
 		log.Error(err)

--- a/example/instance/vagrant/main.go
+++ b/example/instance/vagrant/main.go
@@ -3,6 +3,8 @@ package main
 import (
 	"os"
 
+	"text/template"
+
 	log "github.com/Sirupsen/logrus"
 	"github.com/docker/infrakit/cli"
 	"github.com/docker/infrakit/plugin/instance/vagrant"
@@ -15,15 +17,19 @@ func main() {
 	var name string
 	var logLevel int
 	var dir string
-	var template string
+	var templFile string
 
 	cmd := &cobra.Command{
 		Use:   os.Args[0],
 		Short: "Vagrant instance plugin",
 		Run: func(c *cobra.Command, args []string) {
+			templ := template.Must(template.New("").Parse(vagrant.VagrantFile))
+			if _, err := os.Stat(templFile); err == nil {
+				templ = template.Must(template.ParseFiles(templFile))
+			}
 
 			cli.SetLogLevel(logLevel)
-			cli.RunPlugin(name, instance_plugin.PluginServer(vagrant.NewVagrantPlugin(dir, template)))
+			cli.RunPlugin(name, instance_plugin.PluginServer(vagrant.NewVagrantPlugin(dir, templ)))
 		},
 	}
 
@@ -37,7 +43,7 @@ func main() {
 		os.Exit(1)
 	}
 	cmd.Flags().StringVar(&dir, "dir", defaultDir, "Vagrant directory")
-	cmd.Flags().StringVar(&template, "template", template, "Vagrant Template file")
+	cmd.Flags().StringVar(&templFile, "template", templFile, "Vagrant Template file")
 
 	if err := cmd.Execute(); err != nil {
 		log.Error(err)

--- a/plugin/instance/vagrant/instance.go
+++ b/plugin/instance/vagrant/instance.go
@@ -5,17 +5,24 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"github.com/docker/infrakit/spi/instance"
 	"io/ioutil"
 	"os"
 	"os/exec"
 	"path"
 	"text/template"
+
+	"github.com/docker/infrakit/spi/instance"
 )
 
 const vagrantFile = `
 Vagrant.configure("2") do |config|
   config.vm.box = "{{.Properties.Box}}"
+  {{if .Properties.BoxVersion }}
+  config.vm.box_version = "{{.Properties.BoxVersion}}"
+  {{end}}
+  {{if .Properties.BoxURL }}
+  config.vm.box_url = "{{.Properties.BoxURL}}"
+  {{end}}
   config.vm.hostname = "infrakit.box"
   config.vm.network "private_network"{{.NetworkOptions}}
 
@@ -51,9 +58,11 @@ func inheritedEnvCommand(cmdAndArgs []string, extraEnv ...string) (string, error
 }
 
 type schema struct {
-	Box    string
-	Memory int
-	CPUs   int
+	Box        string
+	BoxVersion string
+	BoxURL     string
+	Memory     int
+	CPUs       int
 }
 
 // Provision creates a new instance.

--- a/plugin/instance/vagrant/instance.go
+++ b/plugin/instance/vagrant/instance.go
@@ -27,12 +27,13 @@ Vagrant.configure("2") do |config|
 end`
 
 // NewVagrantPlugin creates an instance plugin for vagrant.
-func NewVagrantPlugin(dir string) instance.Plugin {
-	return &vagrantPlugin{VagrantfilesDir: dir}
+func NewVagrantPlugin(dir string, template string) instance.Plugin {
+	return &vagrantPlugin{VagrantfilesDir: dir, VagrantTmpl: template}
 }
 
 type vagrantPlugin struct {
 	VagrantfilesDir string
+	VagrantTmpl     string
 }
 
 // Validate performs local validation on a provision request.
@@ -73,8 +74,8 @@ func (v vagrantPlugin) Provision(spec instance.Spec) (*instance.ID, error) {
 	}
 
 	templ := template.Must(template.New("").Parse(vagrantFile))
-	if _, err := os.Stat(v.VagrantfilesDir + "vagrant.tmpl"); err == nil {
-		templ = template.Must(template.ParseFiles(v.VagrantfilesDir + "vagrant.tmpl"))
+	if _, err := os.Stat(v.VagrantTmpl); err == nil {
+		templ = template.Must(template.ParseFiles(v.VagrantTmpl))
 	}
 
 	networkOptions := `, type: "dhcp"`

--- a/templates/vagrant.tmpl
+++ b/templates/vagrant.tmpl
@@ -1,0 +1,18 @@
+Vagrant.configure("2") do |config|
+  config.vm.box = "{{.Properties.Box}}"
+  {{if .Properties.BoxVersion }}
+  config.vm.box_version = "{{.Properties.BoxVersion}}"
+  {{end}}
+  {{if .Properties.BoxURL }}
+  config.vm.box_url = "{{.Properties.BoxURL}}"
+  {{end}}
+  config.vm.hostname = "infrakit.box"
+  config.vm.network "private_network"{{.NetworkOptions}}
+
+  config.vm.provision :shell, path: "boot.sh"
+
+  config.vm.provider :virtualbox do |vb|
+    vb.memory = {{.Properties.Memory}}
+    vb.cpus = {{.Properties.CPUs}}
+  end
+end


### PR DESCRIPTION
Updated the Vagrant plugin to conditionally support using a vagrant file processed as a go template.
This allows for greater flexibility in the declaration of vagrant instance specifics, by passing the `--template` to the vagrant plugin

cc @wfarner @chungers 