### PR TITLE
Use blockcheck in docs and the build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,11 +11,11 @@ ifeq (${DISABLE_OPTIMIZATION},true)
 	VERSION:="$(VERSION)-noopt"
 endif
 
-.PHONY: clean all fmt vet lint build test vendor-update containers
+.PHONY: clean all fmt vet lint build test vendor-update containers check-docs
 .DEFAULT: all
 all: clean fmt vet lint build test binaries
 
-ci: fmt vet lint coverage
+ci: fmt vet lint check-docs coverage
 
 AUTHORS: .mailmap .git/HEAD
 	 git log --format='%aN <%aE>' | sort -fu > $@
@@ -55,6 +55,10 @@ lint:
 	$(if $(shell which golint || echo ''), , \
 		$(error Please install golint: `go get -u github.com/golang/lint/golint`))
 	@test -z "$$(golint ./... 2>&1 | grep -v ^vendor/ | grep -v mock/ | tee /dev/stderr)"
+
+check-docs:
+	@echo "+ $@"
+	find . -name '*.md' | grep -v vendor/ | blockcheck
 
 build:
 	@echo "+ $@"

--- a/README.md
+++ b/README.md
@@ -133,10 +133,9 @@ cd infrakit
 
 We recommended go version 1.7.1 or greater for all platforms.
 
-Also install a few build tools
-
+Also install a few build tools:
 ```shell
-go get -u github.com/golang/lint/golint  # if you're running tests
+go get -u github.com/golang/lint/golint github.com/wfarner/blockcheck  # if you're running tests
 ```
 
 ### Running tests

--- a/circle.yml
+++ b/circle.yml
@@ -27,7 +27,7 @@ dependencies:
     - cp -R "$HOME/$CIRCLE_PROJECT_REPONAME" "$WORKDIR"
 
     # Install dependencies
-    - cd $WORKDIR && go get github.com/axw/gocov/gocov github.com/golang/lint/golint
+    - cd $WORKDIR && go get github.com/golang/lint/golint github.com/wfarner/blockcheck
 
 test:
   override:

--- a/cmd/cli/README.md
+++ b/cmd/cli/README.md
@@ -36,8 +36,8 @@ Using the plugin `instance-file` as an example:
 
 ### Validate
 
-```
-$ cat << EOF > instance.json
+Save the folliwing in a file named `instance.json`,
+```json
 {
     "Properties": {
         "version": "v0.0.1"
@@ -49,8 +49,10 @@ $ cat << EOF > instance.json
     "Init": "#!/bin/sh\napt-get install -y wget",
     "LogicalID": "logic2"
 }
-EOF
+```
 
+and send a request for an instance plugin to validate it:
+```shell
 $ build/infrakit instance --name instance-file instance.json
 validate:ok
 ```

--- a/docs/tutorial.md
+++ b/docs/tutorial.md
@@ -66,8 +66,8 @@ So now we have the names of the plugins and their configurations.
 
 Putting everything together, we have the configuration to give to the default Group plugin:
 
-```shell
-$ cat << EOF > cattle.json
+<!-- blockcheck cattle.json -->
+```json
 {
   "ID": "cattle",
   "Properties": {
@@ -95,7 +95,6 @@ $ cat << EOF > cattle.json
     }
   }
 }
-EOF
 ```
 
 Note that we specify the number of instances via the `Size` parameter in the `flavor-vanilla` plugin.  It's possible
@@ -141,7 +140,39 @@ instance-1475104956           	  -             infrakit.config_sha=Y23cKqyRpkQ_M
 instance-1475104966           	  -             infrakit.config_sha=Y23cKqyRpkQ_M60vIq7CufFmQWk=,infrakit.group=cattle,project=infrakit,tier=web
 ```
 
-Now let's update the configuration by changing the size of the group and a property of the instance:
+Now let's update the configuration by changing the size of the group and a property of the instance.  Save this file as
+`cattle2.json`:
+
+<!-- blockcheck cattle2.json -->
+```json
+{
+  "ID": "cattle",
+  "Properties": {
+    "Allocation": {
+      "Size": 10
+    },
+    "Instance": {
+      "Plugin": "instance-file",
+      "Properties": {
+        "Note": "Instance properties version 2.0"
+      }
+    },
+    "Flavor": {
+      "Plugin": "flavor-vanilla",
+      "Properties": {
+        "Init": [
+          "docker pull nginx:alpine",
+          "docker run -d -p 80:80 nginx-alpine"
+        ],
+        "Tags": {
+          "tier": "web",
+          "project": "infrakit"
+        }
+      }
+    }
+  }
+}
+```
 
 ```shell
 $ diff cattle.json cattle2.json 

--- a/example/flavor/zookeeper/README.md
+++ b/example/flavor/zookeeper/README.md
@@ -35,6 +35,7 @@ Be sure to verify that the plugin is [discoverable](../../../cmd/cli/README.md#l
 
 Here's a JSON for the group we'd like to see [vagrant-zk.json](./vagrant-zk.json):
 
+<!-- blockcheck vagrant-zk.json -->
 ```json
 {
   "ID": "zk",


### PR DESCRIPTION
Blockcheck automates maintaining consistency between docs and files
in the repository.  This allows `scripts/tutorial_test` to avoid
code rot, and could be used more for similar purposes.

Signed-off-by: Bill Farner <bill@docker.com>