### PR TITLE
Drain instances before destroying them

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -97,7 +97,7 @@ generate:
 
 test:
 	@echo "+ $@"
-	@go test -test.short -race -v $(PKGS)
+	@go test -test.short -timeout 30s -race -v $(PKGS)
 
 coverage:
 	@echo "+ $@"

--- a/mock/plugin/group/group.go
+++ b/mock/plugin/group/group.go
@@ -38,7 +38,7 @@ func (_mr *_MockScaledRecorder) CreateOne(arg0 interface{}) *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "CreateOne", arg0)
 }
 
-func (_m *MockScaled) Destroy(_param0 instance.ID) {
+func (_m *MockScaled) Destroy(_param0 instance.Description) {
 	_m.ctrl.Call(_m, "Destroy", _param0)
 }
 

--- a/mock/spi/flavor/flavor.go
+++ b/mock/spi/flavor/flavor.go
@@ -32,6 +32,16 @@ func (_m *MockPlugin) EXPECT() *_MockPluginRecorder {
 	return _m.recorder
 }
 
+func (_m *MockPlugin) Drain(_param0 json.RawMessage, _param1 instance.Description) error {
+	ret := _m.ctrl.Call(_m, "Drain", _param0, _param1)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+func (_mr *_MockPluginRecorder) Drain(arg0, arg1 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "Drain", arg0, arg1)
+}
+
 func (_m *MockPlugin) Healthy(_param0 json.RawMessage, _param1 instance.Description) (flavor.Health, error) {
 	ret := _m.ctrl.Call(_m, "Healthy", _param0, _param1)
 	ret0, _ := ret[0].(flavor.Health)

--- a/plugin/flavor/vanilla/flavor.go
+++ b/plugin/flavor/vanilla/flavor.go
@@ -37,6 +37,11 @@ func (f vanillaFlavor) Healthy(flavorProperties json.RawMessage, inst instance.D
 	return flavor.Healthy, nil
 }
 
+func (f vanillaFlavor) Drain(flavorProperties json.RawMessage, inst instance.Description) error {
+	// TODO: We could add support for shell code in the Spec for a drain command to run.
+	return nil
+}
+
 func (f vanillaFlavor) Prepare(
 	flavor json.RawMessage,
 	instance instance.Spec,

--- a/plugin/flavor/zookeeper/flavor.go
+++ b/plugin/flavor/zookeeper/flavor.go
@@ -35,7 +35,7 @@ func parseSpec(flavorProperties json.RawMessage) (spec, error) {
 	return s, err
 }
 
-func (s zkFlavor) Validate(flavorProperties json.RawMessage, allocation types.AllocationMethod) error {
+func (z zkFlavor) Validate(flavorProperties json.RawMessage, allocation types.AllocationMethod) error {
 	properties, err := parseSpec(flavorProperties)
 	if err != nil {
 		return err
@@ -146,12 +146,17 @@ func generateInitScript(useDocker bool, servers []instance.LogicalID, id instanc
 }
 
 // Healthy determines whether an instance is healthy.
-func (s zkFlavor) Healthy(flavorProperties json.RawMessage, inst instance.Description) (flavor.Health, error) {
+func (z zkFlavor) Healthy(flavorProperties json.RawMessage, inst instance.Description) (flavor.Health, error) {
 	// TODO(wfarner): Implement.
 	return flavor.Healthy, nil
 }
 
-func (s zkFlavor) Prepare(
+func (z zkFlavor) Drain(flavorProperties json.RawMessage, inst instance.Description) error {
+	// There doesn't seem to be any need to drain ZK members, especially if they are expected to return.
+	return nil
+}
+
+func (z zkFlavor) Prepare(
 	flavorProperties json.RawMessage,
 	spec instance.Spec,
 	allocation types.AllocationMethod) (instance.Spec, error) {

--- a/plugin/group/group.go
+++ b/plugin/group/group.go
@@ -288,7 +288,7 @@ func (p *plugin) DestroyGroup(gid group.ID) error {
 	}
 
 	for _, desc := range descriptions {
-		context.scaled.Destroy(desc.ID)
+		context.scaled.Destroy(desc)
 	}
 
 	return nil

--- a/plugin/group/quorum.go
+++ b/plugin/group/quorum.go
@@ -98,7 +98,7 @@ func (q *quorum) converge() {
 		grp.Add(1)
 		go func() {
 			defer grp.Done()
-			q.scaled.Destroy(unknownInstance.ID)
+			q.scaled.Destroy(unknownInstance)
 		}()
 	}
 

--- a/plugin/group/quorum_test.go
+++ b/plugin/group/quorum_test.go
@@ -85,7 +85,7 @@ func TestRemoveUnknown(t *testing.T) {
 		scaled.EXPECT().List().Return([]instance.Description{a, b, c}, nil).AnyTimes(),
 	)
 
-	scaled.EXPECT().Destroy(d.ID)
+	scaled.EXPECT().Destroy(d)
 
 	quorum.Run()
 }

--- a/plugin/group/rollingupdate.go
+++ b/plugin/group/rollingupdate.go
@@ -149,9 +149,8 @@ func (r *rollingupdate) Run(pollInterval time.Duration) error {
 		// Sort instances first to ensure predictable destroy order.
 		sort.Sort(sortByID(undesiredInstances))
 
-		// TODO(wfarner): Provide a mechanism to gracefully drain instances.
 		// TODO(wfarner): Make the 'batch size' configurable.
-		r.scaled.Destroy(undesiredInstances[0].ID)
+		r.scaled.Destroy(undesiredInstances[0])
 
 		expectedNewInstances++
 	}

--- a/plugin/group/scaler.go
+++ b/plugin/group/scaler.go
@@ -229,7 +229,7 @@ func (s *scaler) converge() {
 		// injecting a sorter.
 		for _, toDestroy := range sorted[:remove] {
 			grp.Add(1)
-			destroy := toDestroy.ID
+			destroy := toDestroy
 			go func() {
 				defer grp.Done()
 				s.scaled.Destroy(destroy)

--- a/plugin/group/scaler_test.go
+++ b/plugin/group/scaler_test.go
@@ -47,8 +47,8 @@ func TestScaleDown(t *testing.T) {
 		scaled.EXPECT().List().Return([]instance.Description{c, d}, nil).AnyTimes(),
 	)
 
-	scaled.EXPECT().Destroy(a.ID)
-	scaled.EXPECT().Destroy(b.ID)
+	scaled.EXPECT().Destroy(a)
+	scaled.EXPECT().Destroy(b)
 
 	scaler.Run()
 }

--- a/plugin/group/testplugin.go
+++ b/plugin/group/testplugin.go
@@ -104,6 +104,7 @@ const (
 
 type testFlavor struct {
 	healthy func(flavorProperties json.RawMessage, inst instance.Description) (flavor.Health, error)
+	drain   func(flavorProperties json.RawMessage, inst instance.Description) error
 }
 
 type flavorSchema struct {
@@ -160,4 +161,12 @@ func (t testFlavor) Healthy(flavorProperties json.RawMessage, inst instance.Desc
 	}
 
 	return flavor.Healthy, nil
+}
+
+func (t testFlavor) Drain(flavorProperties json.RawMessage, inst instance.Description) error {
+	if t.drain != nil {
+		return t.drain(flavorProperties, inst)
+	}
+
+	return nil
 }

--- a/spi/flavor/spi.go
+++ b/spi/flavor/spi.go
@@ -33,4 +33,7 @@ type Plugin interface {
 
 	// Healthy determines the Health of this Flavor on an instance.
 	Healthy(flavorProperties json.RawMessage, inst instance.Description) (Health, error)
+
+	// Drain allows the flavor to perform a best-effort cleanup operation before the instance is destroyed.
+	Drain(flavorProperties json.RawMessage, inst instance.Description) error
 }


### PR DESCRIPTION
This patch changes the group to always `Drain` the flavor before `Destroy`ing instances.

Closes #235

Signed-off-by: Bill Farner <bill@docker.com>