### PR TITLE
group: add DescribeGroups()

### DIFF
--- a/cmd/cli/group.go
+++ b/cmd/cli/group.go
@@ -232,8 +232,29 @@ func groupPluginCommand(plugins func() discovery.Plugins) *cobra.Command {
 			return err
 		},
 	}
+	describeGroups := &cobra.Command{
+		Use:   "describe-groups",
+		Short: "describe the groups",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			assertNotNil("no plugin", groupPlugin)
 
-	cmd.AddCommand(watch, unwatch, inspect, describe, update, stop, destroy)
+			groups, err := groupPlugin.DescribeGroups()
+			if err == nil {
+
+				if !quiet {
+					fmt.Printf("%-30s\n", "ID")
+				}
+				for _, g := range groups {
+					fmt.Printf("%-30s\n", g.ID)
+				}
+			}
+
+			return err
+		},
+	}
+	describeGroups.Flags().BoolVarP(&quiet, "quiet", "q", false, "Print rows without column headers")
+
+	cmd.AddCommand(watch, unwatch, inspect, describe, update, stop, destroy, describeGroups)
 
 	return cmd
 }

--- a/plugin/group/group.go
+++ b/plugin/group/group.go
@@ -293,3 +293,20 @@ func (p *plugin) DestroyGroup(gid group.ID) error {
 
 	return nil
 }
+
+func (p *plugin) DescribeGroups() ([]group.Spec, error) {
+	p.lock.Lock()
+	defer p.lock.Unlock()
+	var specs []group.Spec
+	err := p.groups.forEach(func(id group.ID, ctx *groupContext) error {
+		if ctx != nil {
+			spec, err := types.UnparseProperties(string(id), ctx.settings.config)
+			if err != nil {
+				return err
+			}
+			specs = append(specs, spec)
+		}
+		return nil
+	})
+	return specs, err
+}

--- a/plugin/group/state.go
+++ b/plugin/group/state.go
@@ -85,6 +85,17 @@ func (g *groups) put(id group.ID, context *groupContext) {
 	g.byID[id] = context
 }
 
+func (g *groups) forEach(fn func(group.ID, *groupContext) error) error {
+	g.lock.Lock()
+	defer g.lock.Unlock()
+	for id, ctx := range g.byID {
+		if err := fn(id, ctx); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
 type sortByID []instance.Description
 
 func (n sortByID) Len() int {

--- a/plugin/group/types/types.go
+++ b/plugin/group/types/types.go
@@ -43,6 +43,18 @@ func ParseProperties(config group.Spec) (Spec, error) {
 	return parsed, nil
 }
 
+// UnparseProperties composes group.spec from id and props
+func UnparseProperties(id string, props Spec) (group.Spec, error) {
+	unparsed := group.Spec{ID: group.ID(id)}
+	b, err := json.Marshal(props)
+	if err != nil {
+		return unparsed, fmt.Errorf("Invalid properties: %s", err)
+	}
+	rawMessage := json.RawMessage(b)
+	unparsed.Properties = &rawMessage
+	return unparsed, nil
+}
+
 // MustParse can be wrapped over ParseProperties to panic if parsing fails.
 func MustParse(s Spec, e error) Spec {
 	if e != nil {

--- a/spi/group/spi.go
+++ b/spi/group/spi.go
@@ -20,6 +20,8 @@ type Plugin interface {
 	StopUpdate(id ID) error
 
 	DestroyGroup(id ID) error
+
+	DescribeGroups() ([]Spec, error)
 }
 
 // ID is the unique identifier for a Group.

--- a/spi/http/group/impl.go
+++ b/spi/http/group/impl.go
@@ -37,6 +37,7 @@ func PluginServer(p group.Plugin) http.Handler {
 		g.updateGroup,
 		g.stopUpdate,
 		g.destroyGroup,
+		g.describeGroups,
 	})
 }
 
@@ -157,5 +158,20 @@ func (s *groupServer) destroyGroup() (plugin.Endpoint, plugin.Handler) {
 		func(vars map[string]string, body io.Reader) (result interface{}, err error) {
 			err = s.plugin.DestroyGroup(group.ID(vars["id"]))
 			return nil, err
+		}
+}
+
+func (c *client) DescribeGroups() ([]group.Spec, error) {
+	result := []group.Spec{}
+	_, err := c.c.Call(&util.HTTPEndpoint{Method: "POST", Path: "/Group.DescribeGroups"}, nil, &result)
+	return result, err
+
+}
+
+func (s *groupServer) describeGroups() (plugin.Endpoint, plugin.Handler) {
+	return &util.HTTPEndpoint{Method: "POST", Path: "/Group.DescribeGroups"},
+
+		func(vars map[string]string, body io.Reader) (result interface{}, err error) {
+			return s.plugin.DescribeGroups()
 		}
 }

--- a/spi/http/group/impl_test.go
+++ b/spi/http/group/impl_test.go
@@ -22,6 +22,7 @@ type testPlugin struct {
 	DoUpdateGroup    func(updated group.Spec) error
 	DoStopUpdate     func(id group.ID) error
 	DoDestroyGroup   func(id group.ID) error
+	DoDescribeGroups func() ([]group.Spec, error)
 }
 
 func (t *testPlugin) WatchGroup(grp group.Spec) error {
@@ -44,6 +45,9 @@ func (t *testPlugin) StopUpdate(id group.ID) error {
 }
 func (t *testPlugin) DestroyGroup(id group.ID) error {
 	return t.DoDestroyGroup(id)
+}
+func (t *testPlugin) DescribeGroups() ([]group.Spec, error) {
+	return t.DoDescribeGroups()
 }
 
 func tempSocket() string {


### PR DESCRIPTION
This PR adds `DescribeGroups()`, which list up the available groups.

Added CLI as well.

Usage:
```console
$ infrakit group describe-groups
ID
aws-example
```
Signed-off-by: Akihiro Suda <suda.akihiro@lab.ntt.co.jp>