### PR TITLE
Swarm plugin: accept config property to restart Docker

### DIFF
--- a/example/flavor/swarm/README.md
+++ b/example/flavor/swarm/README.md
@@ -10,12 +10,14 @@ cluster in [Swarm Mode](https://docs.docker.com/engine/swarm/).
 Here's a skeleton of this Plugin's schema:
 ```json
 {
-  "Type": ""
+  "Type": "",
+  "DockerRestartCommand": ""
 }
 ```
 
 The supported fields are:
 * `Type`: The Swarm mode node type, `manager` or `worker`
+* `DockerRestartCommand`: A shell command that will restart the Docker daemon, used when adding daemon labels
 
 
 ## Example

--- a/plugin/flavor/swarm/flavor_test.go
+++ b/plugin/flavor/swarm/flavor_test.go
@@ -21,9 +21,11 @@ func TestValidate(t *testing.T) {
 
 	swarmFlavor := NewSwarmFlavor(mock_client.NewMockAPIClient(ctrl))
 
-	require.NoError(t, swarmFlavor.Validate(json.RawMessage(`{"type": "worker"}`), types.AllocationMethod{Size: 5}))
 	require.NoError(t, swarmFlavor.Validate(
-		json.RawMessage(`{"type": "manager"}`),
+		json.RawMessage(`{"Type": "worker", "DockerRestartCommand": "systemctl restart docker"}`),
+		types.AllocationMethod{Size: 5}))
+	require.NoError(t, swarmFlavor.Validate(
+		json.RawMessage(`{"Type": "manager", "DockerRestartCommand": "systemctl restart docker"}`),
 		types.AllocationMethod{LogicalIDs: []instance.LogicalID{"127.0.0.1"}}))
 	require.Error(t, swarmFlavor.Validate(json.RawMessage(`{"type": "other"}`), types.AllocationMethod{Size: 5}))
 }


### PR DESCRIPTION
After specifying the engine label, Docker must be restarted. Rather than
trying to hack around a platform-neutral way to do this, we accept a
property containing shell code to restart Docker

Signed-off-by: Bill Farner <bill@docker.com>