### PR TITLE
CLI: rename group subcommands

### DIFF
--- a/cmd/cli/group.go
+++ b/cmd/cli/group.go
@@ -136,7 +136,7 @@ func groupPluginCommand(plugins func() discovery.Plugins) *cobra.Command {
 	inspect.Flags().BoolVarP(&quiet, "quiet", "q", false, "Print rows without column headers")
 
 	describe := &cobra.Command{
-		Use:   "describe <group configuration file>",
+		Use:   "describe-update <group configuration file>",
 		Short: "describes the steps to perform an update",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			assertNotNil("no plugin", groupPlugin)
@@ -197,7 +197,7 @@ func groupPluginCommand(plugins func() discovery.Plugins) *cobra.Command {
 	}
 
 	stop := &cobra.Command{
-		Use:   "stop <group ID>",
+		Use:   "stop-update <group ID>",
 		Short: "stop updating a group",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			assertNotNil("no plugin", groupPlugin)
@@ -238,8 +238,8 @@ func groupPluginCommand(plugins func() discovery.Plugins) *cobra.Command {
 		},
 	}
 	describeGroups := &cobra.Command{
-		Use:   "describe-groups",
-		Short: "describe the groups",
+		Use:   "ls",
+		Short: "list groups",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			assertNotNil("no plugin", groupPlugin)
 

--- a/docs/tutorial.md
+++ b/docs/tutorial.md
@@ -188,7 +188,7 @@ $ diff cattle.json cattle2.json
 
 Before we do an update, we can see what the proposed changes are:
 ```shell
-$ build/infrakit group describe cattle2.json 
+$ build/infrakit group describe-update cattle2.json 
 Performs a rolling update on 5 instances, then adds 5 instances to increase the group size to 10
 ```
 

--- a/example/instance/terraform/cattle_demo.md
+++ b/example/instance/terraform/cattle_demo.md
@@ -103,7 +103,7 @@ Let's change the size to 8 and the instance type to `t2.nano`.
 Before we run we can check to see what will be done:
 
 ```shell
-$ build/infrakit group describe example/instance/terraform/aws-two-tier/group.json
+$ build/infrakit group describe-update example/instance/terraform/aws-two-tier/group.json
 terraform_demo : Performs a rolling update on 5 instances, then adds 3 instances to increase the group size to 8
 ```
 

--- a/scripts/tutorial_test
+++ b/scripts/tutorial_test
@@ -65,7 +65,7 @@ expect_output_lines "5 instances should exist" "build/infrakit instance describe
 
 expect_exact_output \
   "Update should roll 5 and scale group to 10" \
-  "build/infrakit group describe docs/cattle2.json" \
+  "build/infrakit group describe-update docs/cattle2.json" \
   "Performs a rolling update on 5 instances, then adds 5 instances to increase the group size to 10"
 
 build/infrakit group update docs/cattle2.json


### PR DESCRIPTION
Following up from discussion in #260.

`describe` becomes `describe-update`
`stop` becomes `stop-update`
`describe-groups` becomes `ls`

Signed-off-by: Bill Farner <bill@docker.com>