### PR TITLE
Update 'group describe-update' to 'group describe'

### DIFF
--- a/docs/tutorial.md
+++ b/docs/tutorial.md
@@ -188,7 +188,7 @@ $ diff cattle.json cattle2.json
 
 Before we do an update, we can see what the proposed changes are:
 ```shell
-$ build/infrakit group describe-update cattle2.json 
+$ build/infrakit group describe cattle2.json 
 Performs a rolling update on 5 instances, then adds 5 instances to increase the group size to 10
 ```
 


### PR DESCRIPTION
To align with terminal output
```
~/go/src/github.com/docker/infrakit (master) $ build/infrakit group -h
Access group plugin

Usage:
  build/infrakit group [command]

Available Commands:
  describe        describes the steps to perform an update
  describe-groups describe the groups
  destroy         destroy a group
  inspect         inspect a group
  stop            stop updating a group
  unwatch         unwatch a group
  update          update group (update < file or update filename)
  watch           watch a group

Flags:
      --name string   Name of plugin (default "group")

Global Flags:
      --log int   Logging level. 0 is least verbose. Max is 5 (default 4)

Use "build/infrakit group [command] --help" for more information about a command.
```