### PR TITLE
Swarm plugin: use explicit rather than implicit attachments

### DIFF
--- a/example/flavor/swarm/README.md
+++ b/example/flavor/swarm/README.md
@@ -11,14 +11,16 @@ Here's a skeleton of this Plugin's schema:
 ```json
 {
   "Type": "",
+  "Attachments": {},
   "DockerRestartCommand": ""
 }
 ```
 
 The supported fields are:
 * `Type`: The Swarm mode node type, `manager` or `worker`
+* `Attachments`: A mapping from logical IDs to arrays of attachment IDs to associate.  The instance plugin being used
+  defines the meaning of attachments and how to attach them.
 * `DockerRestartCommand`: A shell command that will restart the Docker daemon, used when adding daemon labels
-
 
 ## Example
 

--- a/example/flavor/swarm/swarm-vagrant-workers.json
+++ b/example/flavor/swarm/swarm-vagrant-workers.json
@@ -13,7 +13,8 @@
     "Flavor": {
       "Plugin": "flavor-swarm",
       "Properties": {
-        "Type": "worker"
+        "Type": "worker",
+        "DockerRestartCommand": "service docker restart"
       }
     }
   }


### PR DESCRIPTION
This allows the configuration to define attachments rather than trying to work with the implicit association previously done by the swarm plugin.

Signed-off-by: Bill Farner <bill@docker.com>