### PR TITLE
Leadership API + polling implementations

### DIFF
--- a/leader/file/file.go
+++ b/leader/file/file.go
@@ -4,33 +4,12 @@ import (
 	"fmt"
 	"io/ioutil"
 	"os"
-	"os/user"
-	"path/filepath"
 	"strings"
 	"time"
 
 	log "github.com/Sirupsen/logrus"
 	"github.com/docker/infrakit/leader"
 )
-
-const (
-	// LeaderFileEnvVar is the environment variable that may be used to customize the plugin leader detection
-	LeaderFileEnvVar = "INFRAKIT_LEADER_FILE"
-)
-
-// DefaultLeaderFile is the file that this detector uses to decide who the leader is.
-// In a mult-host set up, it's assumed that the file system would be share (e.g. NFS mount or S3 FUSE etc.)
-func DefaultLeaderFile() string {
-	if leaderFile := os.Getenv(LeaderFileEnvVar); leaderFile != "" {
-		return leaderFile
-	}
-
-	home := os.Getenv("HOME")
-	if usr, err := user.Current(); err == nil {
-		home = usr.HomeDir
-	}
-	return filepath.Join(home, ".infrakit/leader")
-}
 
 // NewDetector return an implementation of leader detector
 // This implementation checks a file for its content.  If the content matches the id of the detector

--- a/leader/file/file.go
+++ b/leader/file/file.go
@@ -1,0 +1,59 @@
+package file
+
+import (
+	"fmt"
+	"io/ioutil"
+	"os"
+	"os/user"
+	"path/filepath"
+	"strings"
+	"time"
+
+	log "github.com/Sirupsen/logrus"
+	"github.com/docker/infrakit/leader"
+)
+
+const (
+	// LeaderFileEnvVar is the environment variable that may be used to customize the plugin leader detection
+	LeaderFileEnvVar = "INFRAKIT_LEADER_FILE"
+)
+
+// DefaultLeaderFile is the file that this detector uses to decide who the leader is.
+// In a mult-host set up, it's assumed that the file system would be share (e.g. NFS mount or S3 FUSE etc.)
+func DefaultLeaderFile() string {
+	if leaderFile := os.Getenv(LeaderFileEnvVar); leaderFile != "" {
+		return leaderFile
+	}
+
+	home := os.Getenv("HOME")
+	if usr, err := user.Current(); err == nil {
+		home = usr.HomeDir
+	}
+	return filepath.Join(home, ".infrakit/leader")
+}
+
+// NewDetector return an implementation of leader detector
+// This implementation checks a file for its content.  If the content matches the id of the detector
+// then this instance is the leader.
+func NewDetector(pollInterval time.Duration, filename, id string) (leader.Detector, error) {
+	// file must exist
+	info, err := os.Stat(filename)
+	if err != nil {
+		return nil, err
+	}
+
+	if info.IsDir() {
+		return nil, fmt.Errorf("file %s must be a file", filename)
+	}
+
+	return leader.NewPoller(pollInterval,
+		func() (bool, error) {
+			content, err := ioutil.ReadFile(filename)
+
+			match := strings.Trim(string(content), " \t\n")
+
+			log.Debugf("ID (%s) - checked %s for leadership: %s, err=%v, leader=%v", id, filename, match, err, match == id)
+
+			return match == id, err
+		}), nil
+}

--- a/leader/file/file_test.go
+++ b/leader/file/file_test.go
@@ -1,0 +1,85 @@
+package file
+
+import (
+	"fmt"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/docker/infrakit/leader"
+	"github.com/stretchr/testify/require"
+)
+
+func TestFileDetector(t *testing.T) {
+
+	file := filepath.Join(os.TempDir(), fmt.Sprintf("%d", time.Now().UnixNano()))
+
+	err := ioutil.WriteFile(file, []byte("instance1"), 0644)
+	require.NoError(t, err)
+
+	detector1, err := NewDetector(10*time.Millisecond, file, "instance1")
+	require.NoError(t, err)
+	detector2, err := NewDetector(10*time.Millisecond, file, "instance2")
+	require.NoError(t, err)
+
+	events1, err1 := detector1.Start()
+	require.NoError(t, err1)
+	require.NotNil(t, events1)
+
+	events2, err2 := detector2.Start()
+	require.NoError(t, err2)
+	require.NotNil(t, events2)
+
+	instance1 := make(chan bool)
+	instance2 := make(chan bool)
+
+	go func() {
+		for event := range events1 {
+			if event.Status == leader.StatusLeader {
+				instance1 <- true
+			}
+		}
+	}()
+
+	go func() {
+		for event := range events2 {
+			if event.Status == leader.StatusLeader {
+				instance2 <- true
+			}
+		}
+	}()
+
+	count := 5
+	leader := []string{}
+loop:
+	for {
+		select {
+
+		case <-instance1:
+
+			// It's instance1 for a while and then we switch to instance2
+			count += -1
+			if count == 0 {
+				err = ioutil.WriteFile(file, []byte("instance2"), 0644)
+				require.NoError(t, err)
+				count = 5
+				leader = append(leader, "instance1")
+			}
+
+		case <-instance2:
+
+			count += -1
+			if count == 0 {
+				leader = append(leader, "instance2")
+				break loop
+			}
+		}
+	}
+
+	detector1.Stop()
+	detector2.Stop()
+
+	require.Equal(t, []string{"instance1", "instance2"}, leader)
+}

--- a/leader/file/file_test.go
+++ b/leader/file/file_test.go
@@ -1,10 +1,8 @@
 package file
 
 import (
-	"fmt"
 	"io/ioutil"
 	"os"
-	"path/filepath"
 	"testing"
 	"time"
 
@@ -14,14 +12,16 @@ import (
 
 func TestFileDetector(t *testing.T) {
 
-	file := filepath.Join(os.TempDir(), fmt.Sprintf("%d", time.Now().UnixNano()))
-
-	err := ioutil.WriteFile(file, []byte("instance1"), 0644)
+	dir := os.TempDir()
+	file, err := ioutil.TempFile(dir, "infrakit-file-test")
 	require.NoError(t, err)
 
-	detector1, err := NewDetector(10*time.Millisecond, file, "instance1")
+	err = ioutil.WriteFile(file.Name(), []byte("instance1"), 0644)
 	require.NoError(t, err)
-	detector2, err := NewDetector(10*time.Millisecond, file, "instance2")
+
+	detector1, err := NewDetector(10*time.Millisecond, file.Name(), "instance1")
+	require.NoError(t, err)
+	detector2, err := NewDetector(10*time.Millisecond, file.Name(), "instance2")
 	require.NoError(t, err)
 
 	events1, err1 := detector1.Start()
@@ -62,7 +62,7 @@ loop:
 			// It's instance1 for a while and then we switch to instance2
 			count += -1
 			if count == 0 {
-				err = ioutil.WriteFile(file, []byte("instance2"), 0644)
+				err = ioutil.WriteFile(file.Name(), []byte("instance2"), 0644)
 				require.NoError(t, err)
 				count = 5
 				leader = append(leader, "instance1")

--- a/leader/file/file_test.go
+++ b/leader/file/file_test.go
@@ -37,7 +37,7 @@ func TestFileDetector(t *testing.T) {
 
 	go func() {
 		for event := range events1 {
-			if event.Status == leader.StatusLeader {
+			if event.Status == leader.Leader {
 				instance1 <- true
 			}
 		}
@@ -45,7 +45,7 @@ func TestFileDetector(t *testing.T) {
 
 	go func() {
 		for event := range events2 {
-			if event.Status == leader.StatusLeader {
+			if event.Status == leader.Leader {
 				instance2 <- true
 			}
 		}

--- a/leader/leader.go
+++ b/leader/leader.go
@@ -16,6 +16,9 @@ const (
 
 // CheckLeaderFunc is all that a special backend needs to implement.  It can be used with the
 // NewPoller function to return a polling implementation of the Detector interface.
+// This function returns true or false for leadership, or errors / exceptions that arise during the check.
+// The consumer of this information will apply common criteria based on this raw data so that the implementation
+// here won't have to do its own error handling or filtering and behavior can be enforced across all implementations.
 type CheckLeaderFunc func() (bool, error)
 
 // Leadership is a struct that captures the leadership state, possibly error if exception occurs

--- a/leader/leader.go
+++ b/leader/leader.go
@@ -4,20 +4,20 @@ package leader
 type Status int
 
 const (
-	// StatusNotLeader means the current node is not a leader
-	StatusNotLeader Status = iota
+	// NotLeader means the current node is not a leader
+	NotLeader Status = iota
 
-	// StatusLeader means the current node / instance is a leader
-	StatusLeader
+	// Leader means the current node / instance is a leader
+	Leader
 
-	// StatusUnknown indicates some exception happened while determining leadership.  Consumer will interpret accordingly.
-	StatusUnknown
+	// Unknown indicates some exception happened while determining leadership.  Consumer will interpret accordingly.
+	Unknown
 )
 
 // CheckLeaderFunc is all that a special backend needs to implement.  It can be used with the
 // NewPoller function to return a polling implementation of the Detector interface.
-// This function returns true or false for leadership when there are no errors.  Return error if there
-// are errors and the poller may assume lost leadership.
+// This function returns true or false for leadership when there are no errors.  Returned error is reported and
+// the status of the event will be set to `Unknown`.
 type CheckLeaderFunc func() (bool, error)
 
 // Leadership is a struct that captures the leadership state, possibly error if exception occurs

--- a/leader/leader.go
+++ b/leader/leader.go
@@ -35,3 +35,10 @@ type Detector interface {
 	// Stop stops
 	Stop()
 }
+
+// Always is a trivial implementation that asserts the current instance to always be the leader (or not)
+func Always(leader bool) CheckLeaderFunc {
+	return func() (bool, error) {
+		return leader, nil
+	}
+}

--- a/leader/leader.go
+++ b/leader/leader.go
@@ -16,9 +16,8 @@ const (
 
 // CheckLeaderFunc is all that a special backend needs to implement.  It can be used with the
 // NewPoller function to return a polling implementation of the Detector interface.
-// This function returns true or false for leadership, or errors / exceptions that arise during the check.
-// The consumer of this information will apply common criteria based on this raw data so that the implementation
-// here won't have to do its own error handling or filtering and behavior can be enforced across all implementations.
+// This function returns true or false for leadership when there are no errors.  Return error if there
+// are errors and the poller may assume lost leadership.
 type CheckLeaderFunc func() (bool, error)
 
 // Leadership is a struct that captures the leadership state, possibly error if exception occurs

--- a/leader/leader.go
+++ b/leader/leader.go
@@ -1,0 +1,35 @@
+package leader
+
+// Status indicates leadership status
+type Status int
+
+const (
+	// StatusNotLeader means the current node is not a leader
+	StatusNotLeader Status = iota
+
+	// StatusLeader means the current node / instance is a leader
+	StatusLeader
+
+	// StatusUnknown indicates some exception happened while determining leadership.  Consumer will interpret accordingly.
+	StatusUnknown
+)
+
+// CheckLeaderFunc is all that a special backend needs to implement.  It can be used with the
+// NewPoller function to return a polling implementation of the Detector interface.
+type CheckLeaderFunc func() (bool, error)
+
+// Leadership is a struct that captures the leadership state, possibly error if exception occurs
+type Leadership struct {
+	Status Status
+	Error  error
+}
+
+// Detector is the interface for determining whether this instance is a leader
+type Detector interface {
+
+	// Start starts leadership detection
+	Start() (<-chan Leadership, error)
+
+	// Stop stops
+	Stop()
+}

--- a/leader/poller.go
+++ b/leader/poller.go
@@ -1,0 +1,75 @@
+package leader
+
+import (
+	"time"
+
+	log "github.com/Sirupsen/logrus"
+)
+
+type poller struct {
+	leaderChan   chan Leadership
+	pollInterval time.Duration
+	tick         <-chan time.Time
+	stop         chan struct{}
+	pollFunc     CheckLeaderFunc
+}
+
+// NewPoller returns a detector implementation given the poll interval and function that polls
+func NewPoller(pollInterval time.Duration, f CheckLeaderFunc) Detector {
+	return &poller{
+		pollInterval: pollInterval,
+		tick:         time.Tick(pollInterval),
+		pollFunc:     f,
+	}
+}
+
+// Start implements Detect.Start
+func (l *poller) Start() (<-chan Leadership, error) {
+	if l.leaderChan != nil {
+		return l.leaderChan, nil
+	}
+
+	l.leaderChan = make(chan Leadership)
+	l.stop = make(chan struct{})
+
+	go l.poll()
+	return l.leaderChan, nil
+}
+
+// Stop implements Detect.Stop
+func (l *poller) Stop() {
+	if l.stop != nil {
+		close(l.stop)
+	}
+}
+
+func (l *poller) poll() {
+	for {
+		select {
+
+		case <-l.tick:
+
+			isLeader, err := l.pollFunc()
+			event := Leadership{}
+			if err != nil {
+				event.Status = StatusUnknown
+				event.Error = err
+			} else {
+				if isLeader {
+					event.Status = StatusLeader
+				} else {
+					event.Status = StatusNotLeader
+				}
+			}
+
+			l.leaderChan <- event
+
+		case <-l.stop:
+			log.Infoln("Stopping leadership check")
+			close(l.leaderChan)
+			l.leaderChan = nil
+			l.stop = nil
+			return
+		}
+	}
+}

--- a/leader/poller.go
+++ b/leader/poller.go
@@ -52,13 +52,13 @@ func (l *poller) poll() {
 			isLeader, err := l.pollFunc()
 			event := Leadership{}
 			if err != nil {
-				event.Status = StatusUnknown
+				event.Status = Unknown
 				event.Error = err
 			} else {
 				if isLeader {
-					event.Status = StatusLeader
+					event.Status = Leader
 				} else {
-					event.Status = StatusNotLeader
+					event.Status = NotLeader
 				}
 			}
 

--- a/leader/poller_test.go
+++ b/leader/poller_test.go
@@ -35,4 +35,6 @@ func TestPoller(t *testing.T) {
 
 	// Expect proper stopping
 	detector.Stop()
+
+	<-events // ensures properly closed channel.
 }

--- a/leader/poller_test.go
+++ b/leader/poller_test.go
@@ -1,0 +1,38 @@
+package leader
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestPoller(t *testing.T) {
+
+	called := make(chan bool)
+	getValue := make(chan bool)
+
+	detector := NewPoller(10*time.Millisecond, func() (bool, error) {
+		called <- true
+		return <-getValue, nil
+	})
+
+	events, err := detector.Start()
+	require.NoError(t, err)
+	require.NotNil(t, events)
+
+	for {
+		didCall := <-called
+		if didCall {
+			getValue <- true
+			break
+		}
+	}
+
+	// Expect 1 event from the channel
+	event := <-events
+	require.Equal(t, StatusLeader, event.Status)
+
+	// Expect proper stopping
+	detector.Stop()
+}

--- a/leader/poller_test.go
+++ b/leader/poller_test.go
@@ -31,7 +31,7 @@ func TestPoller(t *testing.T) {
 
 	// Expect 1 event from the channel
 	event := <-events
-	require.Equal(t, StatusLeader, event.Status)
+	require.Equal(t, Leader, event.Status)
 
 	// Expect proper stopping
 	detector.Stop()

--- a/leader/swarm/swarm.go
+++ b/leader/swarm/swarm.go
@@ -12,12 +12,12 @@ import (
 // NewDetector return an implementation of leader detector
 func NewDetector(pollInterval time.Duration, client client.APIClient) leader.Detector {
 	return leader.NewPoller(pollInterval, func() (bool, error) {
-		return amISwarmLeader(client, context.Background())
+		return amISwarmLeader(context.Background(), client)
 	})
 }
 
 // amISwarmLeader determines if the current node is the swarm manager leader
-func amISwarmLeader(client client.APIClient, ctx context.Context) (bool, error) {
+func amISwarmLeader(ctx context.Context, client client.APIClient) (bool, error) {
 	info, err := client.Info(ctx)
 
 	if err != nil {

--- a/leader/swarm/swarm.go
+++ b/leader/swarm/swarm.go
@@ -1,0 +1,38 @@
+package swarm
+
+import (
+	"time"
+
+	log "github.com/Sirupsen/logrus"
+	"github.com/docker/docker/client"
+	"github.com/docker/infrakit/leader"
+	"golang.org/x/net/context"
+)
+
+// NewDetector return an implementation of leader detector
+func NewDetector(pollInterval time.Duration, client client.APIClient) leader.Detector {
+	return leader.NewPoller(pollInterval, func() (bool, error) {
+		return amISwarmLeader(client, context.Background())
+	})
+}
+
+// amISwarmLeader determines if the current node is the swarm manager leader
+func amISwarmLeader(client client.APIClient, ctx context.Context) (bool, error) {
+	info, err := client.Info(ctx)
+
+	if err != nil {
+		return false, err
+	}
+
+	// inspect itself to see if i am the leader
+	node, _, err := client.NodeInspectWithRaw(ctx, info.Swarm.NodeID)
+	if err != nil {
+		return false, err
+	}
+
+	if node.ManagerStatus == nil {
+		return false, nil
+	}
+	log.Debugln("leader=", node.ManagerStatus.Leader, "node=", node)
+	return node.ManagerStatus.Leader, nil
+}

--- a/leader/swarm/swarm_test.go
+++ b/leader/swarm/swarm_test.go
@@ -41,7 +41,7 @@ func TestSwarmDetector(t *testing.T) {
 
 	count := 10
 	for event := range events {
-		require.Equal(t, leader.StatusLeader, event.Status)
+		require.Equal(t, leader.Leader, event.Status)
 		count += -1
 		if count == 0 {
 			detector.Stop()

--- a/leader/swarm/swarm_test.go
+++ b/leader/swarm/swarm_test.go
@@ -1,0 +1,51 @@
+package swarm
+
+import (
+	"testing"
+	"time"
+
+	"github.com/docker/docker/api/types"
+	"github.com/docker/docker/api/types/swarm"
+	"github.com/docker/infrakit/leader"
+	docker_mock "github.com/docker/infrakit/mock/docker/docker/client"
+	"github.com/golang/mock/gomock"
+	"github.com/stretchr/testify/require"
+	"golang.org/x/net/context"
+)
+
+func TestSwarmDetector(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	ctx := context.Background()
+	nodeInfo := types.Info{
+		Swarm: swarm.Info{
+			NodeID: "node",
+		},
+	}
+	node := swarm.Node{
+		ManagerStatus: &swarm.ManagerStatus{
+			Leader: true,
+		},
+	}
+
+	mock := docker_mock.NewMockAPIClient(ctrl)
+	mock.EXPECT().Info(ctx).Return(nodeInfo, nil).AnyTimes()
+	mock.EXPECT().NodeInspectWithRaw(ctx, "node").Return(node, nil, nil).AnyTimes()
+
+	detector := NewDetector(10*time.Millisecond, mock)
+
+	events, err := detector.Start()
+	require.NoError(t, err)
+	require.NotNil(t, events)
+
+	count := 10
+	for event := range events {
+		require.Equal(t, leader.StatusLeader, event.Status)
+		count += -1
+		if count == 0 {
+			detector.Stop()
+		}
+	}
+	// tests that we will stop cleanly here
+}

--- a/leader/swarm/swarm_test.go
+++ b/leader/swarm/swarm_test.go
@@ -47,5 +47,6 @@ func TestSwarmDetector(t *testing.T) {
 			detector.Stop()
 		}
 	}
-	// tests that we will stop cleanly here
+
+	<-events // ensures clean stop
 }


### PR DESCRIPTION
Closes #278 

  + Simple API defined for leadership detection.  See `leader.go`
  + Two implementations are included:
    
    - Simple disk file.  To be used over a shared filesystem (e.g. NFS mount), this implementation checks for the leadership by comparing the value of a file.  If a named instance (the caller) is given an id, we can determine leadership by comparing the value of the file with the name of the instance.   This is the easiest way and is good for local testing.
     - Leadership via Swarm mode -- uses Docker API / Swarm mode to decide if *this* instance is running as leader.  This assumes InfraKit replicas are running on Docker swarm manager nodes.

Signed-off-by: David Chung <david.chung@docker.com>