### PR TITLE
CLI: add a command to get raw group configs

### DIFF
--- a/cmd/cli/main.go
+++ b/cmd/cli/main.go
@@ -24,6 +24,13 @@ func main() {
 		},
 	}
 
+	// Don't print usage text for any error returned from a RunE function.  Only print it when explicitly requested.
+	cmd.SilenceUsage = true
+
+	// Don't automatically print errors returned from a RunE function.  They are returned from cmd.Execute() below
+	// and we print it ourselves.
+	cmd.SilenceErrors = true
+
 	cmd.AddCommand(cli.VersionCommand())
 
 	f := func() discovery.Plugins {

--- a/docs/tutorial.md
+++ b/docs/tutorial.md
@@ -8,6 +8,11 @@ To illustrate the concept of working with Group, Flavor, and Instance plugins, w
 It may be helpful to familiarize yourself with [plugin discovery](../README.md#plugin-discovery) if you have not already
 done so.
 
+First, build the plugins:
+```shell
+$ make binaries
+```
+
 Start the default Group plugin
 
 ```shell
@@ -19,7 +24,7 @@ Start the file Instance plugin
 
 ```shell
 $ mkdir -p tutorial
-$ build/infrakit-instance-file --dir ./tutorial/
+$ build/infrakit-instance-file --dir ./tutorial
 INFO[0000] Listening at: ~/.infrakit/plugins/instance-file
 ```
 Note the directory `./tutorial` where the plugin will store the instances as they are provisioned.
@@ -45,7 +50,7 @@ instance-file           ~/.infrakit/plugins/instance-file
 
 Note the names of the plugin.  We will use the names in the `--name` flag of the plugin CLI to refer to them.
 
-Here we have a configuration JSON for the group.  In general, the JSON structures follow a pattern:
+Now we must create the JSOn for a group.  You will find that the JSON structures follow a pattern:
 
 ```json
 {
@@ -96,6 +101,7 @@ Putting everything together, we have the configuration to give to the default Gr
   }
 }
 ```
+*Save this as `cattle.json`*
 
 Note that we specify the number of instances via the `Size` parameter in the `flavor-vanilla` plugin.  It's possible
 that a specialized Flavor plugin doesn't even accept a size for the group, but rather computes the optimal size based on
@@ -106,7 +112,6 @@ Checking for the instances via the CLI:
 ```shell
 $ build/infrakit instance --name instance-file describe
 ID                              LOGICAL                         TAGS
-
 ```
 
 Let's tell the group plugin to `watch` our group by providing the group plugin with the configuration:
@@ -119,7 +124,7 @@ watching cattle
 The group plugin is responsible for ensuring that the infrastructure state matches with your specifications.  Since we
 started out with nothing, it will create 5 instances and maintain that state by monitoring the instances:
 ```shell
-$ build/infrakit group inspect cattle
+$ build/infrakit group describe cattle
 ID                              LOGICAL         TAGS
 instance-1475104926           	  -             infrakit.config_sha=Y23cKqyRpkQ_M60vIq7CufFmQWk=,infrakit.group=cattle,project=infrakit,tier=web
 instance-1475104936           	  -             infrakit.config_sha=Y23cKqyRpkQ_M60vIq7CufFmQWk=,infrakit.group=cattle,project=infrakit,tier=web
@@ -188,6 +193,7 @@ Now let's update the configuration by changing the size of the group and a prope
   }
 }
 ```
+*Save this as `cattle2.json`*
 
 ```shell
 $ diff cattle.json cattle2.json 
@@ -221,7 +227,7 @@ update cattle completed
 Now we can check:
 
 ```shell
-$ build/infrakit group inspect cattle
+$ build/infrakit group describe cattle
 ID                              LOGICAL         TAGS
 instance-1475105646           	  -             infrakit.config_sha=BXedrwY0GdZlHhgHmPAzxTN4oHM=,infrakit.group=cattle,project=infrakit,tier=web
 instance-1475105656           	  -             infrakit.config_sha=BXedrwY0GdZlHhgHmPAzxTN4oHM=,infrakit.group=cattle,project=infrakit,tier=web

--- a/example/instance/terraform/cattle_demo.md
+++ b/example/instance/terraform/cattle_demo.md
@@ -88,7 +88,7 @@ these instances ![instances](images/1.png)
 
 ## 5. List members
 ```shell
-$ build/infrakit group inspect terraform_demo
+$ build/infrakit group describe terraform_demo
 ID                              LOGICAL                         TAGS
 instance-1475601644               -                             Name=instance-1475601644,Tier=web,infrakit.config_sha=BmjtnDnrqBvGHm05Nin3Vb66NaA=,infrakit.group=terraform_demo,provisioner=infrakit-terraform-demo
 instance-1475601645               -                             Name=instance-1475601645,Tier=web,infrakit.config_sha=BmjtnDnrqBvGHm05Nin3Vb66NaA=,infrakit.group=terraform_demo,provisioner=infrakit-terraform-demo
@@ -117,7 +117,7 @@ update terraform_demo completed
 ## 7. Check on the group:
 
 ```shell
-$ build/infrakit group inspect terraform_demo
+$ build/infrakit group describe terraform_demo
 ID                              LOGICAL                         TAGS
 instance-1475602365               -                             Name=instance-1475602365,Tier=web,infrakit.config_sha=NP0kIk4bVoojdRZsRGC0XKTrrUs=,infrakit.group=terraform_demo,provisioner=infrakit-terraform-demo
 instance-1475602374               -                             Name=instance-1475602374,Tier=web,infrakit.config_sha=NP0kIk4bVoojdRZsRGC0XKTrrUs=,infrakit.group=terraform_demo,provisioner=infrakit-terraform-demo

--- a/plugin/group/group.go
+++ b/plugin/group/group.go
@@ -150,7 +150,7 @@ func (p *plugin) UnwatchGroup(id group.ID) error {
 	return nil
 }
 
-func (p *plugin) InspectGroup(id group.ID) (group.Description, error) {
+func (p *plugin) DescribeGroup(id group.ID) (group.Description, error) {
 	p.lock.Lock()
 	defer p.lock.Unlock()
 
@@ -294,7 +294,7 @@ func (p *plugin) DestroyGroup(gid group.ID) error {
 	return nil
 }
 
-func (p *plugin) DescribeGroups() ([]group.Spec, error) {
+func (p *plugin) InspectGroups() ([]group.Spec, error) {
 	p.lock.Lock()
 	defer p.lock.Unlock()
 	var specs []group.Spec

--- a/plugin/group/integration_test.go
+++ b/plugin/group/integration_test.go
@@ -99,7 +99,7 @@ func TestInvalidGroupCalls(t *testing.T) {
 	grp := NewGroupPlugin(pluginLookup(pluginName, plugin), flavorPluginLookup, 1*time.Millisecond)
 
 	require.Error(t, grp.DestroyGroup(id))
-	_, err := grp.InspectGroup(id)
+	_, err := grp.DescribeGroup(id)
 	require.Error(t, err)
 	require.Error(t, grp.UnwatchGroup(id))
 	require.Error(t, grp.StopUpdate(id))

--- a/rpc/group/client.go
+++ b/rpc/group/client.go
@@ -43,10 +43,10 @@ func (c *client) UnwatchGroup(id group.ID) error {
 	return nil
 }
 
-func (c *client) InspectGroup(id group.ID) (group.Description, error) {
-	req := &InspectGroupRequest{ID: id}
-	resp := &InspectGroupResponse{}
-	err := c.rpc.Call("Group.InspectGroup", req, resp)
+func (c *client) DescribeGroup(id group.ID) (group.Description, error) {
+	req := &DescribeGroupRequest{ID: id}
+	resp := &DescribeGroupResponse{}
+	err := c.rpc.Call("Group.DescribeGroup", req, resp)
 	return resp.Description, err
 }
 
@@ -90,9 +90,9 @@ func (c *client) DestroyGroup(id group.ID) error {
 	return nil
 }
 
-func (c *client) DescribeGroups() ([]group.Spec, error) {
-	req := &DescribeGroupsRequest{}
-	resp := &DescribeGroupsResponse{}
-	err := c.rpc.Call("Group.DescribeGroups", req, resp)
+func (c *client) InspectGroups() ([]group.Spec, error) {
+	req := &InspectGroupsRequest{}
+	resp := &InspectGroupsResponse{}
+	err := c.rpc.Call("Group.InspectGroups", req, resp)
 	return resp.Groups, err
 }

--- a/rpc/group/rpc_test.go
+++ b/rpc/group/rpc_test.go
@@ -16,12 +16,12 @@ import (
 type testPlugin struct {
 	DoWatchGroup     func(grp group.Spec) error
 	DoUnwatchGroup   func(id group.ID) error
-	DoInspectGroup   func(id group.ID) (group.Description, error)
+	DoDescribeGroup  func(id group.ID) (group.Description, error)
 	DoDescribeUpdate func(updated group.Spec) (string, error)
 	DoUpdateGroup    func(updated group.Spec) error
 	DoStopUpdate     func(id group.ID) error
 	DoDestroyGroup   func(id group.ID) error
-	DoDescribeGroups func() ([]group.Spec, error)
+	DoInspectGroups  func() ([]group.Spec, error)
 }
 
 func testClient(t *testing.T, socket string) group.Plugin {
@@ -36,8 +36,8 @@ func (t *testPlugin) WatchGroup(grp group.Spec) error {
 func (t *testPlugin) UnwatchGroup(id group.ID) error {
 	return t.DoUnwatchGroup(id)
 }
-func (t *testPlugin) InspectGroup(id group.ID) (group.Description, error) {
-	return t.DoInspectGroup(id)
+func (t *testPlugin) DescribeGroup(id group.ID) (group.Description, error) {
+	return t.DoDescribeGroup(id)
 }
 func (t *testPlugin) DescribeUpdate(updated group.Spec) (string, error) {
 	return t.DoDescribeUpdate(updated)
@@ -51,8 +51,8 @@ func (t *testPlugin) StopUpdate(id group.ID) error {
 func (t *testPlugin) DestroyGroup(id group.ID) error {
 	return t.DoDestroyGroup(id)
 }
-func (t *testPlugin) DescribeGroups() ([]group.Spec, error) {
-	return t.DoDescribeGroups()
+func (t *testPlugin) InspectGroups() ([]group.Spec, error) {
+	return t.DoInspectGroups()
 }
 
 func tempSocket() string {
@@ -360,14 +360,14 @@ func TestGroupPluginInspectGroup(t *testing.T) {
 	}
 
 	stop, _, err := rpc.StartPluginAtPath(socketPath, PluginServer(&testPlugin{
-		DoInspectGroup: func(req group.ID) (group.Description, error) {
+		DoDescribeGroup: func(req group.ID) (group.Description, error) {
 			idActual <- req
 			return desc, nil
 		},
 	}))
 	require.NoError(t, err)
 
-	res, err := testClient(t, socketPath).InspectGroup(id)
+	res, err := testClient(t, socketPath).DescribeGroup(id)
 	require.NoError(t, err)
 	require.Equal(t, desc, res)
 
@@ -387,14 +387,14 @@ func TestGroupPluginInspectGroupError(t *testing.T) {
 	}
 
 	stop, _, err := rpc.StartPluginAtPath(socketPath, PluginServer(&testPlugin{
-		DoInspectGroup: func(req group.ID) (group.Description, error) {
+		DoDescribeGroup: func(req group.ID) (group.Description, error) {
 			idActual <- req
 			return desc, errors.New("no")
 		},
 	}))
 	require.NoError(t, err)
 
-	_, err = testClient(t, socketPath).InspectGroup(id)
+	_, err = testClient(t, socketPath).DescribeGroup(id)
 	require.Error(t, err)
 	require.Equal(t, "no", err.Error())
 

--- a/rpc/group/service.go
+++ b/rpc/group/service.go
@@ -34,9 +34,9 @@ func (p *Group) UnwatchGroup(req *UnwatchGroupRequest, resp *UnwatchGroupRespons
 	return nil
 }
 
-// InspectGroup is the rpc method to inspect a group
-func (p *Group) InspectGroup(req *InspectGroupRequest, resp *InspectGroupResponse) error {
-	desc, err := p.plugin.InspectGroup(req.ID)
+// DescribeGroup is the rpc method to describe a group
+func (p *Group) DescribeGroup(req *DescribeGroupRequest, resp *DescribeGroupResponse) error {
+	desc, err := p.plugin.DescribeGroup(req.ID)
 	if err != nil {
 		return err
 	}
@@ -84,9 +84,9 @@ func (p *Group) DestroyGroup(req *DestroyGroupRequest, resp *DestroyGroupRespons
 	return nil
 }
 
-// DescribeGroups is the rpc method to describe groups
-func (p *Group) DescribeGroups(req *DescribeGroupsRequest, resp *DescribeGroupsResponse) error {
-	groups, err := p.plugin.DescribeGroups()
+// InspectGroups is the rpc method to inspect groups
+func (p *Group) InspectGroups(req *InspectGroupsRequest, resp *InspectGroupsResponse) error {
+	groups, err := p.plugin.InspectGroups()
 	if err != nil {
 		return err
 	}

--- a/rpc/group/types.go
+++ b/rpc/group/types.go
@@ -24,13 +24,13 @@ type UnwatchGroupResponse struct {
 	OK bool
 }
 
-// InspectGroupRequest is the rpc wrapper for the input to inspect a group
-type InspectGroupRequest struct {
+// DescribeGroupRequest is the rpc wrapper for the input to inspect a group
+type DescribeGroupRequest struct {
 	ID group.ID
 }
 
-// InspectGroupResponse is the rpc wrapper for the results from inspecting a group
-type InspectGroupResponse struct {
+// DescribeGroupResponse is the rpc wrapper for the results from inspecting a group
+type DescribeGroupResponse struct {
 	Description group.Description
 }
 
@@ -74,13 +74,13 @@ type DestroyGroupResponse struct {
 	OK bool
 }
 
-// DescribeGroupsRequest is the rpc wrapper for the input to destroy a group
-type DescribeGroupsRequest struct {
+// InspectGroupsRequest is the rpc wrapper for the input to destroy a group
+type InspectGroupsRequest struct {
 	ID group.ID
 }
 
-// DescribeGroupsResponse is the rpc wrapper for the output from destroying a group
-type DescribeGroupsResponse struct {
+// InspectGroupsResponse is the rpc wrapper for the output from destroying a group
+type InspectGroupsResponse struct {
 	Groups []group.Spec
 }
 
@@ -89,10 +89,10 @@ type DescribeGroupsResponse struct {
 type RPCService interface {
 	WatchGroup(req *WatchGroupRequest, resp *WatchGroupResponse) error
 	UnwatchGroup(req *UnwatchGroupRequest, resp *UnwatchGroupResponse) error
-	InspectGroup(req *InspectGroupRequest, resp *InspectGroupResponse) error
+	DescribeGroup(req *DescribeGroupRequest, resp *DescribeGroupResponse) error
 	DescribeUpdate(req *DescribeUpdateRequest, resp *DescribeUpdateResponse) error
 	UpdateGroup(req *UpdateGroupRequest, resp *UpdateGroupResponse) error
 	StopUpdate(req *StopUpdateRequest, resp *StopUpdateResponse) error
 	DestroyGroup(req *DestroyGroupRequest, resp *DestroyGroupResponse) error
-	DescribeGroups(req *DescribeGroupsRequest, resp *DescribeGroupsResponse) error
+	InspectGroups(req *InspectGroupsRequest, resp *InspectGroupsResponse) error
 }

--- a/scripts/tutorial_test
+++ b/scripts/tutorial_test
@@ -63,7 +63,7 @@ build/infrakit group watch docs/cattle.json
 echo 'Waiting for group to be provisioned'
 sleep 2
 
-expect_output_lines "5 instances should exist in group" "build/infrakit group inspect cattle -q" "5"
+expect_output_lines "5 instances should exist in group" "build/infrakit group describe cattle -q" "5"
 expect_output_lines "5 instances should exist" "build/infrakit instance describe -q --name instance-file" "5"
 
 build/infrakit group unwatch cattle
@@ -79,7 +79,7 @@ expect_exact_output \
 build/infrakit group update docs/cattle2.json
 sleep 20
 
-expect_output_lines "10 instances should exist in group" "build/infrakit group inspect cattle -q" "10"
+expect_output_lines "10 instances should exist in group" "build/infrakit group describe cattle -q" "10"
 
 # Terminate 3 instances.
 pushd tutorial
@@ -88,7 +88,7 @@ popd
 
 sleep 20
 
-expect_output_lines "10 instances should exist in group" "build/infrakit group inspect cattle -q" "10"
+expect_output_lines "10 instances should exist in group" "build/infrakit group describe cattle -q" "10"
 
 build/infrakit group destroy cattle
 expect_output_lines "0 instances should exist" "build/infrakit instance describe -q --name instance-file" "0"

--- a/spi/group/spi.go
+++ b/spi/group/spi.go
@@ -11,7 +11,7 @@ type Plugin interface {
 
 	UnwatchGroup(id ID) error
 
-	InspectGroup(id ID) (Description, error)
+	DescribeGroup(id ID) (Description, error)
 
 	DescribeUpdate(updated Spec) (string, error)
 
@@ -21,7 +21,7 @@ type Plugin interface {
 
 	DestroyGroup(id ID) error
 
-	DescribeGroups() ([]Spec, error)
+	InspectGroups() ([]Spec, error)
 }
 
 // ID is the unique identifier for a Group.


### PR DESCRIPTION
This seemed to make most sense with renaming the existing 'inspect'
command to 'describe'.

Signed-off-by: Bill Farner <bill@docker.com>