### PR TITLE
A very simple state storage API with two implementations

### DIFF
--- a/store/README.md
+++ b/store/README.md
@@ -1,0 +1,7 @@
+# Store API
+
+* This API is still evolving. Provided implementations may change. *
+
+The current iteration of the Store API does not define a plugin interface.  When the
+plugin interface is finalized, we expect implementations using different backends
+to reside in their own git repos.

--- a/store/file/file.go
+++ b/store/file/file.go
@@ -1,0 +1,50 @@
+package file
+
+import (
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+
+	"github.com/docker/infrakit/store"
+)
+
+type snapshot struct {
+	dir  string
+	name string
+}
+
+// NewSnapshot returns an instance of the snapshot service where data is stored in the directory given.
+// This is a simple implementation that assumes a single file for the entire snapshot.
+func NewSnapshot(dir, name string) (store.Snapshot, error) {
+	// file must exist
+	info, err := os.Stat(dir)
+	if err != nil {
+		return nil, err
+	}
+
+	if !info.IsDir() {
+		return nil, fmt.Errorf("file %s must be a directory", dir)
+	}
+
+	return &snapshot{dir: dir, name: name}, nil
+}
+
+// Save saves a snapshot of the given object and revision
+func (s *snapshot) Save(obj interface{}) error {
+	buff, err := json.MarshalIndent(obj, "  ", "  ")
+	if err != nil {
+		return err
+	}
+	return ioutil.WriteFile(filepath.Join(s.dir, s.name), buff, 0644)
+}
+
+// Load loads a snapshot and marshals into the given reference
+func (s *snapshot) Load(output interface{}) error {
+	buff, err := ioutil.ReadFile(filepath.Join(s.dir, s.name))
+	if err != nil {
+		return err
+	}
+	return json.Unmarshal(buff, output)
+}

--- a/store/store.go
+++ b/store/store.go
@@ -1,0 +1,12 @@
+package store
+
+// Snapshot provides means to save and load an object.  This is not meant to be
+// a generic k-v store.
+type Snapshot interface {
+
+	// Save marshals (encodes) and saves a snapshot of the given object.
+	Save(obj interface{}) error
+
+	// Load loads a snapshot and marshals (decodes) into the given reference
+	Load(output interface{}) error
+}

--- a/store/swarm/swarm.go
+++ b/store/swarm/swarm.go
@@ -1,0 +1,104 @@
+package swarm
+
+import (
+	"bytes"
+	"compress/zlib"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"io"
+
+	log "github.com/Sirupsen/logrus"
+	"github.com/docker/docker/api/types/swarm"
+	"github.com/docker/docker/client"
+	"github.com/docker/infrakit/store"
+	"golang.org/x/net/context"
+)
+
+const (
+	// SwarmLabel is the label for the swarm annotation that stores a compressed version of the config.
+	SwarmLabel = "infrakit"
+)
+
+type snapshot struct {
+	client client.APIClient
+}
+
+// NewSnapshot returns an instance of the snapshot service where data is stored as a label
+// in the swarm raft store.
+func NewSnapshot(client client.APIClient) (store.Snapshot, error) {
+	return &snapshot{client: client}, nil
+}
+
+// Save saves a snapshot of the given object and revision.
+func (s *snapshot) Save(obj interface{}) error {
+	label, err := encode(obj)
+	if err != nil {
+		return err
+	}
+	return writeSwarm(s.client, label)
+}
+
+// Load loads a snapshot and marshals into the given reference
+func (s *snapshot) Load(output interface{}) error {
+	label, err := readSwarm(s.client)
+	if err != nil {
+		return err
+	}
+	return decode(label, output)
+}
+
+func readSwarm(client client.APIClient) (string, error) {
+	info, err := client.SwarmInspect(context.Background())
+	if err != nil {
+		return "", err
+	}
+
+	if info.ClusterInfo.Spec.Annotations.Labels != nil {
+		if l, has := info.ClusterInfo.Spec.Annotations.Labels[SwarmLabel]; has {
+			log.Debugln("config=", l)
+			return l, nil
+		}
+	}
+	return "", fmt.Errorf("not-found")
+}
+
+func writeSwarm(client client.APIClient, value string) error {
+	info, err := client.SwarmInspect(context.Background())
+	if err != nil {
+		return err
+	}
+	if info.ClusterInfo.Spec.Annotations.Labels == nil {
+		info.ClusterInfo.Spec.Annotations.Labels = map[string]string{}
+	}
+	info.ClusterInfo.Spec.Annotations.Labels[SwarmLabel] = value
+	return client.SwarmUpdate(context.Background(), info.ClusterInfo.Meta.Version, info.ClusterInfo.Spec,
+		swarm.UpdateFlags{})
+}
+
+func encode(obj interface{}) (string, error) {
+	buff, err := json.MarshalIndent(obj, "  ", "  ")
+	if err != nil {
+		return "", err
+	}
+	var b bytes.Buffer
+	w := zlib.NewWriter(&b)
+	w.Write(buff)
+	w.Close()
+	return base64.StdEncoding.EncodeToString(b.Bytes()), nil
+}
+
+func decode(label string, output interface{}) error {
+	data, err := base64.StdEncoding.DecodeString(label)
+	if err != nil {
+		return err
+	}
+	b := bytes.NewBuffer(data)
+	r, err := zlib.NewReader(b)
+
+	var inflate bytes.Buffer
+	io.Copy(&inflate, r)
+	r.Close()
+
+	return json.Unmarshal(inflate.Bytes(), output)
+}

--- a/store/swarm/swarm_test.go
+++ b/store/swarm/swarm_test.go
@@ -1,0 +1,34 @@
+package swarm
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestEncodeDecode(t *testing.T) {
+
+	input := map[string]interface{}{
+		"Group": map[string]interface{}{
+			"managers": map[string]interface{}{
+				"Instance":   "foo",
+				"Flavor":     "bar",
+				"Allocation": []interface{}{"a", "b", "c"},
+			},
+			"workers": map[string]interface{}{
+				"Instance": "bar",
+				"Flavor":   "baz",
+			},
+		},
+	}
+
+	encoded, err := encode(input)
+	require.NoError(t, err)
+	t.Log("encoded=", encoded)
+
+	output := map[string]interface{}{}
+	err = decode(encoded, &output)
+	require.NoError(t, err)
+
+	require.Equal(t, input, output)
+}


### PR DESCRIPTION
Related #244 

This is a small API that considers storing and retrieving a state blob.  It's not to be general-purpose key-value api on purpose.  It is intentionally offering only simple save/load methods so that the consumer of this does not need to worry about the key for the value to store.  A more general key-value storage API will be introduced when it make sense.

There are two implementations:

  + File -- where the blob is stored as a well-known file
  + Swarm -- where the blob is stored as a well-known annotation in Docker's swarm mode.

Note that the parameter for the object to be saved/loaded is simply an `interface{}` at the moment because I don't want to impose some kind of schema for the state of infrakit at the moment.

Signed-off-by: David Chung <david.chung@docker.com>