### PR TITLE
Collapse `watch` and `update` commands into `commit`

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,10 +46,8 @@ for converging towards, and maintaining, that desired state.
 Therefore, a [group plugin](spi/group/spi.go) manages Groups of Instances and exposes the operations that are of
 interest to a user:
 
-  + watch/ unwatch a group (start / stop managing a group)
+  + commit a group configuration, to start managing a group
   + inspect a group
-  + trigger an update the configuration of a group - like changing its size or underlying properties of instances. 
-  + stop an update
   + destroy a group
 
 ##### Default Group plugin

--- a/cmd/cli/group.go
+++ b/cmd/cli/group.go
@@ -83,8 +83,8 @@ func groupPluginCommand(plugins func() discovery.Plugins) *cobra.Command {
 	cmd.AddCommand(&commit)
 
 	cmd.AddCommand(&cobra.Command{
-		Use:   "release <group ID>",
-		Short: "release a group from active monitoring, nondestructive",
+		Use:   "free <group ID>",
+		Short: "free a group from active monitoring, nondestructive",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			assertNotNil("no plugin", groupPlugin)
 
@@ -94,9 +94,9 @@ func groupPluginCommand(plugins func() discovery.Plugins) *cobra.Command {
 			}
 
 			groupID := group.ID(args[0])
-			err := groupPlugin.ReleaseGroup(groupID)
+			err := groupPlugin.FreeGroup(groupID)
 			if err == nil {
-				fmt.Println("Released", groupID)
+				fmt.Println("Freed", groupID)
 			}
 			return err
 		},

--- a/docs/tutorial.md
+++ b/docs/tutorial.md
@@ -145,7 +145,7 @@ instance-8430289623921829870   	  -                            	infrakit.config_
 instance-9014687032220994836   	  -                            	infrakit.config_sha=006438mMXW8gXeYtUxgf9Zbg94Y=,infrakit.group=cattle,project=infrakit,tier=web
 ```
 
-At any point you can safely `release` a group.  This is a non-destructive action, which instructs _InfraKit_ to cease
+At any point you can safely `free` a group.  This is a non-destructive action, which instructs _InfraKit_ to cease
 active monitoring.  No instances are affected, but _InfraKit_ will no longer manage them.
 ```shell
 $ build/infrakit group free cattle

--- a/docs/tutorial.md
+++ b/docs/tutorial.md
@@ -148,8 +148,8 @@ instance-9014687032220994836   	  -                            	infrakit.config_
 At any point you can safely `release` a group.  This is a non-destructive action, which instructs _InfraKit_ to cease
 active monitoring.  No instances are affected, but _InfraKit_ will no longer manage them.
 ```shell
-$ build/infrakit group release cattle
-Released cattle
+$ build/infrakit group free cattle
+Freed cattle
 ```
 
 You can `commit` the group to start monitoring it again:

--- a/docs/tutorial.md
+++ b/docs/tutorial.md
@@ -114,50 +114,55 @@ $ build/infrakit instance --name instance-file describe
 ID                              LOGICAL                         TAGS
 ```
 
-Let's tell the group plugin to `watch` our group by providing the group plugin with the configuration:
+Let's tell the group plugin to `commit` our group by providing the group plugin with the configuration:
 
 ```shell
-$ build/infrakit group watch cattle.json
-watching cattle
+$ build/infrakit group commit cattle.json
+Committed cattle: Managing 5 instances
 ```
 
 The group plugin is responsible for ensuring that the infrastructure state matches with your specifications.  Since we
 started out with nothing, it will create 5 instances and maintain that state by monitoring the instances:
 ```shell
 $ build/infrakit group describe cattle
-ID                              LOGICAL         TAGS
-instance-1475104926           	  -             infrakit.config_sha=Y23cKqyRpkQ_M60vIq7CufFmQWk=,infrakit.group=cattle,project=infrakit,tier=web
-instance-1475104936           	  -             infrakit.config_sha=Y23cKqyRpkQ_M60vIq7CufFmQWk=,infrakit.group=cattle,project=infrakit,tier=web
-instance-1475104946           	  -             infrakit.config_sha=Y23cKqyRpkQ_M60vIq7CufFmQWk=,infrakit.group=cattle,project=infrakit,tier=web
-instance-1475104956           	  -             infrakit.config_sha=Y23cKqyRpkQ_M60vIq7CufFmQWk=,infrakit.group=cattle,project=infrakit,tier=web
-instance-1475104966           	  -             infrakit.config_sha=Y23cKqyRpkQ_M60vIq7CufFmQWk=,infrakit.group=cattle,project=infrakit,tier=web
+ID                             	LOGICAL                        	TAGS
+instance-5993795900014843850   	  -                            	infrakit.config_sha=006438mMXW8gXeYtUxgf9Zbg94Y=,infrakit.group=cattle,project=infrakit,tier=web
+instance-6529053068646043018   	  -                            	infrakit.config_sha=006438mMXW8gXeYtUxgf9Zbg94Y=,infrakit.group=cattle,project=infrakit,tier=web
+instance-7203714904652099824   	  -                            	infrakit.config_sha=006438mMXW8gXeYtUxgf9Zbg94Y=,infrakit.group=cattle,project=infrakit,tier=web
+instance-8430289623921829870   	  -                            	infrakit.config_sha=006438mMXW8gXeYtUxgf9Zbg94Y=,infrakit.group=cattle,project=infrakit,tier=web
+instance-9014687032220994836   	  -                            	infrakit.config_sha=006438mMXW8gXeYtUxgf9Zbg94Y=,infrakit.group=cattle,project=infrakit,tier=web
 ```
 
 The Instance Plugin can also report instances, it will report all instances across all groups (not just `cattle`).
 
 ```shell
 $ build/infrakit instance --name instance-file describe
-ID                              LOGICAL         TAGS
-instance-1475104926           	  -             infrakit.config_sha=Y23cKqyRpkQ_M60vIq7CufFmQWk=,infrakit.group=cattle,project=infrakit,tier=web
-instance-1475104936           	  -             infrakit.config_sha=Y23cKqyRpkQ_M60vIq7CufFmQWk=,infrakit.group=cattle,project=infrakit,tier=web
-instance-1475104946           	  -             infrakit.config_sha=Y23cKqyRpkQ_M60vIq7CufFmQWk=,infrakit.group=cattle,project=infrakit,tier=web
-instance-1475104956           	  -             infrakit.config_sha=Y23cKqyRpkQ_M60vIq7CufFmQWk=,infrakit.group=cattle,project=infrakit,tier=web
-instance-1475104966           	  -             infrakit.config_sha=Y23cKqyRpkQ_M60vIq7CufFmQWk=,infrakit.group=cattle,project=infrakit,tier=web
+ID                             	LOGICAL                        	TAGS
+instance-5993795900014843850   	  -                            	infrakit.config_sha=006438mMXW8gXeYtUxgf9Zbg94Y=,infrakit.group=cattle,project=infrakit,tier=web
+instance-6529053068646043018   	  -                            	infrakit.config_sha=006438mMXW8gXeYtUxgf9Zbg94Y=,infrakit.group=cattle,project=infrakit,tier=web
+instance-7203714904652099824   	  -                            	infrakit.config_sha=006438mMXW8gXeYtUxgf9Zbg94Y=,infrakit.group=cattle,project=infrakit,tier=web
+instance-8430289623921829870   	  -                            	infrakit.config_sha=006438mMXW8gXeYtUxgf9Zbg94Y=,infrakit.group=cattle,project=infrakit,tier=web
+instance-9014687032220994836   	  -                            	infrakit.config_sha=006438mMXW8gXeYtUxgf9Zbg94Y=,infrakit.group=cattle,project=infrakit,tier=web
 ```
 
-At any point you can safely `unwatch` a group.  This will instruct _InfraKit_ to cease active monitoring:
+At any point you can safely `release` a group.  This is a non-destructive action, which instructs _InfraKit_ to cease
+active monitoring.  No instances are affected, but _InfraKit_ will no longer manage them.
 ```shell
-$ build/infrakit group unwatch cattle
+$ build/infrakit group release cattle
+Released cattle
 ```
 
-You can `watch` the group to start monitoring it again:
+You can `commit` the group to start monitoring it again:
 ```shell
-$ build/infrakit group watch cattle.json
+$ build/infrakit group commit cattle.json
+Committed cattle: Managing 5 instances
 ```
 
-Check which groups are being watched:
+Check which groups are being managed:
 ```shell
 $ build/infrakit group ls
+ID
+cattle
 ```
 
 Now let's update the configuration by changing the size of the group and a property of the instance.  Save this file as
@@ -209,8 +214,8 @@ $ diff cattle.json cattle2.json
 
 Before we do an update, we can see what the proposed changes are:
 ```shell
-$ build/infrakit group describe-update cattle2.json 
-Performs a rolling update on 5 instances, then adds 5 instances to increase the group size to 10
+$ build/infrakit group commit cattle2.json --pretend 
+Committing cattle would involve: Performing a rolling update on 5 instances, then adding 5 instances to increase the group size to 10
 ```
 
 So here 5 instances will be updated via rolling update, while 5 new instances at the new configuration will
@@ -219,51 +224,48 @@ be created.
 Let's apply the new config:
 
 ```shell
-$ build/infrakit group update cattle2.json 
-
-# ..... wait a bit...
-update cattle completed
+$ build/infrakit group commit cattle2.json 
+Committed cattle: Performing a rolling update on 5 instances, then adding 5 instances to increase the group size to 10
 ```
-Now we can check:
 
+If we poll the group, we can see state will converging until all instances have been updated:
 ```shell
 $ build/infrakit group describe cattle
-ID                              LOGICAL         TAGS
-instance-1475105646           	  -             infrakit.config_sha=BXedrwY0GdZlHhgHmPAzxTN4oHM=,infrakit.group=cattle,project=infrakit,tier=web
-instance-1475105656           	  -             infrakit.config_sha=BXedrwY0GdZlHhgHmPAzxTN4oHM=,infrakit.group=cattle,project=infrakit,tier=web
-instance-1475105666           	  -             infrakit.config_sha=BXedrwY0GdZlHhgHmPAzxTN4oHM=,infrakit.group=cattle,project=infrakit,tier=web
-instance-1475105676           	  -             infrakit.config_sha=BXedrwY0GdZlHhgHmPAzxTN4oHM=,infrakit.group=cattle,project=infrakit,tier=web
-instance-1475105686           	  -             infrakit.config_sha=BXedrwY0GdZlHhgHmPAzxTN4oHM=,infrakit.group=cattle,project=infrakit,tier=web
-instance-1475105696           	  -             infrakit.config_sha=BXedrwY0GdZlHhgHmPAzxTN4oHM=,infrakit.group=cattle,project=infrakit,tier=web
-instance-1475105706           	  -             infrakit.config_sha=BXedrwY0GdZlHhgHmPAzxTN4oHM=,infrakit.group=cattle,project=infrakit,tier=web
-instance-1475105716           	  -             infrakit.config_sha=BXedrwY0GdZlHhgHmPAzxTN4oHM=,infrakit.group=cattle,project=infrakit,tier=web
-instance-1475105726           	  -             infrakit.config_sha=BXedrwY0GdZlHhgHmPAzxTN4oHM=,infrakit.group=cattle,project=infrakit,tier=web
-instance-1475105736           	  -             infrakit.config_sha=BXedrwY0GdZlHhgHmPAzxTN4oHM=,infrakit.group=cattle,project=infrakit,tier=web
+ID                             	LOGICAL                        	TAGS
+instance-1422140834255860063   	  -                            	infrakit.config_sha=eB2JuP0c5Sf41X5e2vc2gJ4ZTVg=,infrakit.group=cattle,project=infrakit,tier=web
+instance-1478871890164117825   	  -                            	infrakit.config_sha=eB2JuP0c5Sf41X5e2vc2gJ4ZTVg=,infrakit.group=cattle,project=infrakit,tier=web
+instance-1507972539885141336   	  -                            	infrakit.config_sha=eB2JuP0c5Sf41X5e2vc2gJ4ZTVg=,infrakit.group=cattle,project=infrakit,tier=web
+instance-1665488406863611296   	  -                            	infrakit.config_sha=eB2JuP0c5Sf41X5e2vc2gJ4ZTVg=,infrakit.group=cattle,project=infrakit,tier=web
+instance-2340140454359833670   	  -                            	infrakit.config_sha=eB2JuP0c5Sf41X5e2vc2gJ4ZTVg=,infrakit.group=cattle,project=infrakit,tier=web
+instance-2796731287627125229   	  -                            	infrakit.config_sha=eB2JuP0c5Sf41X5e2vc2gJ4ZTVg=,infrakit.group=cattle,project=infrakit,tier=web
+instance-285480170677988698    	  -                            	infrakit.config_sha=eB2JuP0c5Sf41X5e2vc2gJ4ZTVg=,infrakit.group=cattle,project=infrakit,tier=web
+instance-4084455402433225349   	  -                            	infrakit.config_sha=eB2JuP0c5Sf41X5e2vc2gJ4ZTVg=,infrakit.group=cattle,project=infrakit,tier=web
+instance-5591036640758692177   	  -                            	infrakit.config_sha=eB2JuP0c5Sf41X5e2vc2gJ4ZTVg=,infrakit.group=cattle,project=infrakit,tier=web
+instance-6810420924276316298   	  -                            	infrakit.config_sha=eB2JuP0c5Sf41X5e2vc2gJ4ZTVg=,infrakit.group=cattle,project=infrakit,tier=web
 ```
 
-Note the instances now have a new SHA `BXedrwY0GdZlHhgHmPAzxTN4oHM=` (vs `Y23cKqyRpkQ_M60vIq7CufFmQWk=` previously)
+Note the instances now have a new SHA `eB2JuP0c5Sf41X5e2vc2gJ4ZTVg=` (vs `006438mMXW8gXeYtUxgf9Zbg94Y_M60vIq7CufFmQWk=` previously)
 
 To see that the Group plugin can enforce the size of the group, let's simulate an instance disappearing.
 
 ```shell
-$ rm tutorial/instance-1475105646 tutorial/instance-1475105686 tutorial/instance-1475105726
+$ rm tutorial/instance-1422140834255860063 tutorial/instance-1478871890164117825 tutorial/instance-1507972539885141336
+```
 
-# ... now check
-
-$ ls -al tutorial
-total 104
-drwxr-xr-x  15 davidchung  staff   510 Sep 28 16:40 .
-drwxr-xr-x  36 davidchung  staff  1224 Sep 28 16:39 ..
--rw-r--r--   1 davidchung  staff   654 Sep 28 16:34 instance-1475105656
--rw-r--r--   1 davidchung  staff   654 Sep 28 16:34 instance-1475105666
--rw-r--r--   1 davidchung  staff   654 Sep 28 16:34 instance-1475105676
--rw-r--r--   1 davidchung  staff   654 Sep 28 16:34 instance-1475105696
--rw-r--r--   1 davidchung  staff   654 Sep 28 16:35 instance-1475105706
--rw-r--r--   1 davidchung  staff   654 Sep 28 16:35 instance-1475105716
--rw-r--r--   1 davidchung  staff   654 Sep 28 16:35 instance-1475105736
--rw-r--r--   1 davidchung  staff   654 Sep 28 16:40 instance-1475106016 <-- new instance
--rw-r--r--   1 davidchung  staff   654 Sep 28 16:40 instance-1475106026 <-- new instance
--rw-r--r--   1 davidchung  staff   654 Sep 28 16:40 instance-1475106036 <-- new instance
+After a few moments, the missing instances will be replaced (we've highlighted new instances with `-->`):
+```shell
+$ build/infrakit group describe cattle
+ID                             	LOGICAL                        	TAGS
+--> instance-1265288729718091217   	  -                            	infrakit.config_sha=eB2JuP0c5Sf41X5e2vc2gJ4ZTVg=,infrakit.group=cattle,project=infrakit,tier=web
+instance-1665488406863611296   	  -                            	infrakit.config_sha=eB2JuP0c5Sf41X5e2vc2gJ4ZTVg=,infrakit.group=cattle,project=infrakit,tier=web
+--> instance-1952247477026188949   	  -                            	infrakit.config_sha=eB2JuP0c5Sf41X5e2vc2gJ4ZTVg=,infrakit.group=cattle,project=infrakit,tier=web
+instance-2340140454359833670   	  -                            	infrakit.config_sha=eB2JuP0c5Sf41X5e2vc2gJ4ZTVg=,infrakit.group=cattle,project=infrakit,tier=web
+instance-2796731287627125229   	  -                            	infrakit.config_sha=eB2JuP0c5Sf41X5e2vc2gJ4ZTVg=,infrakit.group=cattle,project=infrakit,tier=web
+instance-285480170677988698    	  -                            	infrakit.config_sha=eB2JuP0c5Sf41X5e2vc2gJ4ZTVg=,infrakit.group=cattle,project=infrakit,tier=web
+instance-4084455402433225349   	  -                            	infrakit.config_sha=eB2JuP0c5Sf41X5e2vc2gJ4ZTVg=,infrakit.group=cattle,project=infrakit,tier=web
+--> instance-4161733946225446641   	  -                            	infrakit.config_sha=eB2JuP0c5Sf41X5e2vc2gJ4ZTVg=,infrakit.group=cattle,project=infrakit,tier=web
+instance-5591036640758692177   	  -                            	infrakit.config_sha=eB2JuP0c5Sf41X5e2vc2gJ4ZTVg=,infrakit.group=cattle,project=infrakit,tier=web
+instance-6810420924276316298   	  -                            	infrakit.config_sha=eB2JuP0c5Sf41X5e2vc2gJ4ZTVg=,infrakit.group=cattle,project=infrakit,tier=web
 ```
 
 We see that 3 new instance have been created to replace the three removed, to match our
@@ -277,7 +279,7 @@ $ build/infrakit group destroy cattle
 
 This concludes our quick tutorial.  In this tutorial we:
   + Started the plugins and learned to access them
-  + Created a configuration for a group we wanted to watch
+  + Created a configuration for a group we wanted to manage
   + Verified the instances created matched the specifications
   + Updated the configurations of the group and scaled up the group
   + Reviewed the proposed changes

--- a/example/flavor/combo/README.md
+++ b/example/flavor/combo/README.md
@@ -57,10 +57,10 @@ $ build/infrakit-flavor-combo
 INFO[0000] Listening at: ~/.infrakit/plugins/flavor-combo
 ```
 
-Using the [example](example.json) configuration, start watching a group:
+Using the [example](example.json) configuration, commit a group:
 ```shell
-$ build/infrakit group watch example/flavor/combo/example.json
-watching combo
+$ build/infrakit group commit example/flavor/combo/example.json
+Committed combo
 ```
 
 You will notice that the configuration is somewhat nonsensical, as the result could have been achieved without

--- a/example/flavor/swarm/README.md
+++ b/example/flavor/swarm/README.md
@@ -65,7 +65,7 @@ fetched from.  In this case, we are pointing at the yet-to-be-created Swarm mana
 Next, create the [manager node](swarm-vagrant-manager.json) and initialize the cluster:
 
 ```shell
-$ build/infrakit group watch example/flavor/swarm/swarm-vagrant-manager.json
+$ build/infrakit group commit example/flavor/swarm/swarm-vagrant-manager.json
 ```
 
 Once the first node has been successfully created, confirm that the Swarm was initialized:
@@ -77,7 +77,7 @@ exid5ftbv15pgqkfzastnpw9n *  infrakit  Ready   Active        Leader
  
 Now the [worker group](swarm-vagrant-workers.json) may be created:
 ```shell
-$ build/infrakit group watch example/flavor/swarm/swarm-vagrant-workers.json
+$ build/infrakit group commit example/flavor/swarm/swarm-vagrant-workers.json
 ```
 
 Once completed, the cluster contains two nodes:

--- a/example/flavor/zookeeper/README.md
+++ b/example/flavor/zookeeper/README.md
@@ -59,9 +59,9 @@ Here's a JSON for the group we'd like to see [vagrant-zk.json](./vagrant-zk.json
 }
 ```
 
-Now tell the group plugin to watch the zk group, create if necessary:
+Now commit the group configuration:
 
 ```shell
-$ build/infrakit group watch ./vagrant-zk.json
+$ build/infrakit group commit vagrant-zk.json
 watching zk
 ```

--- a/example/instance/terraform/cattle_demo.md
+++ b/example/instance/terraform/cattle_demo.md
@@ -74,13 +74,13 @@ $ build/infrakit instance --name=instance-terraform describe
 ID                                                LOGICAL                               TAGS
 # no instances
 ```
-## 4.  Start watching!
+## 4. Commit the group
 
-Using the JSON we showed above, start watching this group:
+Using the JSON we showed above, commit the group:
 
 ```shell
-$ build/infrakit group watch example/instance/terraform/aws-two-tier/group.json
-watching terraform_demo
+$ build/infrakit group commit example/instance/terraform/aws-two-tier/group.json
+Committed terraform_demo
 ```
 The group plugin starts to create new instances to match the specification.
 In the AWS console using `infrakit-terraform-demo` as tag filter, we find 
@@ -100,22 +100,23 @@ instance-1475601636               -                             Name=instance-14
 ## 6. Update the config
 Let's change the size to 8 and the instance type to `t2.nano`.  
 
-Before we run we can check to see what will be done:
+Before committing, let's use the `--pretend` flag to double-check what will happen:
 
 ```shell
-$ build/infrakit group describe-update example/instance/terraform/aws-two-tier/group.json
-terraform_demo : Performs a rolling update on 5 instances, then adds 3 instances to increase the group size to 8
+$ build/infrakit group commit example/instance/terraform/aws-two-tier/group.json --pretend
+Committing terraform_demo will involve: Performing a rolling update on 5 instances, then adding 3 instances to increase the group size to 8
 ```
 
 Looks good.  Let's commit:
 
 ```shell
-$ build/infrakit group update example/instance/terraform/aws-two-tier/group.json
-update terraform_demo completed
+$ build/infrakit group commit example/instance/terraform/aws-two-tier/group.json
+Committed terraform_demo
 ```
 
 ## 7. Check on the group:
 
+The commit will proceed in the background, and after a short period the group will converge to the new configuration:
 ```shell
 $ build/infrakit group describe terraform_demo
 ID                              LOGICAL                         TAGS

--- a/manager/manager.go
+++ b/manager/manager.go
@@ -260,7 +260,7 @@ func (m *manager) onLostLeadership() error {
 	if err != nil {
 		return err
 	}
-	return m.doReleaseGroups(config)
+	return m.doFreeGroups(config)
 }
 
 func (m *manager) doCommit() error {
@@ -295,15 +295,15 @@ func (m *manager) doCommitGroups(config GlobalSpec) error {
 		})
 }
 
-func (m *manager) doReleaseGroups(config GlobalSpec) error {
-	log.Infoln("Releasing groups")
+func (m *manager) doFreeGroups(config GlobalSpec) error {
+	log.Infoln("Freeing groups")
 	return m.execPlugins(config,
 		func(plugin group.Plugin, spec group.Spec) error {
 
-			log.Infoln("Releasing group", spec.ID)
+			log.Infoln("Freeing group", spec.ID)
 			err := plugin.FreeGroup(spec.ID)
 			if err != nil {
-				log.Warningln("Error releasing group:", spec.ID, "Err=", err)
+				log.Warningln("Error freeing group:", spec.ID, "Err=", err)
 			}
 			return nil
 		})

--- a/manager/manager.go
+++ b/manager/manager.go
@@ -3,9 +3,9 @@ package manager
 import (
 	"encoding/json"
 	"fmt"
-	"strings"
 	"sync"
 
+	"errors"
 	log "github.com/Sirupsen/logrus"
 	"github.com/docker/infrakit/discovery"
 	"github.com/docker/infrakit/leader"
@@ -48,7 +48,10 @@ type backendOp struct {
 
 // NewManager returns the manager which depends on other services to coordinate and manage
 // the plugins in order to ensure the infrastructure state matches the user's spec.
-func NewManager(plugins discovery.Plugins, leader leader.Detector, snapshot store.Snapshot,
+func NewManager(
+	plugins discovery.Plugins,
+	leader leader.Detector,
+	snapshot store.Snapshot,
 	backendName string) (Backend, error) {
 
 	m := &manager{
@@ -113,7 +116,7 @@ func (m *manager) Start() (<-chan struct{}, error) {
 				if m.isLeader {
 					op.err <- op.operation()
 				} else {
-					op.err <- fmt.Errorf("not-a-leader")
+					op.err <- errors.New("not-a-leader")
 				}
 
 			case <-stopWorkQueue:
@@ -248,7 +251,7 @@ func (m *manager) onAssumeLeadership() error {
 	if err != nil {
 		return err
 	}
-	return m.doWatchGroups(config)
+	return m.doCommitGroups(config)
 }
 
 func (m *manager) onLostLeadership() error {
@@ -257,7 +260,7 @@ func (m *manager) onLostLeadership() error {
 	if err != nil {
 		return err
 	}
-	return m.doUnwatchGroups(config)
+	return m.doReleaseGroups(config)
 }
 
 func (m *manager) doCommit() error {
@@ -271,67 +274,36 @@ func (m *manager) doCommit() error {
 		return err
 	}
 
-	log.Infoln("Committing.  Loaded snapshot. err=", err)
+	log.Infoln("Committing. Loaded snapshot. err=", err)
 	if err != nil {
 		return err
 	}
-	return m.doUpdateGroups(config)
+	return m.doCommitGroups(config)
 }
 
-func (m *manager) doUpdateGroups(config GlobalSpec) error {
+func (m *manager) doCommitGroups(config GlobalSpec) error {
 	return m.execPlugins(config,
 		func(plugin group.Plugin, spec group.Spec) error {
 
-			log.Infoln("UPDATE group", spec.ID, "with spec:", spec)
-			err := plugin.UpdateGroup(spec)
+			log.Infoln("Committing group", spec.ID, "with spec:", spec)
 
-			// TODO(chungers) -- yes this is clunky comparing error text -- replace with typed error / code later.
-			if err != nil && strings.Contains(err.Error(), "not being watched") {
-
-				log.Infoln("UPDATE group", spec.ID, "changed to WATCH")
-				err = plugin.WatchGroup(spec)
-
-			}
-
+			_, err := plugin.CommitGroup(spec, false)
 			if err != nil {
-				log.Warningln("Error updating/watch group:", spec.ID, "Err=", err)
+				log.Warningln("Error committing group:", spec.ID, "Err=", err)
 			}
 			return err
 		})
 }
 
-func (m *manager) doWatchGroups(config GlobalSpec) error {
-	log.Infoln("Start watching groups")
+func (m *manager) doReleaseGroups(config GlobalSpec) error {
+	log.Infoln("Releasing groups")
 	return m.execPlugins(config,
 		func(plugin group.Plugin, spec group.Spec) error {
 
-			log.Infoln("WATCH group", spec.ID, "with spec:", spec)
-			err := plugin.WatchGroup(spec)
-
-			// TODO(chungers) -- yes this is clunky with string comparison of error text.
-			// Consider adding return code or error types for the Group SPI.
-			if err != nil && strings.Contains(err.Error(), "Already watching") {
-
-				log.Warningln("Already WATCHING", spec.ID, "no action")
-				return nil
-			}
-
+			log.Infoln("Releasing group", spec.ID)
+			err := plugin.ReleaseGroup(spec.ID)
 			if err != nil {
-				log.Warningln("Error watching group:", spec.ID, "Err=", err)
-			}
-			return nil
-		})
-}
-
-func (m *manager) doUnwatchGroups(config GlobalSpec) error {
-	log.Infoln("Unwatching groups")
-	return m.execPlugins(config,
-		func(plugin group.Plugin, spec group.Spec) error {
-
-			log.Infoln("UNWATCH group", spec.ID, "with spec:", spec)
-			err := plugin.UnwatchGroup(spec.ID)
-			if err != nil {
-				log.Warningln("Error unwatching group:", spec.ID, "Err=", err)
+				log.Warningln("Error releasing group:", spec.ID, "Err=", err)
 			}
 			return nil
 		})

--- a/manager/manager.go
+++ b/manager/manager.go
@@ -301,7 +301,7 @@ func (m *manager) doReleaseGroups(config GlobalSpec) error {
 		func(plugin group.Plugin, spec group.Spec) error {
 
 			log.Infoln("Releasing group", spec.ID)
-			err := plugin.ReleaseGroup(spec.ID)
+			err := plugin.FreeGroup(spec.ID)
 			if err != nil {
 				log.Warningln("Error releasing group:", spec.ID, "Err=", err)
 			}

--- a/plugin/group/group.go
+++ b/plugin/group/group.go
@@ -112,7 +112,7 @@ func (p *plugin) CommitGroup(config group.Spec, pretend bool) (string, error) {
 	return fmt.Sprintf("Managing %d instances", supervisor.Size()), nil
 }
 
-func (p *plugin) doRelease(id group.ID) (*groupContext, error) {
+func (p *plugin) doFree(id group.ID) (*groupContext, error) {
 	p.lock.Lock()
 	defer p.lock.Unlock()
 
@@ -129,8 +129,8 @@ func (p *plugin) doRelease(id group.ID) (*groupContext, error) {
 	return grp, nil
 }
 
-func (p *plugin) ReleaseGroup(id group.ID) error {
-	_, err := p.doRelease(id)
+func (p *plugin) FreeGroup(id group.ID) error {
+	_, err := p.doFree(id)
 	return err
 }
 
@@ -154,7 +154,7 @@ func (p *plugin) DescribeGroup(id group.ID) (group.Description, error) {
 }
 
 func (p *plugin) DestroyGroup(gid group.ID) error {
-	context, err := p.doRelease(gid)
+	context, err := p.doFree(gid)
 
 	if context != nil {
 		descriptions, err := context.scaled.List()

--- a/plugin/group/integration_test.go
+++ b/plugin/group/integration_test.go
@@ -319,7 +319,7 @@ func TestScaleDecrease(t *testing.T) {
 	require.NoError(t, grp.FreeGroup(id))
 }
 
-func TestReleaseGroup(t *testing.T) {
+func TestFreeGroup(t *testing.T) {
 	plugin := newTestInstancePlugin(
 		newFakeInstance(minions, nil),
 		newFakeInstance(minions, nil),
@@ -467,7 +467,7 @@ func TestFlavorChange(t *testing.T) {
 	require.NoError(t, grp.FreeGroup(id))
 }
 
-func TestReleaseGroupWhileConverging(t *testing.T) {
+func TestFreeGroupWhileConverging(t *testing.T) {
 
 	// Ensures that the group can be ignored while a commit is converging.
 

--- a/plugin/group/integration_test.go
+++ b/plugin/group/integration_test.go
@@ -101,7 +101,7 @@ func TestInvalidGroupCalls(t *testing.T) {
 	require.Error(t, grp.DestroyGroup(id))
 	_, err := grp.DescribeGroup(id)
 	require.Error(t, err)
-	require.Error(t, grp.ReleaseGroup(id))
+	require.Error(t, grp.FreeGroup(id))
 }
 
 func memberTags(id group.ID) map[string]string {
@@ -154,7 +154,7 @@ func TestNoopUpdate(t *testing.T) {
 		require.Equal(t, newFakeInstance(minions, nil).Tags, i.Tags)
 	}
 
-	require.NoError(t, grp.ReleaseGroup(id))
+	require.NoError(t, grp.FreeGroup(id))
 }
 
 func awaitGroupConvergence(t *testing.T, grp group.Plugin) {
@@ -212,7 +212,7 @@ func TestRollingUpdate(t *testing.T) {
 		require.Equal(t, provisionTags(updated), i.Tags)
 	}
 
-	require.NoError(t, grp.ReleaseGroup(id))
+	require.NoError(t, grp.FreeGroup(id))
 }
 
 func TestRollAndAdjustScale(t *testing.T) {
@@ -250,7 +250,7 @@ func TestRollAndAdjustScale(t *testing.T) {
 		require.Equal(t, provisionTags(updated), i.Tags)
 	}
 
-	require.NoError(t, grp.ReleaseGroup(id))
+	require.NoError(t, grp.FreeGroup(id))
 }
 
 func TestScaleIncrease(t *testing.T) {
@@ -283,7 +283,7 @@ func TestScaleIncrease(t *testing.T) {
 		require.Equal(t, provisionTags(updated), i.Tags)
 	}
 
-	require.NoError(t, grp.ReleaseGroup(id))
+	require.NoError(t, grp.FreeGroup(id))
 }
 
 func TestScaleDecrease(t *testing.T) {
@@ -316,7 +316,7 @@ func TestScaleDecrease(t *testing.T) {
 		require.Equal(t, provisionTags(updated), i.Tags)
 	}
 
-	require.NoError(t, grp.ReleaseGroup(id))
+	require.NoError(t, grp.FreeGroup(id))
 }
 
 func TestReleaseGroup(t *testing.T) {
@@ -330,7 +330,7 @@ func TestReleaseGroup(t *testing.T) {
 	_, err := grp.CommitGroup(minions, false)
 	require.NoError(t, err)
 
-	require.NoError(t, grp.ReleaseGroup(id))
+	require.NoError(t, grp.FreeGroup(id))
 }
 
 func TestDestroyGroup(t *testing.T) {
@@ -384,7 +384,7 @@ func TestSuperviseQuorum(t *testing.T) {
 
 	// TODO(wfarner): Validate logical IDs in created instances.
 
-	require.NoError(t, grp.ReleaseGroup(id))
+	require.NoError(t, grp.FreeGroup(id))
 }
 
 func TestUpdateCompletes(t *testing.T) {
@@ -404,7 +404,7 @@ func TestUpdateCompletes(t *testing.T) {
 	_, err = grp.CommitGroup(updated, false)
 	require.NoError(t, err)
 
-	require.NoError(t, grp.ReleaseGroup(id))
+	require.NoError(t, grp.FreeGroup(id))
 }
 
 func TestInstanceAndFlavorChange(t *testing.T) {
@@ -441,7 +441,7 @@ func TestInstanceAndFlavorChange(t *testing.T) {
 		require.Equal(t, "data2", properties["OpaqueValue"])
 	}
 
-	require.NoError(t, grp.ReleaseGroup(id))
+	require.NoError(t, grp.FreeGroup(id))
 }
 
 func TestFlavorChange(t *testing.T) {
@@ -464,7 +464,7 @@ func TestFlavorChange(t *testing.T) {
 
 	require.Equal(t, "Performing a rolling update on 3 instances", desc)
 
-	require.NoError(t, grp.ReleaseGroup(id))
+	require.NoError(t, grp.FreeGroup(id))
 }
 
 func TestReleaseGroupWhileConverging(t *testing.T) {
@@ -516,7 +516,7 @@ func TestReleaseGroupWhileConverging(t *testing.T) {
 	// Wait for the first health check to ensure the update has begun.
 	<-healthChecksStarted
 
-	require.NoError(t, grp.ReleaseGroup(id))
+	require.NoError(t, grp.FreeGroup(id))
 }
 
 func TestUpdateFailsWhenInstanceIsUnhealthy(t *testing.T) {
@@ -560,5 +560,5 @@ func TestUpdateFailsWhenInstanceIsUnhealthy(t *testing.T) {
 	}
 
 	require.Equal(t, 1, badUpdateInstanaces)
-	require.NoError(t, grp.ReleaseGroup(id))
+	require.NoError(t, grp.FreeGroup(id))
 }

--- a/plugin/group/quorum.go
+++ b/plugin/group/quorum.go
@@ -10,6 +10,8 @@ import (
 	"time"
 )
 
+// TODO(wfarner): Converge this implementation with scaler.go, they share a lot of behavior.
+
 type quorum struct {
 	scaled       Scaled
 	LogicalIDs   []instance.LogicalID
@@ -35,7 +37,7 @@ func (q *quorum) PlanUpdate(scaled Scaled, settings groupSettings, newSettings g
 
 	return &rollingupdate{
 		desc: fmt.Sprintf(
-			"Performs a rolling update on %d instances",
+			"Performing a rolling update on %d instances",
 			len(settings.config.Allocation.LogicalIDs)),
 		scaled:     scaled,
 		updatingTo: newSettings,
@@ -61,6 +63,10 @@ func (q *quorum) Run() {
 			return
 		}
 	}
+}
+
+func (q *quorum) Size() uint {
+	return uint(len(q.LogicalIDs))
 }
 
 func (q *quorum) converge() {

--- a/plugin/group/scaler.go
+++ b/plugin/group/scaler.go
@@ -3,20 +3,11 @@ package group
 import (
 	"fmt"
 	log "github.com/Sirupsen/logrus"
-	"github.com/docker/infrakit/plugin/group/util"
 	"github.com/docker/infrakit/spi/instance"
 	"sort"
 	"sync"
 	"time"
 )
-
-// Scaler is the spi of the scaler controller which mimics the behavior
-// of an autoscaling group / scale set on AWS or Azure.
-type Scaler interface {
-	util.RunStop
-	Size() uint
-	SetSize(size uint)
-}
 
 type scaler struct {
 	scaled       Scaled
@@ -73,11 +64,11 @@ func (s *scaler) PlanUpdate(scaled Scaled, settings groupSettings, newSettings g
 			// created. We proceed with the update here, which will likely only change the target
 			// configuration in the scaler.
 
-			plan.desc = "Adjusts the instance configuration, no restarts necessary"
+			plan.desc = "Adjusting the instance configuration, no restarts necessary"
 			return &plan, nil
 		}
 
-		plan.desc = fmt.Sprintf("Performs a rolling update on %d instances", rollCount)
+		plan.desc = fmt.Sprintf("Performing a rolling update on %d instances", rollCount)
 
 	case sizeChange < 0:
 		rollCount := int(newSettings.config.Allocation.Size) - len(desired)
@@ -87,13 +78,13 @@ func (s *scaler) PlanUpdate(scaled Scaled, settings groupSettings, newSettings g
 
 		if rollCount == 0 {
 			plan.desc = fmt.Sprintf(
-				"Terminates %d instances to reduce the group size to %d",
+				"Terminating %d instances to reduce the group size to %d",
 				int(sizeChange)*-1,
 				newSettings.config.Allocation.Size)
 		} else {
 			plan.desc = fmt.Sprintf(
-				"Terminates %d instances to reduce the group size to %d, "+
-					" then performs a rolling update on %d instances",
+				"Terminating %d instances to reduce the group size to %d, "+
+					" then performing a rolling update on %d instances",
 				int(sizeChange)*-1,
 				newSettings.config.Allocation.Size,
 				rollCount)
@@ -104,13 +95,13 @@ func (s *scaler) PlanUpdate(scaled Scaled, settings groupSettings, newSettings g
 
 		if rollCount == 0 {
 			plan.desc = fmt.Sprintf(
-				"Adds %d instances to increase the group size to %d",
+				"Adding %d instances to increase the group size to %d",
 				sizeChange,
 				newSettings.config.Allocation.Size)
 		} else {
 			plan.desc = fmt.Sprintf(
-				"Performs a rolling update on %d instances,"+
-					" then adds %d instances to increase the group size to %d",
+				"Performing a rolling update on %d instances,"+
+					" then adding %d instances to increase the group size to %d",
 				rollCount,
 				sizeChange,
 				newSettings.config.Allocation.Size)
@@ -196,6 +187,10 @@ func (s *scaler) Run() {
 			return
 		}
 	}
+}
+
+func (s *scaler) Size() uint {
+	return s.size
 }
 
 func (s *scaler) converge() {

--- a/plugin/group/state.go
+++ b/plugin/group/state.go
@@ -14,6 +14,8 @@ import (
 type Supervisor interface {
 	util.RunStop
 
+	Size() uint
+
 	PlanUpdate(scaled Scaled, settings groupSettings, newSettings groupSettings) (updatePlan, error)
 }
 
@@ -38,11 +40,21 @@ func (c *groupContext) setUpdate(plan updatePlan) {
 	c.update = plan
 }
 
-func (c *groupContext) getUpdate() updatePlan {
+func (c *groupContext) updating() bool {
 	c.lock.Lock()
 	defer c.lock.Unlock()
 
-	return c.update
+	return c.update != nil
+}
+
+func (c *groupContext) stopUpdating() {
+	c.lock.Lock()
+	defer c.lock.Unlock()
+
+	if c.update != nil {
+		c.update.Stop()
+		c.update = nil
+	}
 }
 
 func (c *groupContext) changeSettings(settings groupSettings) {

--- a/rpc/group/client.go
+++ b/rpc/group/client.go
@@ -31,10 +31,10 @@ func (c *client) CommitGroup(grp group.Spec, pretend bool) (string, error) {
 	return resp.Details, nil
 }
 
-func (c *client) ReleaseGroup(id group.ID) error {
-	req := &ReleaseGroupRequest{ID: id}
-	resp := &ReleaseGroupResponse{}
-	err := c.rpc.Call("Group.ReleaseGroup", req, resp)
+func (c *client) FreeGroup(id group.ID) error {
+	req := &FreeGroupRequest{ID: id}
+	resp := &FreeGroupResponse{}
+	err := c.rpc.Call("Group.FreeGroup", req, resp)
 	if err != nil {
 		return err
 	}

--- a/rpc/group/client.go
+++ b/rpc/group/client.go
@@ -21,21 +21,20 @@ type client struct {
 	rpc *rpc.Client
 }
 
-func (c *client) WatchGroup(grp group.Spec) error {
-	req := &WatchGroupRequest{Spec: grp}
-	resp := &WatchGroupResponse{}
-	err := c.rpc.Call("Group.WatchGroup", req, resp)
+func (c *client) CommitGroup(grp group.Spec, pretend bool) (string, error) {
+	req := &CommitGroupRequest{Spec: grp, Pretend: pretend}
+	resp := &CommitGroupResponse{}
+	err := c.rpc.Call("Group.CommitGroup", req, resp)
 	if err != nil {
-		return err
+		return resp.Details, err
 	}
-	resp.OK = true
-	return nil
+	return resp.Details, nil
 }
 
-func (c *client) UnwatchGroup(id group.ID) error {
-	req := &UnwatchGroupRequest{ID: id}
-	resp := &UnwatchGroupResponse{}
-	err := c.rpc.Call("Group.UnwatchGroup", req, resp)
+func (c *client) ReleaseGroup(id group.ID) error {
+	req := &ReleaseGroupRequest{ID: id}
+	resp := &ReleaseGroupResponse{}
+	err := c.rpc.Call("Group.ReleaseGroup", req, resp)
 	if err != nil {
 		return err
 	}
@@ -48,35 +47,6 @@ func (c *client) DescribeGroup(id group.ID) (group.Description, error) {
 	resp := &DescribeGroupResponse{}
 	err := c.rpc.Call("Group.DescribeGroup", req, resp)
 	return resp.Description, err
-}
-
-func (c *client) DescribeUpdate(updated group.Spec) (string, error) {
-	req := &DescribeUpdateRequest{Spec: updated}
-	resp := &DescribeUpdateResponse{}
-	err := c.rpc.Call("Group.DescribeUpdate", req, resp)
-	return resp.Plan, err
-}
-
-func (c *client) UpdateGroup(updated group.Spec) error {
-	req := &UpdateGroupRequest{Spec: updated}
-	resp := &UpdateGroupResponse{}
-	err := c.rpc.Call("Group.UpdateGroup", req, resp)
-	if err != nil {
-		return err
-	}
-	resp.OK = true
-	return nil
-}
-
-func (c *client) StopUpdate(id group.ID) error {
-	req := &StopUpdateRequest{ID: id}
-	resp := &StopUpdateResponse{}
-	err := c.rpc.Call("Group.StopUpdate", req, resp)
-	if err != nil {
-		return err
-	}
-	resp.OK = true
-	return nil
 }
 
 func (c *client) DestroyGroup(id group.ID) error {

--- a/rpc/group/rpc_test.go
+++ b/rpc/group/rpc_test.go
@@ -15,7 +15,7 @@ import (
 
 type testPlugin struct {
 	DoCommitGroup   func(grp group.Spec, pretend bool) (string, error)
-	DoReleaseGroup  func(id group.ID) error
+	DoFreeGroup     func(id group.ID) error
 	DoDescribeGroup func(id group.ID) (group.Description, error)
 	DoDestroyGroup  func(id group.ID) error
 	DoInspectGroups func() ([]group.Spec, error)
@@ -30,8 +30,8 @@ func testClient(t *testing.T, socket string) group.Plugin {
 func (t *testPlugin) CommitGroup(grp group.Spec, pretend bool) (string, error) {
 	return t.DoCommitGroup(grp, pretend)
 }
-func (t *testPlugin) ReleaseGroup(id group.ID) error {
-	return t.DoReleaseGroup(id)
+func (t *testPlugin) FreeGroup(id group.ID) error {
+	return t.DoFreeGroup(id)
 }
 func (t *testPlugin) DescribeGroup(id group.ID) (group.Description, error) {
 	return t.DoDescribeGroup(id)
@@ -107,40 +107,40 @@ func TestGroupPluginCommitGroupError(t *testing.T) {
 	require.Equal(t, groupSpec, <-groupSpecActual)
 }
 
-func TestGroupPluginReleaseGroup(t *testing.T) {
+func TestGroupPluginFreeGroup(t *testing.T) {
 	socketPath := tempSocket()
 
 	id := group.ID("group")
 	idActual := make(chan group.ID, 1)
 	stop, _, err := rpc.StartPluginAtPath(socketPath, PluginServer(&testPlugin{
-		DoReleaseGroup: func(req group.ID) error {
+		DoFreeGroup: func(req group.ID) error {
 			idActual <- req
 			return nil
 		},
 	}))
 	require.NoError(t, err)
 
-	err = testClient(t, socketPath).ReleaseGroup(id)
+	err = testClient(t, socketPath).FreeGroup(id)
 	require.NoError(t, err)
 
 	close(stop)
 	require.Equal(t, id, <-idActual)
 }
 
-func TestGroupPluginReleaseGroupError(t *testing.T) {
+func TestGroupPluginFreeGroupError(t *testing.T) {
 	socketPath := tempSocket()
 
 	id := group.ID("group")
 	idActual := make(chan group.ID, 1)
 	stop, _, err := rpc.StartPluginAtPath(socketPath, PluginServer(&testPlugin{
-		DoReleaseGroup: func(req group.ID) error {
+		DoFreeGroup: func(req group.ID) error {
 			idActual <- req
 			return errors.New("no")
 		},
 	}))
 	require.NoError(t, err)
 
-	err = testClient(t, socketPath).ReleaseGroup(id)
+	err = testClient(t, socketPath).FreeGroup(id)
 	require.Error(t, err)
 	require.Equal(t, "no", err.Error())
 

--- a/rpc/group/service.go
+++ b/rpc/group/service.go
@@ -24,9 +24,9 @@ func (p *Group) CommitGroup(req *CommitGroupRequest, resp *CommitGroupResponse) 
 	return nil
 }
 
-// ReleaseGroup is the rpc method to release a group
-func (p *Group) ReleaseGroup(req *ReleaseGroupRequest, resp *ReleaseGroupResponse) error {
-	err := p.plugin.ReleaseGroup(req.ID)
+// FreeGroup is the rpc method to free a group
+func (p *Group) FreeGroup(req *FreeGroupRequest, resp *FreeGroupResponse) error {
+	err := p.plugin.FreeGroup(req.ID)
 	if err != nil {
 		return err
 	}

--- a/rpc/group/service.go
+++ b/rpc/group/service.go
@@ -14,19 +14,19 @@ type Group struct {
 	plugin group.Plugin
 }
 
-// WatchGroup is the rpc method to watch a group
-func (p *Group) WatchGroup(req *WatchGroupRequest, resp *WatchGroupResponse) error {
-	err := p.plugin.WatchGroup(req.Spec)
+// CommitGroup is the rpc method to commit a group
+func (p *Group) CommitGroup(req *CommitGroupRequest, resp *CommitGroupResponse) error {
+	details, err := p.plugin.CommitGroup(req.Spec, req.Pretend)
 	if err != nil {
 		return err
 	}
-	resp.OK = true
+	resp.Details = details
 	return nil
 }
 
-// UnwatchGroup is the rpc method to unwatch a group
-func (p *Group) UnwatchGroup(req *UnwatchGroupRequest, resp *UnwatchGroupResponse) error {
-	err := p.plugin.UnwatchGroup(req.ID)
+// ReleaseGroup is the rpc method to release a group
+func (p *Group) ReleaseGroup(req *ReleaseGroupRequest, resp *ReleaseGroupResponse) error {
+	err := p.plugin.ReleaseGroup(req.ID)
 	if err != nil {
 		return err
 	}
@@ -41,36 +41,6 @@ func (p *Group) DescribeGroup(req *DescribeGroupRequest, resp *DescribeGroupResp
 		return err
 	}
 	resp.Description = desc
-	return nil
-}
-
-// DescribeUpdate is the rpc method to describe an update without performing it
-func (p *Group) DescribeUpdate(req *DescribeUpdateRequest, resp *DescribeUpdateResponse) error {
-	plan, err := p.plugin.DescribeUpdate(req.Spec)
-	if err != nil {
-		return err
-	}
-	resp.Plan = plan
-	return nil
-}
-
-// UpdateGroup is the rpc method to actually updating a group
-func (p *Group) UpdateGroup(req *UpdateGroupRequest, resp *UpdateGroupResponse) error {
-	err := p.plugin.UpdateGroup(req.Spec)
-	if err != nil {
-		return err
-	}
-	resp.OK = true
-	return nil
-}
-
-// StopUpdate is the rpc method to stop a current update
-func (p *Group) StopUpdate(req *StopUpdateRequest, resp *StopUpdateResponse) error {
-	err := p.plugin.StopUpdate(req.ID)
-	if err != nil {
-		return err
-	}
-	resp.OK = true
 	return nil
 }
 

--- a/rpc/group/types.go
+++ b/rpc/group/types.go
@@ -15,13 +15,13 @@ type CommitGroupResponse struct {
 	Details string
 }
 
-// ReleaseGroupRequest is the rpc wrapper for input to release a group
-type ReleaseGroupRequest struct {
+// FreeGroupRequest is the rpc wrapper for input to release a group
+type FreeGroupRequest struct {
 	ID group.ID
 }
 
-// ReleaseGroupResponse is the rpc wrapper for the results to release a group
-type ReleaseGroupResponse struct {
+// FreeGroupResponse is the rpc wrapper for the results to release a group
+type FreeGroupResponse struct {
 	OK bool
 }
 
@@ -59,7 +59,7 @@ type InspectGroupsResponse struct {
 // defined in net/rpc
 type RPCService interface {
 	CommitGroup(req *CommitGroupRequest, resp *CommitGroupResponse) error
-	ReleaseGroup(req *ReleaseGroupRequest, resp *ReleaseGroupResponse) error
+	FreeGroup(req *FreeGroupRequest, resp *FreeGroupResponse) error
 	DescribeGroup(req *DescribeGroupRequest, resp *DescribeGroupResponse) error
 	DestroyGroup(req *DestroyGroupRequest, resp *DestroyGroupResponse) error
 	InspectGroups(req *InspectGroupsRequest, resp *InspectGroupsResponse) error

--- a/rpc/group/types.go
+++ b/rpc/group/types.go
@@ -4,23 +4,24 @@ import (
 	"github.com/docker/infrakit/spi/group"
 )
 
-// WatchGroupRequest is the rpc wrapper for input to watch a group
-type WatchGroupRequest struct {
-	Spec group.Spec
+// CommitGroupRequest is the rpc wrapper for input to commit a group
+type CommitGroupRequest struct {
+	Spec    group.Spec
+	Pretend bool
 }
 
-// WatchGroupResponse is the rpc wrapper for the results to watch a group
-type WatchGroupResponse struct {
-	OK bool
+// CommitGroupResponse is the rpc wrapper for the results to commit a group
+type CommitGroupResponse struct {
+	Details string
 }
 
-// UnwatchGroupRequest is the rpc wrapper for input to unwatch a group
-type UnwatchGroupRequest struct {
+// ReleaseGroupRequest is the rpc wrapper for input to release a group
+type ReleaseGroupRequest struct {
 	ID group.ID
 }
 
-// UnwatchGroupResponse is the rpc wrapper for the results to unwatch a group
-type UnwatchGroupResponse struct {
+// ReleaseGroupResponse is the rpc wrapper for the results to release a group
+type ReleaseGroupResponse struct {
 	OK bool
 }
 
@@ -32,36 +33,6 @@ type DescribeGroupRequest struct {
 // DescribeGroupResponse is the rpc wrapper for the results from inspecting a group
 type DescribeGroupResponse struct {
 	Description group.Description
-}
-
-// DescribeUpdateRequest is the rpc wrapper for the input to describe an update
-type DescribeUpdateRequest struct {
-	Spec group.Spec
-}
-
-// DescribeUpdateResponse is the rpc wrapper for the results from describing an update
-type DescribeUpdateResponse struct {
-	Plan string
-}
-
-// UpdateGroupRequest is the rpc wrapper for the input to update a group
-type UpdateGroupRequest struct {
-	Spec group.Spec
-}
-
-// UpdateGroupResponse is the rpc wrapper for the results of updating a group
-type UpdateGroupResponse struct {
-	OK bool
-}
-
-// StopUpdateRequest is the rpc wrapper for input to stop an update
-type StopUpdateRequest struct {
-	ID group.ID
-}
-
-// StopUpdateResponse is the rpc wrapper for the output from stopping an update
-type StopUpdateResponse struct {
-	OK bool
 }
 
 // DestroyGroupRequest is the rpc wrapper for the input to destroy a group
@@ -87,12 +58,9 @@ type InspectGroupsResponse struct {
 // RPCService is the interface for exposing the group plugin as a RPC service. It conforms to the call conventions
 // defined in net/rpc
 type RPCService interface {
-	WatchGroup(req *WatchGroupRequest, resp *WatchGroupResponse) error
-	UnwatchGroup(req *UnwatchGroupRequest, resp *UnwatchGroupResponse) error
+	CommitGroup(req *CommitGroupRequest, resp *CommitGroupResponse) error
+	ReleaseGroup(req *ReleaseGroupRequest, resp *ReleaseGroupResponse) error
 	DescribeGroup(req *DescribeGroupRequest, resp *DescribeGroupResponse) error
-	DescribeUpdate(req *DescribeUpdateRequest, resp *DescribeUpdateResponse) error
-	UpdateGroup(req *UpdateGroupRequest, resp *UpdateGroupResponse) error
-	StopUpdate(req *StopUpdateRequest, resp *StopUpdateResponse) error
 	DestroyGroup(req *DestroyGroupRequest, resp *DestroyGroupResponse) error
 	InspectGroups(req *InspectGroupsRequest, resp *InspectGroupsResponse) error
 }

--- a/rpc/group/types.go
+++ b/rpc/group/types.go
@@ -15,12 +15,12 @@ type CommitGroupResponse struct {
 	Details string
 }
 
-// FreeGroupRequest is the rpc wrapper for input to release a group
+// FreeGroupRequest is the rpc wrapper for input to free a group
 type FreeGroupRequest struct {
 	ID group.ID
 }
 
-// FreeGroupResponse is the rpc wrapper for the results to release a group
+// FreeGroupResponse is the rpc wrapper for the results to free a group
 type FreeGroupResponse struct {
 	OK bool
 }

--- a/scripts/tutorial_test
+++ b/scripts/tutorial_test
@@ -17,7 +17,7 @@ trap cleanup EXIT
 
 mkdir -p tutorial
 build/infrakit-instance-file --dir ./tutorial/ &
-build/infrakit-group-default &
+build/infrakit-group-default --poll-interval 500ms &
 build/infrakit-flavor-vanilla &
 
 sleep 1
@@ -27,8 +27,8 @@ expect_exact_output() {
   cmd=$2
   expected_output=$3
 
-  echo -n "$1: "
   actual_output="$($2)"
+  echo -n "--> $message: "
   if [ "$actual_output" = "$3" ]
   then
     echo 'PASS'
@@ -45,12 +45,15 @@ expect_output_lines() {
   cmd=$2
   expected_lines=$3
 
-  echo -n "$1: "
-  if [ "$($2 | wc -l)" -eq "$3" ]
+  actual_line_count=$($2 | wc -l)
+  echo -n "--> $message: "
+  if [ "$actual_line_count" -eq "$3" ]
   then
     echo 'PASS'
   else
     echo 'FAIL'
+    echo "Expected line count: $expected_lines"
+    echo "Actual line count: $actual_line_count"
     exit 1
   fi
 }
@@ -58,7 +61,7 @@ expect_output_lines() {
 expect_output_lines "3 plugins should be discoverable" "build/infrakit plugin ls -q" "3"
 expect_output_lines "0 instances should exist" "build/infrakit instance describe -q --name instance-file" "0"
 
-build/infrakit group watch docs/cattle.json
+build/infrakit group commit docs/cattle.json
 
 echo 'Waiting for group to be provisioned'
 sleep 2
@@ -66,18 +69,19 @@ sleep 2
 expect_output_lines "5 instances should exist in group" "build/infrakit group describe cattle -q" "5"
 expect_output_lines "5 instances should exist" "build/infrakit instance describe -q --name instance-file" "5"
 
-build/infrakit group unwatch cattle
-build/infrakit group watch docs/cattle.json
+build/infrakit group release cattle
+build/infrakit group commit docs/cattle.json
 
 expect_exact_output "Should be watching one group" "build/infrakit group ls -q" "cattle"
 
 expect_exact_output \
   "Update should roll 5 and scale group to 10" \
-  "build/infrakit group describe-update docs/cattle2.json" \
-  "Performs a rolling update on 5 instances, then adds 5 instances to increase the group size to 10"
+  "build/infrakit group commit docs/cattle2.json --pretend" \
+  "Committing cattle would involve: Performing a rolling update on 5 instances, then adding 5 instances to increase the group size to 10"
 
-build/infrakit group update docs/cattle2.json
-sleep 20
+build/infrakit group commit docs/cattle2.json
+
+sleep 5
 
 expect_output_lines "10 instances should exist in group" "build/infrakit group describe cattle -q" "10"
 
@@ -86,7 +90,7 @@ pushd tutorial
   rm $(ls | head -3)
 popd
 
-sleep 20
+sleep 5
 
 expect_output_lines "10 instances should exist in group" "build/infrakit group describe cattle -q" "10"
 

--- a/scripts/tutorial_test
+++ b/scripts/tutorial_test
@@ -69,7 +69,7 @@ sleep 2
 expect_output_lines "5 instances should exist in group" "build/infrakit group describe cattle -q" "5"
 expect_output_lines "5 instances should exist" "build/infrakit instance describe -q --name instance-file" "5"
 
-build/infrakit group release cattle
+build/infrakit group free cattle
 build/infrakit group commit docs/cattle.json
 
 expect_exact_output "Should be watching one group" "build/infrakit group ls -q" "cattle"

--- a/spi/group/spi.go
+++ b/spi/group/spi.go
@@ -9,7 +9,7 @@ import (
 type Plugin interface {
 	CommitGroup(grp Spec, pretend bool) (string, error)
 
-	ReleaseGroup(id ID) error
+	FreeGroup(id ID) error
 
 	DescribeGroup(id ID) (Description, error)
 

--- a/spi/group/spi.go
+++ b/spi/group/spi.go
@@ -7,17 +7,11 @@ import (
 
 // Plugin defines the functions for a Group plugin.
 type Plugin interface {
-	WatchGroup(grp Spec) error
+	CommitGroup(grp Spec, pretend bool) (string, error)
 
-	UnwatchGroup(id ID) error
+	ReleaseGroup(id ID) error
 
 	DescribeGroup(id ID) (Description, error)
-
-	DescribeUpdate(updated Spec) (string, error)
-
-	UpdateGroup(updated Spec) error
-
-	StopUpdate(id ID) error
 
 	DestroyGroup(id ID) error
 
@@ -43,4 +37,5 @@ type Spec struct {
 // Description is a placeholder for the reported state of a Group.
 type Description struct {
 	Instances []instance.Description
+	Converged bool
 }


### PR DESCRIPTION
Introduces the `commit` command, with a `--pretend` flag
`unwatch` is renamed to `free`
The following commands are removed: `watch`, `update`, `stop-update`, and `describe-update`

Closes #292 

Signed-off-by: Bill Farner <bill@docker.com>