### PR TITLE
Add HTTP request debug logging

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -84,13 +84,13 @@ endif
 	$(call build_binary,infrakit,github.com/docker/infrakit/cmd/cli)
 	$(call build_binary,infrakit-manager,github.com/docker/infrakit/cmd/manager)
 	$(call build_binary,infrakit-group-default,github.com/docker/infrakit/cmd/group)
-	$(call build_binary,infrakit-flavor-combo,github.com/docker/infrakit/example/flavor/combo)
-	$(call build_binary,infrakit-flavor-swarm,github.com/docker/infrakit/example/flavor/swarm)
-	$(call build_binary,infrakit-flavor-vanilla,github.com/docker/infrakit/example/flavor/vanilla)
-	$(call build_binary,infrakit-flavor-zookeeper,github.com/docker/infrakit/example/flavor/zookeeper)
-	$(call build_binary,infrakit-instance-file,github.com/docker/infrakit/example/instance/file)
-	$(call build_binary,infrakit-instance-terraform,github.com/docker/infrakit/example/instance/terraform)
-	$(call build_binary,infrakit-instance-vagrant,github.com/docker/infrakit/example/instance/vagrant)
+	$(call build_binary,infrakit-flavor-combo,github.com/docker/infrakit/pkg/example/flavor/combo)
+	$(call build_binary,infrakit-flavor-swarm,github.com/docker/infrakit/pkg/example/flavor/swarm)
+	$(call build_binary,infrakit-flavor-vanilla,github.com/docker/infrakit/pkg/example/flavor/vanilla)
+	$(call build_binary,infrakit-flavor-zookeeper,github.com/docker/infrakit/pkg/example/flavor/zookeeper)
+	$(call build_binary,infrakit-instance-file,github.com/docker/infrakit/pkg/example/instance/file)
+	$(call build_binary,infrakit-instance-terraform,github.com/docker/infrakit/pkg/example/instance/terraform)
+	$(call build_binary,infrakit-instance-vagrant,github.com/docker/infrakit/pkg/example/instance/vagrant)
 
 install:
 	@echo "+ $@"

--- a/pkg/rpc/server/server.go
+++ b/pkg/rpc/server/server.go
@@ -39,7 +39,7 @@ type loggingHandler struct {
 func (h loggingHandler) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 	requestData, err := httputil.DumpRequest(req, true)
 	if err == nil {
-		log.Debug(string(requestData))
+		log.Debugf("Received request %s", string(requestData))
 	} else {
 		log.Error(err)
 	}
@@ -50,7 +50,7 @@ func (h loggingHandler) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 
 	responseData, err := httputil.DumpResponse(recorder.Result(), true)
 	if err == nil {
-		log.Debug(string(responseData))
+		log.Debugf("Sending response %s", string(responseData))
 	} else {
 		log.Error(err)
 	}


### PR DESCRIPTION
This adds debug-level logging for plugin clients and servers.

Here's an excerpt from the group Plugin to show how this logging presents, showing the full call chain to create an instance:

```shell
INFO[0000] Listening at: /Users/billfarner/.infrakit/plugins/group
DEBU[0015] Received request POST /rpc HTTP/1.1
Host: d
Accept-Encoding: gzip
Content-Length: 409
Content-Type: application/json
User-Agent: Go-http-client/1.1

{"method":"Group.CommitGroup","params":[{"Spec":{"ID":"cattle","Properties":{"Allocation":{"Size":5},"Instance":{"Plugin":"instance-file","Properties":{"Note":"Instance properties version 1.0"}},"Flavor":{"Plugin":"flavor-vanilla","Properties":{"Init":["docker pull nginx:alpine","docker run -d -p 80:80 nginx-alpine"],"Tags":{"tier":"web","project":"infrakit"}}}}},"Pretend":false}],"id":5577006791947779410}
...
DEBU[0015] Sending request POST / HTTP/1.1
Content-Type: application/json

{"method":"Flavor.Validate","params":[{"Properties":{"Init":["docker pull nginx:alpine","docker run -d -p 80:80 nginx-alpine"],"Tags":{"tier":"web","project":"infrakit"}},"Allocation":{"Size":5,"LogicalIDs":null}}],"id":2403489562072437156}
DEBU[0015] Received response HTTP/1.1 200 OK
Content-Length: 60
Content-Type: text/plain; charset=utf-8
Date: Tue, 15 Nov 2016 23:03:26 GMT

{"result":{"OK":true},"error":null,"id":2403489562072437156}
...
DEBU[0015] Sending request POST / HTTP/1.1
Content-Type: application/json

{"method":"Instance.Validate","params":[{"Properties":{"Note":"Instance properties version 1.0"}}],"id":6372761812113081704}
DEBU[0015] Received response HTTP/1.1 200 OK
Content-Length: 60
Content-Type: text/plain; charset=utf-8
Date: Tue, 15 Nov 2016 23:03:26 GMT

{"result":{"OK":true},"error":null,"id":6372761812113081704}
INFO[0015] Committing group cattle (pretend=false)
DEBU[0015] Sending response HTTP/1.1 200 OK
Connection: close
X-Content-Type-Options: nosniff

{"result":{"Details":"Managing 5 instances"},"error":null,"id":5577006791947779410}
```

Closes #269

Signed-off-by: Bill Farner <bill@docker.com>