### PR TITLE
Establish a convention for declaring CLI flags

### DIFF
--- a/cmd/cli/group.go
+++ b/cmd/cli/group.go
@@ -22,26 +22,24 @@ const (
 
 func groupPluginCommand(plugins func() discovery.Plugins) *cobra.Command {
 
-	name := DefaultGroupPluginName
 	var groupPlugin group.Plugin
 
 	cmd := &cobra.Command{
 		Use:   "group",
 		Short: "Access group plugin",
-		PersistentPreRunE: func(c *cobra.Command, args []string) error {
-
-			endpoint, err := plugins().Find(name)
-			if err != nil {
-				return err
-			}
-
-			groupPlugin = group_plugin.NewClient(endpoint.Address)
-
-			return nil
-		},
 	}
+	name := cmd.PersistentFlags().String("name", DefaultGroupPluginName, "Name of plugin")
+	cmd.PersistentPreRunE = func(c *cobra.Command, args []string) error {
 
-	cmd.PersistentFlags().StringVar(&name, "name", name, "Name of plugin")
+		endpoint, err := plugins().Find(*name)
+		if err != nil {
+			return err
+		}
+
+		groupPlugin = group_plugin.NewClient(endpoint.Address)
+
+		return nil
+	}
 
 	commit := cobra.Command{
 		Use:   "commit <group configuration>",
@@ -99,44 +97,43 @@ func groupPluginCommand(plugins func() discovery.Plugins) *cobra.Command {
 		},
 	})
 
-	var quiet bool
 	describe := &cobra.Command{
 		Use:   "describe <group ID>",
 		Short: "describe the live instances that make up a group",
-		RunE: func(cmd *cobra.Command, args []string) error {
-			assertNotNil("no plugin", groupPlugin)
-
-			if len(args) != 1 {
-				cmd.Usage()
-				os.Exit(1)
-			}
-
-			groupID := group.ID(args[0])
-			desc, err := groupPlugin.DescribeGroup(groupID)
-
-			if err == nil {
-				if !quiet {
-					fmt.Printf("%-30s\t%-30s\t%-s\n", "ID", "LOGICAL", "TAGS")
-				}
-				for _, d := range desc.Instances {
-					logical := "  -   "
-					if d.LogicalID != nil {
-						logical = string(*d.LogicalID)
-					}
-
-					printTags := []string{}
-					for k, v := range d.Tags {
-						printTags = append(printTags, fmt.Sprintf("%s=%s", k, v))
-					}
-					sort.Strings(printTags)
-
-					fmt.Printf("%-30s\t%-30s\t%-s\n", d.ID, logical, strings.Join(printTags, ","))
-				}
-			}
-			return err
-		},
 	}
-	describe.Flags().BoolVarP(&quiet, "quiet", "q", false, "Print rows without column headers")
+	quietDescribe := describe.Flags().BoolP("quiet", "q", false, "Print rows without column headers")
+	describe.RunE = func(cmd *cobra.Command, args []string) error {
+		assertNotNil("no plugin", groupPlugin)
+
+		if len(args) != 1 {
+			cmd.Usage()
+			os.Exit(1)
+		}
+
+		groupID := group.ID(args[0])
+		desc, err := groupPlugin.DescribeGroup(groupID)
+
+		if err == nil {
+			if !*quietDescribe {
+				fmt.Printf("%-30s\t%-30s\t%-s\n", "ID", "LOGICAL", "TAGS")
+			}
+			for _, d := range desc.Instances {
+				logical := "  -   "
+				if d.LogicalID != nil {
+					logical = string(*d.LogicalID)
+				}
+
+				printTags := []string{}
+				for k, v := range d.Tags {
+					printTags = append(printTags, fmt.Sprintf("%s=%s", k, v))
+				}
+				sort.Strings(printTags)
+
+				fmt.Printf("%-30s\t%-30s\t%-s\n", d.ID, logical, strings.Join(printTags, ","))
+			}
+		}
+		return err
+	}
 	cmd.AddCommand(describe)
 
 	cmd.AddCommand(&cobra.Command{
@@ -198,23 +195,23 @@ func groupPluginCommand(plugins func() discovery.Plugins) *cobra.Command {
 	describeGroups := &cobra.Command{
 		Use:   "ls",
 		Short: "list groups",
-		RunE: func(cmd *cobra.Command, args []string) error {
-			assertNotNil("no plugin", groupPlugin)
-
-			groups, err := groupPlugin.InspectGroups()
-			if err == nil {
-				if !quiet {
-					fmt.Printf("%s\n", "ID")
-				}
-				for _, g := range groups {
-					fmt.Printf("%s\n", g.ID)
-				}
-			}
-
-			return err
-		},
 	}
-	describeGroups.Flags().BoolVarP(&quiet, "quiet", "q", false, "Print rows without column headers")
+	quietls := describe.Flags().BoolP("quiet", "q", false, "Print rows without column headers")
+	describeGroups.RunE = func(cmd *cobra.Command, args []string) error {
+		assertNotNil("no plugin", groupPlugin)
+
+		groups, err := groupPlugin.InspectGroups()
+		if err == nil {
+			if !*quietls {
+				fmt.Printf("%s\n", "ID")
+			}
+			for _, g := range groups {
+				fmt.Printf("%s\n", g.ID)
+			}
+		}
+
+		return err
+	}
 	cmd.AddCommand(describeGroups)
 
 	return cmd

--- a/cmd/cli/group.go
+++ b/cmd/cli/group.go
@@ -196,7 +196,7 @@ func groupPluginCommand(plugins func() discovery.Plugins) *cobra.Command {
 		Use:   "ls",
 		Short: "list groups",
 	}
-	quietls := describe.Flags().BoolP("quiet", "q", false, "Print rows without column headers")
+	quietls := describeGroups.Flags().BoolP("quiet", "q", false, "Print rows without column headers")
 	describeGroups.RunE = func(cmd *cobra.Command, args []string) error {
 		assertNotNil("no plugin", groupPlugin)
 

--- a/cmd/cli/main.go
+++ b/cmd/cli/main.go
@@ -14,14 +14,13 @@ import (
 
 func main() {
 
-	logLevel := cli.DefaultLogLevel
-
 	cmd := &cobra.Command{
 		Use:   os.Args[0],
 		Short: "infrakit cli",
-		PersistentPreRun: func(c *cobra.Command, args []string) {
-			cli.SetLogLevel(logLevel)
-		},
+	}
+	logLevel := cmd.PersistentFlags().Int("log", cli.DefaultLogLevel, "Logging level. 0 is least verbose. Max is 5")
+	cmd.PersistentPreRun = func(c *cobra.Command, args []string) {
+		cli.SetLogLevel(*logLevel)
 	}
 
 	// Don't print usage text for any error returned from a RunE function.  Only print it when explicitly requested.
@@ -42,8 +41,6 @@ func main() {
 		return d
 	}
 	cmd.AddCommand(pluginCommand(f), instancePluginCommand(f), groupPluginCommand(f), flavorPluginCommand(f))
-
-	cmd.PersistentFlags().IntVar(&logLevel, "log", logLevel, "Logging level. 0 is least verbose. Max is 5")
 
 	err := cmd.Execute()
 	if err != nil {

--- a/cmd/cli/plugin.go
+++ b/cmd/cli/plugin.go
@@ -13,27 +13,26 @@ func pluginCommand(plugins func() discovery.Plugins) *cobra.Command {
 		Short: "Manage plugins",
 	}
 
-	var quiet bool
 	ls := cobra.Command{
 		Use:   "ls",
 		Short: "List available plugins",
-		RunE: func(c *cobra.Command, args []string) error {
-			entries, err := plugins().List()
-			if err != nil {
-				return err
-			}
-
-			if !quiet {
-				fmt.Printf("%-20s\t%-s\n", "NAME", "LISTEN")
-			}
-			for k, v := range entries {
-				fmt.Printf("%-20s\t%-s\n", k, v.Address)
-			}
-
-			return nil
-		},
 	}
-	ls.Flags().BoolVarP(&quiet, "quiet", "q", false, "Print rows without column headers")
+	quiet := ls.Flags().BoolP("quiet", "q", false, "Print rows without column headers")
+	ls.RunE = func(c *cobra.Command, args []string) error {
+		entries, err := plugins().List()
+		if err != nil {
+			return err
+		}
+
+		if !*quiet {
+			fmt.Printf("%-20s\t%-s\n", "NAME", "LISTEN")
+		}
+		for k, v := range entries {
+			fmt.Printf("%-20s\t%-s\n", k, v.Address)
+		}
+
+		return nil
+	}
 
 	cmd.AddCommand(&ls)
 

--- a/cmd/manager/swarm.go
+++ b/cmd/manager/swarm.go
@@ -12,49 +12,49 @@ import (
 	"github.com/spf13/cobra"
 )
 
-func swarmEnvironment(backend *backend) *cobra.Command {
-
-	tlsOptions := tlsconfig.Options{}
-	host := "unix:///var/run/docker.sock"
-
-	var pollInterval time.Duration
+func swarmEnvironment(getConfig func() config) *cobra.Command {
 
 	cmd := &cobra.Command{
 		Use:   "swarm",
 		Short: "swarm mode for leader detection and storage",
-		RunE: func(c *cobra.Command, args []string) error {
-
-			dockerClient, err := docker.NewDockerClient(host, &tlsOptions)
-			log.Infoln("Connect to docker", host, "err=", err)
-			if err != nil {
-				return err
-			}
-
-			leader := swarm_leader.NewDetector(pollInterval, dockerClient)
-			snapshot, err := swarm_store.NewSnapshot(dockerClient)
-			if err != nil {
-				return err
-			}
-
-			plugins, err := discovery.NewPluginDiscovery()
-			if err != nil {
-				return err
-			}
-
-			backend.plugins = plugins
-			backend.leader = leader
-			backend.snapshot = snapshot
-
-			return runMain(backend)
-		},
 	}
+	pollInterval := cmd.Flags().Duration("poll-interval", 5*time.Second, "Leader polling interval")
+	host := cmd.Flags().String("host", "unix:///var/run/docker.sock", "Docker host")
+	caFile := cmd.Flags().String("tlscacert", "", "TLS CA cert file path")
+	certFile := cmd.Flags().String("tlscert", "", "TLS cert file path")
+	tlsKey := cmd.Flags().String("tlskey", "", "TLS key file path")
+	insecureSkipVerify := cmd.Flags().Bool("tlsverify", true, "True to skip TLS")
+	cmd.RunE = func(c *cobra.Command, args []string) error {
 
-	cmd.Flags().DurationVar(&pollInterval, "poll-interval", 5*time.Second, "Leader polling interval")
-	cmd.Flags().StringVar(&host, "host", host, "Docker host")
-	cmd.Flags().StringVar(&tlsOptions.CAFile, "tlscacert", "", "TLS CA cert file path")
-	cmd.Flags().StringVar(&tlsOptions.CertFile, "tlscert", "", "TLS cert file path")
-	cmd.Flags().StringVar(&tlsOptions.KeyFile, "tlskey", "", "TLS key file path")
-	cmd.Flags().BoolVar(&tlsOptions.InsecureSkipVerify, "tlsverify", true, "True to skip TLS")
+		dockerClient, err := docker.NewDockerClient(*host, &tlsconfig.Options{
+			CAFile:             *caFile,
+			CertFile:           *certFile,
+			KeyFile:            *tlsKey,
+			InsecureSkipVerify: *insecureSkipVerify,
+		})
+		log.Infoln("Connect to docker", host, "err=", err)
+		if err != nil {
+			return err
+		}
+
+		leader := swarm_leader.NewDetector(*pollInterval, dockerClient)
+		snapshot, err := swarm_store.NewSnapshot(dockerClient)
+		if err != nil {
+			return err
+		}
+
+		plugins, err := discovery.NewPluginDiscovery()
+		if err != nil {
+			return err
+		}
+
+		cfg := getConfig()
+		cfg.plugins = plugins
+		cfg.leader = leader
+		cfg.snapshot = snapshot
+
+		return runMain(cfg)
+	}
 
 	return cmd
 }

--- a/pkg/example/flavor/combo/main.go
+++ b/pkg/example/flavor/combo/main.go
@@ -13,37 +13,33 @@ import (
 
 func main() {
 
-	var logLevel int
-	var name string
-
 	cmd := &cobra.Command{
 		Use:   os.Args[0],
 		Short: "A Flavor plugin that supports composition of other Flavors",
-		Run: func(c *cobra.Command, args []string) {
+	}
+	logLevel := cmd.Flags().Int("log", cli.DefaultLogLevel, "Logging level. 0 is least verbose. Max is 5")
+	name := cmd.Flags().String("name", "flavor-combo", "Plugin name to advertise for discovery")
+	cmd.Run = func(c *cobra.Command, args []string) {
 
-			plugins, err := discovery.NewPluginDiscovery()
+		plugins, err := discovery.NewPluginDiscovery()
+		if err != nil {
+			log.Error(err)
+			os.Exit(1)
+		}
+
+		flavorPluginLookup := func(n string) (flavor.Plugin, error) {
+			endpoint, err := plugins.Find(n)
 			if err != nil {
-				log.Error(err)
-				os.Exit(1)
+				return nil, err
 			}
+			return flavor_rpc.NewClient(endpoint.Address), nil
+		}
 
-			flavorPluginLookup := func(n string) (flavor.Plugin, error) {
-				endpoint, err := plugins.Find(n)
-				if err != nil {
-					return nil, err
-				}
-				return flavor_rpc.NewClient(endpoint.Address), nil
-			}
-
-			cli.SetLogLevel(logLevel)
-			cli.RunPlugin(name, flavor_rpc.PluginServer(NewPlugin(flavorPluginLookup)))
-		},
+		cli.SetLogLevel(*logLevel)
+		cli.RunPlugin(*name, flavor_rpc.PluginServer(NewPlugin(flavorPluginLookup)))
 	}
 
 	cmd.AddCommand(cli.VersionCommand())
-
-	cmd.Flags().IntVar(&logLevel, "log", cli.DefaultLogLevel, "Logging level. 0 is least verbose. Max is 5")
-	cmd.Flags().StringVar(&name, "name", "flavor-combo", "Plugin name to advertise for discovery")
 
 	err := cmd.Execute()
 	if err != nil {

--- a/pkg/example/flavor/vanilla/main.go
+++ b/pkg/example/flavor/vanilla/main.go
@@ -12,22 +12,18 @@ import (
 
 func main() {
 
-	logLevel := cli.DefaultLogLevel
-	var name string
-
 	cmd := &cobra.Command{
 		Use:   os.Args[0],
 		Short: "Vanilla flavor plugin",
-		Run: func(c *cobra.Command, args []string) {
-			cli.SetLogLevel(logLevel)
-			cli.RunPlugin(name, flavor_plugin.PluginServer(vanilla.NewPlugin()))
-		},
+	}
+	logLevel := cmd.Flags().Int("log", cli.DefaultLogLevel, "Logging level. 0 is least verbose. Max is 5")
+	name := cmd.Flags().String("name", "flavor-vanilla", "Plugin name to advertise for discovery")
+	cmd.Run = func(c *cobra.Command, args []string) {
+		cli.SetLogLevel(*logLevel)
+		cli.RunPlugin(*name, flavor_plugin.PluginServer(vanilla.NewPlugin()))
 	}
 
 	cmd.AddCommand(cli.VersionCommand())
-
-	cmd.Flags().IntVar(&logLevel, "log", logLevel, "Logging level. 0 is least verbose. Max is 5")
-	cmd.Flags().StringVar(&name, "name", "flavor-vanilla", "Plugin name to advertise for discovery")
 
 	err := cmd.Execute()
 	if err != nil {

--- a/pkg/example/flavor/zookeeper/main.go
+++ b/pkg/example/flavor/zookeeper/main.go
@@ -12,23 +12,18 @@ import (
 
 func main() {
 
-	var logLevel int
-	var name string
-
 	cmd := &cobra.Command{
 		Use:   os.Args[0],
 		Short: "Zookeeper flavor plugin",
-		Run: func(c *cobra.Command, args []string) {
-
-			cli.SetLogLevel(logLevel)
-			cli.RunPlugin(name, flavor_plugin.PluginServer(zk.NewPlugin()))
-		},
+	}
+	name := cmd.Flags().String("name", "flavor-zookeeper", "Plugin name to advertise for discovery")
+	logLevel := cmd.Flags().Int("log", cli.DefaultLogLevel, "Logging level. 0 is least verbose. Max is 5")
+	cmd.Run = func(c *cobra.Command, args []string) {
+		cli.SetLogLevel(*logLevel)
+		cli.RunPlugin(*name, flavor_plugin.PluginServer(zk.NewPlugin()))
 	}
 
 	cmd.AddCommand(cli.VersionCommand())
-
-	cmd.Flags().StringVar(&name, "name", "flavor-zookeeper", "Plugin name to advertise for discovery")
-	cmd.PersistentFlags().IntVar(&logLevel, "log", cli.DefaultLogLevel, "Logging level. 0 is least verbose. Max is 5")
 
 	err := cmd.Execute()
 	if err != nil {

--- a/pkg/example/instance/file/main.go
+++ b/pkg/example/instance/file/main.go
@@ -11,26 +11,19 @@ import (
 
 func main() {
 
-	var logLevel int
-	var name string
-	var dir string
-
 	cmd := &cobra.Command{
 		Use:   os.Args[0],
 		Short: "File instance plugin",
-		Run: func(c *cobra.Command, args []string) {
-
-			cli.SetLogLevel(logLevel)
-			cli.RunPlugin(name, instance_plugin.PluginServer(NewFileInstancePlugin(dir)))
-		},
+	}
+	name := cmd.Flags().String("name", "instance-file", "Plugin name to advertise for discovery")
+	logLevel := cmd.Flags().Int("log", cli.DefaultLogLevel, "Logging level. 0 is least verbose. Max is 5")
+	dir := cmd.Flags().String("dir", os.TempDir(), "Dir for storing the files")
+	cmd.Run = func(c *cobra.Command, args []string) {
+		cli.SetLogLevel(*logLevel)
+		cli.RunPlugin(*name, instance_plugin.PluginServer(NewFileInstancePlugin(*dir)))
 	}
 
 	cmd.AddCommand(cli.VersionCommand())
-
-	cmd.Flags().StringVar(&name, "name", "instance-file", "Plugin name to advertise for discovery")
-	cmd.PersistentFlags().IntVar(&logLevel, "log", cli.DefaultLogLevel, "Logging level. 0 is least verbose. Max is 5")
-
-	cmd.Flags().StringVar(&dir, "dir", os.TempDir(), "Dir for storing the files")
 
 	err := cmd.Execute()
 	if err != nil {

--- a/pkg/example/instance/terraform/main.go
+++ b/pkg/example/instance/terraform/main.go
@@ -20,26 +20,21 @@ func mustHaveTerraform() {
 
 func main() {
 
-	mustHaveTerraform()
-
-	var name string
-	var logLevel int
-	var dir string
-
 	cmd := &cobra.Command{
 		Use:   os.Args[0],
 		Short: "Terraform instance plugin",
-		Run: func(c *cobra.Command, args []string) {
-			cli.SetLogLevel(logLevel)
-			cli.RunPlugin(name, instance_plugin.PluginServer(NewTerraformInstancePlugin(dir)))
-		},
+	}
+	name := cmd.Flags().String("name", "instance-terraform", "Plugin name to advertise for discovery")
+	logLevel := cmd.Flags().Int("log", cli.DefaultLogLevel, "Logging level. 0 is least verbose. Max is 5")
+	dir := cmd.Flags().String("dir", os.TempDir(), "Dir for storing plan files")
+	cmd.Run = func(c *cobra.Command, args []string) {
+		mustHaveTerraform()
+
+		cli.SetLogLevel(*logLevel)
+		cli.RunPlugin(*name, instance_plugin.PluginServer(NewTerraformInstancePlugin(*dir)))
 	}
 
 	cmd.AddCommand(cli.VersionCommand())
-
-	cmd.Flags().StringVar(&name, "name", "instance-terraform", "Plugin name to advertise for discovery")
-	cmd.PersistentFlags().IntVar(&logLevel, "log", cli.DefaultLogLevel, "Logging level. 0 is least verbose. Max is 5")
-	cmd.Flags().StringVar(&dir, "dir", os.TempDir(), "Dir for storing plan files")
 
 	err := cmd.Execute()
 	if err != nil {

--- a/pkg/example/instance/vagrant/main.go
+++ b/pkg/example/instance/vagrant/main.go
@@ -13,36 +13,38 @@ import (
 
 func main() {
 
-	var name string
-	var logLevel int
-	var dir string
-	var templFile string
-
 	cmd := &cobra.Command{
 		Use:   os.Args[0],
 		Short: "Vagrant instance plugin",
-		Run: func(c *cobra.Command, args []string) {
-			templ := template.Must(template.New("").Parse(vagrant.VagrantFile))
-			if _, err := os.Stat(templFile); err == nil {
-				templ = template.Must(template.ParseFiles(templFile))
-			}
-
-			cli.SetLogLevel(logLevel)
-			cli.RunPlugin(name, instance_plugin.PluginServer(vagrant.NewVagrantPlugin(dir, templ)))
-		},
 	}
-
-	cmd.AddCommand(cli.VersionCommand())
-
-	cmd.Flags().StringVar(&name, "name", "instance-vagrant", "Plugin name to advertise for discovery")
-	cmd.PersistentFlags().IntVar(&logLevel, "log", cli.DefaultLogLevel, "Logging level. 0 is least verbose. Max is 5")
+	name := cmd.Flags().String("name", "instance-vagrant", "Plugin name to advertise for discovery")
+	logLevel := cmd.Flags().Int("log", cli.DefaultLogLevel, "Logging level. 0 is least verbose. Max is 5")
 	defaultDir, err := os.Getwd()
 	if err != nil {
 		log.Error(err)
 		os.Exit(1)
 	}
-	cmd.Flags().StringVar(&dir, "dir", defaultDir, "Vagrant directory")
-	cmd.Flags().StringVar(&templFile, "template", templFile, "Vagrant Template file")
+	dir := cmd.Flags().String("dir", defaultDir, "Vagrant directory")
+	templFile := cmd.Flags().String("template", "", "Vagrant Template file")
+	cmd.RunE = func(c *cobra.Command, args []string) error {
+
+		var templ *template.Template
+		if *templFile == "" {
+			templ = template.Must(template.New("").Parse(vagrant.VagrantFile))
+		} else {
+			var err error
+			templ, err = template.ParseFiles()
+			if err != nil {
+				return err
+			}
+		}
+
+		cli.SetLogLevel(*logLevel)
+		cli.RunPlugin(*name, instance_plugin.PluginServer(vagrant.NewVagrantPlugin(*dir, templ)))
+		return nil
+	}
+
+	cmd.AddCommand(cli.VersionCommand())
 
 	if err := cmd.Execute(); err != nil {
 		log.Error(err)


### PR DESCRIPTION
I'd like to propose this style as a convention for declaring CLI flags and associated variables.  I like this since it eliminates the data flow cycle we frequently had otherwise (declare a zeroed var, refer to zeroed var for flag default, refer to var pointer for arg value).

Signed-off-by: Bill Farner <bill@docker.com>