### PR TITLE
Move all example code under pkg/example

### DIFF
--- a/pkg/example/flavor/swarm/flavor.go
+++ b/pkg/example/flavor/swarm/flavor.go
@@ -1,4 +1,4 @@
-package swarm
+package main
 
 import (
 	"bytes"

--- a/pkg/example/flavor/swarm/flavor_test.go
+++ b/pkg/example/flavor/swarm/flavor_test.go
@@ -1,4 +1,4 @@
-package swarm
+package main
 
 import (
 	"encoding/json"

--- a/pkg/example/flavor/swarm/main.go
+++ b/pkg/example/flavor/swarm/main.go
@@ -6,7 +6,6 @@ import (
 	log "github.com/Sirupsen/logrus"
 	"github.com/docker/go-connections/tlsconfig"
 	"github.com/docker/infrakit/pkg/cli"
-	"github.com/docker/infrakit/pkg/plugin/flavor/swarm"
 	flavor_plugin "github.com/docker/infrakit/pkg/rpc/flavor"
 	"github.com/docker/infrakit/pkg/util/docker/1.24"
 	"github.com/spf13/cobra"
@@ -40,7 +39,7 @@ func main() {
 			return err
 		}
 
-		cli.RunPlugin(*name, flavor_plugin.PluginServer(swarm.NewSwarmFlavor(dockerClient)))
+		cli.RunPlugin(*name, flavor_plugin.PluginServer(NewSwarmFlavor(dockerClient)))
 		return nil
 	}
 

--- a/pkg/example/flavor/vanilla/flavor.go
+++ b/pkg/example/flavor/vanilla/flavor.go
@@ -1,4 +1,4 @@
-package vanilla
+package main
 
 import (
 	"encoding/json"

--- a/pkg/example/flavor/vanilla/main.go
+++ b/pkg/example/flavor/vanilla/main.go
@@ -5,7 +5,6 @@ import (
 
 	log "github.com/Sirupsen/logrus"
 	"github.com/docker/infrakit/pkg/cli"
-	"github.com/docker/infrakit/pkg/plugin/flavor/vanilla"
 	flavor_plugin "github.com/docker/infrakit/pkg/rpc/flavor"
 	"github.com/spf13/cobra"
 )
@@ -20,7 +19,7 @@ func main() {
 	name := cmd.Flags().String("name", "flavor-vanilla", "Plugin name to advertise for discovery")
 	cmd.Run = func(c *cobra.Command, args []string) {
 		cli.SetLogLevel(*logLevel)
-		cli.RunPlugin(*name, flavor_plugin.PluginServer(vanilla.NewPlugin()))
+		cli.RunPlugin(*name, flavor_plugin.PluginServer(NewPlugin()))
 	}
 
 	cmd.AddCommand(cli.VersionCommand())

--- a/pkg/example/flavor/zookeeper/flavor.go
+++ b/pkg/example/flavor/zookeeper/flavor.go
@@ -1,4 +1,4 @@
-package zookeeper
+package main
 
 import (
 	"bytes"

--- a/pkg/example/flavor/zookeeper/main.go
+++ b/pkg/example/flavor/zookeeper/main.go
@@ -5,7 +5,6 @@ import (
 
 	log "github.com/Sirupsen/logrus"
 	"github.com/docker/infrakit/pkg/cli"
-	zk "github.com/docker/infrakit/pkg/plugin/flavor/zookeeper"
 	flavor_plugin "github.com/docker/infrakit/pkg/rpc/flavor"
 	"github.com/spf13/cobra"
 )
@@ -20,7 +19,7 @@ func main() {
 	logLevel := cmd.Flags().Int("log", cli.DefaultLogLevel, "Logging level. 0 is least verbose. Max is 5")
 	cmd.Run = func(c *cobra.Command, args []string) {
 		cli.SetLogLevel(*logLevel)
-		cli.RunPlugin(*name, flavor_plugin.PluginServer(zk.NewPlugin()))
+		cli.RunPlugin(*name, flavor_plugin.PluginServer(NewPlugin()))
 	}
 
 	cmd.AddCommand(cli.VersionCommand())

--- a/pkg/example/instance/vagrant/instance.go
+++ b/pkg/example/instance/vagrant/instance.go
@@ -1,4 +1,4 @@
-package vagrant
+package main
 
 import (
 	"bytes"
@@ -13,19 +13,6 @@ import (
 
 	"github.com/docker/infrakit/pkg/spi/instance"
 )
-
-// VagrantFile is the minimum definition of the vagrant file
-const VagrantFile = `
-Vagrant.configure("2") do |config|
-  config.vm.box = "{{.Properties.Box}}"
-  config.vm.hostname = "infrakit.box"
-  config.vm.network "private_network"{{.NetworkOptions}}
-  config.vm.provision :shell, path: "boot.sh"
-  config.vm.provider :virtualbox do |vb|
-    vb.memory = {{.Properties.Memory}}
-    vb.cpus = {{.Properties.CPUs}}
-  end
-end`
 
 // NewVagrantPlugin creates an instance plugin for vagrant.
 func NewVagrantPlugin(dir string, template *template.Template) instance.Plugin {

--- a/pkg/example/instance/vagrant/main.go
+++ b/pkg/example/instance/vagrant/main.go
@@ -6,7 +6,6 @@ import (
 
 	log "github.com/Sirupsen/logrus"
 	"github.com/docker/infrakit/pkg/cli"
-	"github.com/docker/infrakit/pkg/plugin/instance/vagrant"
 	instance_plugin "github.com/docker/infrakit/pkg/rpc/instance"
 	"github.com/spf13/cobra"
 )
@@ -30,7 +29,7 @@ func main() {
 
 		var templ *template.Template
 		if *templFile == "" {
-			templ = template.Must(template.New("").Parse(vagrant.VagrantFile))
+			templ = template.Must(template.New("").Parse(VagrantFile))
 		} else {
 			var err error
 			templ, err = template.ParseFiles()
@@ -40,7 +39,7 @@ func main() {
 		}
 
 		cli.SetLogLevel(*logLevel)
-		cli.RunPlugin(*name, instance_plugin.PluginServer(vagrant.NewVagrantPlugin(*dir, templ)))
+		cli.RunPlugin(*name, instance_plugin.PluginServer(NewVagrantPlugin(*dir, templ)))
 		return nil
 	}
 
@@ -51,3 +50,16 @@ func main() {
 		os.Exit(1)
 	}
 }
+
+// VagrantFile is the minimum definition of the vagrant file
+const VagrantFile = `
+Vagrant.configure("2") do |config|
+  config.vm.box = "{{.Properties.Box}}"
+  config.vm.hostname = "infrakit.box"
+  config.vm.network "private_network"{{.NetworkOptions}}
+  config.vm.provision :shell, path: "boot.sh"
+  config.vm.provider :virtualbox do |vb|
+    vb.memory = {{.Properties.Memory}}
+    vb.cpus = {{.Properties.CPUs}}
+  end
+end`


### PR DESCRIPTION
We were already partially doing this for some plugins, but these ones were split between `pkg/plugin` and `pkg/example`.  i think it makes everyone's life easier if each plugin's code is centralized.

Signed-off-by: Bill Farner <bill@docker.com>