### PR TITLE
Ensure plugin discovery directory is in place 

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -3,7 +3,7 @@ machine:
     OS: "linux"
     ARCH: "amd64"
 
-    GOVERSION: "1.6"
+    GOVERSION: "1.7"
     GOPATH: "$HOME/.go_workspace"
 
     WORKDIR: "$GOPATH/src/github.com/$CIRCLE_PROJECT_USERNAME/$CIRCLE_PROJECT_REPONAME"

--- a/pkg/cli/serverutil.go
+++ b/pkg/cli/serverutil.go
@@ -1,6 +1,7 @@
 package cli
 
 import (
+	"os"
 	"path"
 
 	log "github.com/Sirupsen/logrus"
@@ -8,12 +9,23 @@ import (
 	"github.com/docker/infrakit/pkg/rpc/server"
 )
 
+// EnsureDirExists makes sure the directory where the socket file will be placed exists.
+func EnsureDirExists(dir string) {
+	os.MkdirAll(dir, 0700)
+}
+
 // RunPlugin runs a plugin server, advertising with the provided name for discovery.
 // The plugin should conform to the rpc call convention as implemented in the rpc package.
 func RunPlugin(name string, plugin server.VersionedInterface) {
-	stoppable, err := server.StartPluginAtPath(path.Join(discovery.Dir(), name), plugin)
+
+	dir := discovery.Dir()
+	EnsureDirExists(dir)
+
+	stoppable, err := server.StartPluginAtPath(path.Join(dir, name), plugin)
 	if err != nil {
 		log.Error(err)
 	}
-	stoppable.AwaitStopped()
+	if stoppable != nil {
+		stoppable.AwaitStopped()
+	}
 }

--- a/pkg/plugin/group/quorum.go
+++ b/pkg/plugin/group/quorum.go
@@ -98,7 +98,8 @@ func (q *quorum) converge() {
 
 	grp := sync.WaitGroup{}
 
-	for _, unknownInstance := range unknownIPs {
+	for _, ip := range unknownIPs {
+		unknownInstance := ip
 		log.Warnf("Destroying instances with unknown IP address: %+v", unknownInstance)
 
 		grp.Add(1)


### PR DESCRIPTION
Small fixes for #308 

  + Ensures the discovery directory is present
  + Don't panic when server can't bind on start up.

This doesn't fix the issue of orphaned socket files after plugins crashed.  That will be in a future PR.