### PR TITLE
Update golang and fix ci error in group plugin quorum

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -3,7 +3,7 @@ machine:
     OS: "linux"
     ARCH: "amd64"
 
-    GOVERSION: "1.6"
+    GOVERSION: "1.7"
     GOPATH: "$HOME/.go_workspace"
 
     WORKDIR: "$GOPATH/src/github.com/$CIRCLE_PROJECT_USERNAME/$CIRCLE_PROJECT_REPONAME"

--- a/pkg/plugin/group/quorum.go
+++ b/pkg/plugin/group/quorum.go
@@ -100,11 +100,12 @@ func (q *quorum) converge() {
 
 	for _, unknownInstance := range unknownIPs {
 		log.Warnf("Destroying instances with unknown IP address: %+v", unknownInstance)
+		uInstance := unknownInstance
 
 		grp.Add(1)
 		go func() {
 			defer grp.Done()
-			q.scaled.Destroy(unknownInstance)
+			q.scaled.Destroy(uInstance)
 		}()
 	}
 


### PR DESCRIPTION
Result require golang version1.7.
https://github.com/docker/infrakit/blob/master/pkg/rpc/server/server.go#L53
https://golang.org/doc/go1.7#net_http_httptest

I get error in CI.

```
cd $WORKDIR && make ci
+ fmt
+ vet
pkg/plugin/group/quorum.go:107: range variable unknownInstance captured by func literal
exit status 1
make: *** [vet] Error 1
```
fix this error.

Signed-off-by: Yuji Oshima <yuji.oshima0x3fd@gmail.com>