### PR TITLE
Add trash vendor tool as part of tools install

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -58,7 +58,8 @@ get-tools:
 	@echo "+ $@"
 	@go get -u \
 		github.com/golang/lint/golint \
-		github.com/wfarner/blockcheck
+		github.com/wfarner/blockcheck \
+		github.com/rancher/trash
 
 vet:
 	@echo "+ $@"


### PR DESCRIPTION
Since [trash](https://github.com/rancher/trash) is being used when updating vendoring, it'd be nice to install it as part of the tools install. 

cc @chungers @wfarner 