### PR TITLE
Automate building of Docker images

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -42,7 +42,4 @@ deployment:
     branch: master
     commands:
       - docker login -u $DOCKER_HUB_USER -p $DOCKER_HUB_PASSWD
-      - DOCKER_PUSH=true DOCKER_TAG_LATEST=true \
-      DOCKER_IMAGE=infrakit/bundle \
-      DOCKER_TAG=master-$CIRCLE_BUILD_NUM \
-      make build-in-container build-docker
+      - DOCKER_PUSH=true DOCKER_TAG_LATEST=true DOCKER_IMAGE="infrakit/bundle" DOCKER_TAG="master-$CIRCLE_BUILD_NUM" make build-in-container build-docker

--- a/circle.yml
+++ b/circle.yml
@@ -2,11 +2,12 @@ machine:
   environment:
     OS: "linux"
     ARCH: "amd64"
-
     GOVERSION: "1.7"
     GOPATH: "$HOME/.go_workspace"
-
     WORKDIR: "$GOPATH/src/github.com/$CIRCLE_PROJECT_USERNAME/$CIRCLE_PROJECT_REPONAME"
+
+  services:
+    - docker
 
 dependencies:
   pre:
@@ -36,3 +37,13 @@ test:
   post:
     # Report to codecov
     - cd $WORKDIR && bash <(curl -s https://codecov.io/bash)
+
+deployment:
+  docker:
+    branch: master
+    commands:
+      - docker login -u $DOCKER_HUB_USER -p $DOCKER_HUB_PASSWD
+      - DOCKER_PUSH=true DOCKER_TAG_LATEST=true \
+      DOCKER_IMAGE=infrakit/bundle \
+      DOCKER_TAG=master-$CIRCLE_BUILD_NUM \
+      make build-in-container build-docker

--- a/circle.yml
+++ b/circle.yml
@@ -1,13 +1,12 @@
 machine:
+  services:
+    - docker
   environment:
     OS: "linux"
     ARCH: "amd64"
     GOVERSION: "1.7"
     GOPATH: "$HOME/.go_workspace"
     WORKDIR: "$GOPATH/src/github.com/$CIRCLE_PROJECT_USERNAME/$CIRCLE_PROJECT_REPONAME"
-
-  services:
-    - docker
 
 dependencies:
   pre:


### PR DESCRIPTION
This adds automation of building docker containers to ease development.  The build `infrakit/bundle` image is for development only and not meant for production deployment. 
