### PR TITLE
rename docker image to devbundle to emphasize for DEVELOPMENT ONLY

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -42,7 +42,7 @@ build-in-container:
 
 # For packaging as Docker container images.  Set the environment variables DOCKER_PUSH, DOCKER_TAG_LATEST
 # if also push to remote repo.  You must have access to the remote repo.
-DOCKER_IMAGE?=infrakit/bundle
+DOCKER_IMAGE?=infrakit/devbundle
 DOCKER_TAG?=dev
 build-docker:
 	@echo "+ $@"

--- a/circle.yml
+++ b/circle.yml
@@ -44,4 +44,4 @@ deployment:
     branch: master
     commands:
       - docker login -e $DOCKER_HUB_EMAIL -u $DOCKER_HUB_USER -p $DOCKER_HUB_PASSWD
-      - DOCKER_PUSH=true DOCKER_TAG_LATEST=true DOCKER_IMAGE="infrakit/bundle" DOCKER_TAG="master-$CIRCLE_BUILD_NUM" DOCKER_BUILD_FLAGS="--rm=false" make build-in-container build-docker
+      - DOCKER_PUSH=true DOCKER_TAG_LATEST=true DOCKER_TAG="master-$CIRCLE_BUILD_NUM" DOCKER_BUILD_FLAGS="--rm=false" make build-docker


### PR DESCRIPTION
Signed-off-by: David Chung <david.chung@docker.com>