### PR TITLE
Remove docker dependency and make version info pkg init() driven

### DIFF
--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -11,8 +11,16 @@ import (
 	"github.com/docker/infrakit/pkg/manager"
 	group_rpc "github.com/docker/infrakit/pkg/rpc/group"
 	"github.com/docker/infrakit/pkg/store"
+	"github.com/docker/infrakit/pkg/util/docker"
 	"github.com/spf13/cobra"
 )
+
+func init() {
+	cli.RegisterInfo("manager - swarm option",
+		map[string]interface{}{
+			"DockerClientAPIVersion": docker.ClientVersion,
+		})
+}
 
 type config struct {
 	id         string

--- a/pkg/cli/version.go
+++ b/pkg/cli/version.go
@@ -3,7 +3,6 @@ package cli
 import (
 	"fmt"
 
-	"github.com/docker/infrakit/pkg/util/docker"
 	"github.com/spf13/cobra"
 )
 
@@ -15,15 +14,32 @@ var (
 	Revision = "Unspecified"
 )
 
+var info = map[string]map[string]interface{}{}
+
+// RegisterInfo allows any packages that use this register additional information to be displayed by the command.
+// For example, a swarm flavor could register the docker api version.  This allows us to selectively incorporate
+// only required dependencies based on package registration (in their init()) without explicitly pulling unused
+// dependencies.
+func RegisterInfo(key string, data map[string]interface{}) {
+	info[key] = data
+}
+
 // VersionCommand creates a cobra Command that prints build version information.
 func VersionCommand() *cobra.Command {
 	return &cobra.Command{
 		Use:   "version",
 		Short: "print build version information",
 		Run: func(cmd *cobra.Command, args []string) {
-			fmt.Printf("Version:             %s\n", Version)
-			fmt.Printf("Revision:            %s\n", Revision)
-			fmt.Printf("DockerClientVersion: %s\n", docker.ClientVersion)
+			fmt.Printf("\n%-24s:  %v", "Version", Version)
+			fmt.Printf("\n%-24s:  %v", "Revision", Revision)
+			for k, m := range info {
+				fmt.Printf("\n\n%s", k)
+				for kk, vv := range m {
+					fmt.Printf("\n%-24s:  %v", kk, vv)
+				}
+				fmt.Printf("\n")
+			}
+			fmt.Println()
 		},
 	}
 }

--- a/pkg/example/flavor/swarm/main.go
+++ b/pkg/example/flavor/swarm/main.go
@@ -11,6 +11,13 @@ import (
 	"github.com/spf13/cobra"
 )
 
+func init() {
+	cli.RegisterInfo("swarm-flavor",
+		map[string]interface{}{
+			"DockerClientAPIVersion": docker.ClientVersion,
+		})
+}
+
 func main() {
 
 	cmd := &cobra.Command{


### PR DESCRIPTION
Previously the docker version was included in a binary's `version` command.
While this was good for diagnostics, it's a problem for other repos that don't make use the Docker client at all -- this forced a dependency when vendoring to pull in the Docker client libraries.
This PR takes a registration approach where the inclusion of the Docker client information is
driven by the packages that make use of the `cli.VersionCommand`.   As such it's a more flexible mechanism for plugin implementations to expose ad-hoc info under the `version` command, without unnecessary dependencies.

For example, the swarm flavor binary:

```shell
$ build/infrakit-flavor-swarm version

Version                 :  48a450c.m
Revision                :  48a450c74c868d965cc7b5ffcc9f5c64b4c3ad65

swarm-flavor
DockerClientAPIVersion  :  1.24
```
Signed-off-by: David Chung <david.chung@docker.com>