### PR TITLE
Exec schema change and test script updates

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -143,7 +143,7 @@ coverage:
 
 tutorial-test: binaries
 	@echo "+ $@"
-	./scripts/tutorial-test
+	./scripts/tutorial-test2
 
 test-full:
 	@echo "+ $@"

--- a/circle.yml
+++ b/circle.yml
@@ -10,6 +10,7 @@ machine:
     GOPATH: "$HOME/.go_workspace"
     WORKDIR: "$GOPATH/src/github.com/$CIRCLE_PROJECT_USERNAME/$CIRCLE_PROJECT_REPONAME"
     DOCKER_RM: "false"
+    SKIP_CLEANUP: "true"
 
 dependencies:
   pre:

--- a/pkg/launch/monitor_test.go
+++ b/pkg/launch/monitor_test.go
@@ -73,8 +73,10 @@ func TestMonitorLoopValidRule(t *testing.T) {
 	var receivedArgs *Config
 	rule := Rule{
 		Plugin: "hello",
-		Exec:   "test",
-		Launch: raw,
+		Launch: ExecRule{
+			Exec:       "test",
+			Properties: raw,
+		},
 	}
 	monitor := NewMonitor(&testLauncher{
 		name: "test",

--- a/scripts/tutorial-start-plugins.json
+++ b/scripts/tutorial-start-plugins.json
@@ -1,28 +1,34 @@
 [
     {
-	"Plugin" : "group-default",
-	"Exec" : "os",
-	"Launch" : {
-	    "Cmd" : "infrakit-group-default --poll-interval 500ms --name group-stateless --log 5 > {{env "LOG_DIR"}}/group-default-{{unixtime}}.log 2>&1 &",
-	    "SamePgID" : true
-	}
+        "Plugin" : "group-default",
+        "Launch" : {
+            "Exec" : "os",
+            "Properties": {
+                "Cmd" : "infrakit-group-default --poll-interval 500ms --name group-stateless --log 5 > {{env "LOG_DIR"}}/group-default-{{unixtime}}.log 2>&1 &",
+                "SamePgID" : true
+            }
+        }
     }
     ,
     {
-	"Plugin" : "instance-file",
-	"Exec" : "os",
-	"Launch" : {
-	    "Cmd" : "infrakit-instance-file --dir {{env "TUTORIAL_DIR"}} --log 5 > {{env "LOG_DIR"}}/instance-file-{{unixtime}}.log 2>&1",
-	    "SamePgID" : true
-	}
+        "Plugin" : "instance-file",
+        "Launch" : {
+            "Exec" : "os",
+            "Properties" : {
+                "Cmd" : "infrakit-instance-file --dir {{env "TUTORIAL_DIR"}} --log 5 > {{env "LOG_DIR"}}/instance-file-{{unixtime}}.log 2>&1",
+                "SamePgID" : true
+            }
+        }
     }
     ,
     {
-	"Plugin" : "flavor-vanilla",
-	"Exec" : "os",
-	"Launch" : {
-	    "Cmd" : "infrakit-flavor-vanilla --log 5 > {{env "LOG_DIR"}}/flavor-vanilla-{{unixtime}}.log 2>&1",
-	    "SamePgID" : true
-	}
+        "Plugin" : "flavor-vanilla",
+        "Launch" : {
+            "Exec" : "os",
+            "Properties" : {
+                "Cmd" : "infrakit-flavor-vanilla --log 5 > {{env "LOG_DIR"}}/flavor-vanilla-{{unixtime}}.log 2>&1",
+                "SamePgID" : true
+            }
+        }
     }
 ]

--- a/scripts/tutorial-test2
+++ b/scripts/tutorial-test2
@@ -6,6 +6,8 @@ set -o nounset
 HERE="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 cd "$HERE/.."
 
+export PATH=$PWD/build:$PATH
+
 starterpid="" # pid of the cli plugin starter
 cleanup() {
     pgid=$(ps -o pgid= -p $starterpid)
@@ -32,9 +34,9 @@ echo group > $leaderfile
 
 # start up multiple instances of manager -- typically we want multiple SETS of plugins and managers
 # but here for simplicity just start up with multiple managers and one set of plugins
-build/infrakit-manager --name group --proxy-for-group group-stateless os --leader-file $leaderfile --store-dir $configstore &
-build/infrakit-manager --name group1 --proxy-for-group group-stateless os --leader-file $leaderfile --store-dir $configstore &
-build/infrakit-manager --name group2 --proxy-for-group group-stateless os --leader-file $leaderfile --store-dir $configstore &
+infrakit-manager --name group --proxy-for-group group-stateless os --leader-file $leaderfile --store-dir $configstore &
+infrakit-manager --name group1 --proxy-for-group group-stateless os --leader-file $leaderfile --store-dir $configstore &
+infrakit-manager --name group2 --proxy-for-group group-stateless os --leader-file $leaderfile --store-dir $configstore &
 
 sleep 5  # manager needs to detect leadership
 
@@ -52,7 +54,7 @@ export LOG_DIR=$LOG_DIR
 export TUTORIAL_DIR=$TUTORIAL_DIR
 
 # note -- on exit, this won't clean up the plugins started by the cli since they will be in a separate process group
-build/infrakit plugin start --wait --config-url file:///$PWD/scripts/tutorial-start-plugins.json --os group-default instance-file flavor-vanilla &
+infrakit plugin start --wait --config-url file:///$PWD/scripts/tutorial-start-plugins.json --os group-default instance-file flavor-vanilla &
 
 starterpid=$!
 echo "plugin start pid=$starterpid"
@@ -95,33 +97,33 @@ expect_output_lines() {
   fi
 }
 
-expect_output_lines "6 plugins should be discoverable" "build/infrakit plugin ls -q" "6"
-expect_output_lines "0 instances should exist" "build/infrakit instance describe -q --name instance-file" "0"
+expect_output_lines "6 plugins should be discoverable" "infrakit plugin ls -q" "6"
+expect_output_lines "0 instances should exist" "infrakit instance describe -q --name instance-file" "0"
 
 echo "Commiting"
-build/infrakit group commit docs/cattle.json
+infrakit group commit docs/cattle.json
 
 echo 'Waiting for group to be provisioned'
 sleep 2
 
-expect_output_lines "5 instances should exist in group" "build/infrakit group describe cattle -q" "5"
-expect_output_lines "5 instances should exist" "build/infrakit instance describe -q --name instance-file" "5"
+expect_output_lines "5 instances should exist in group" "infrakit group describe cattle -q" "5"
+expect_output_lines "5 instances should exist" "infrakit instance describe -q --name instance-file" "5"
 
-build/infrakit group free cattle
-build/infrakit group commit docs/cattle.json
+infrakit group free cattle
+infrakit group commit docs/cattle.json
 
-expect_exact_output "Should be watching one group" "build/infrakit group ls -q" "cattle"
+expect_exact_output "Should be watching one group" "infrakit group ls -q" "cattle"
 
 expect_exact_output \
   "Update should roll 5 and scale group to 10" \
-  "build/infrakit group commit docs/cattle2.json --pretend" \
+  "infrakit group commit docs/cattle2.json --pretend" \
   "Committing cattle would involve: Performing a rolling update on 5 instances, then adding 5 instances to increase the group size to 10"
 
-build/infrakit group commit docs/cattle2.json
+infrakit group commit docs/cattle2.json
 
 sleep 5
 
-expect_output_lines "10 instances should exist in group" "build/infrakit group describe cattle -q" "10"
+expect_output_lines "10 instances should exist in group" "infrakit group describe cattle -q" "10"
 
 # Terminate 3 instances.
 pushd $TUTORIAL_DIR
@@ -130,9 +132,9 @@ popd
 
 sleep 5
 
-expect_output_lines "10 instances should exist in group" "build/infrakit group describe cattle -q" "10"
+expect_output_lines "10 instances should exist in group" "infrakit group describe cattle -q" "10"
 
-build/infrakit group destroy cattle
-expect_output_lines "0 instances should exist" "build/infrakit instance describe -q --name instance-file" "0"
+infrakit group destroy cattle
+expect_output_lines "0 instances should exist" "infrakit instance describe -q --name instance-file" "0"
 
 echo 'ALL TESTS PASSED'

--- a/scripts/tutorial-test2
+++ b/scripts/tutorial-test2
@@ -8,6 +8,8 @@ cd "$HERE/.."
 
 export PATH=$PWD/build:$PATH
 
+SKIP_CLEANUP=${SKIP_CLEANUP:-false}
+
 starterpid="" # pid of the cli plugin starter
 cleanup() {
     pgid=$(ps -o pgid= -p $starterpid)
@@ -18,7 +20,7 @@ cleanup() {
     rm -rf tutorial
 }
 
-if [ "DOCKER_RM" = "true" ]; then
+if [ "$SKIP_CLEANUP" != "true" ]; then
     trap cleanup EXIT
 fi
 

--- a/scripts/tutorial-test2
+++ b/scripts/tutorial-test2
@@ -12,12 +12,15 @@ starterpid="" # pid of the cli plugin starter
 cleanup() {
     pgid=$(ps -o pgid= -p $starterpid)
     echo "Stopping plugin starter utility - $starterpid , pgid=$pgid"
-    $(kill -TERM -$pgid)
+    kill -TERM -$pgid
     echo "Stopping other jobs"
     kill $(jobs -p)
     rm -rf tutorial
 }
-trap cleanup EXIT
+
+if [ "DOCKER_RM" = "true" ]; then
+    trap cleanup EXIT
+fi
 
 # infrakit directories
 plugins=~/.infrakit/plugins

--- a/scripts/tutorial-test2
+++ b/scripts/tutorial-test2
@@ -6,9 +6,14 @@ set -o nounset
 HERE="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 cd "$HERE/.."
 
+starterpid="" # pid of the cli plugin starter
 cleanup() {
-  kill $(jobs -p)
-  rm -rf tutorial
+    pgid=$(ps -o pgid= -p $starterpid)
+    echo "Stopping plugin starter utility - $starterpid , pgid=$pgid"
+    kill -TERM -$pgid
+    echo "Stopping other jobs"
+    kill $(jobs -p)
+    rm -rf tutorial
 }
 trap cleanup EXIT
 
@@ -49,8 +54,8 @@ export TUTORIAL_DIR=$TUTORIAL_DIR
 # note -- on exit, this won't clean up the plugins started by the cli since they will be in a separate process group
 build/infrakit plugin start --wait --config-url file:///$PWD/scripts/tutorial-start-plugins.json --os group-default instance-file flavor-vanilla &
 
-lastpid=$!
-echo "plugin start pid=$lastpid"
+starterpid=$!
+echo "plugin start pid=$starterpid"
 
 sleep 5
 

--- a/scripts/tutorial-test2
+++ b/scripts/tutorial-test2
@@ -12,7 +12,7 @@ starterpid="" # pid of the cli plugin starter
 cleanup() {
     pgid=$(ps -o pgid= -p $starterpid)
     echo "Stopping plugin starter utility - $starterpid , pgid=$pgid"
-    kill -TERM -$pgid
+    $(kill -TERM -$pgid)
     echo "Stopping other jobs"
     kill $(jobs -p)
     rm -rf tutorial


### PR DESCRIPTION
This PR introduces a minor schema change for the config JSON for starting up plugins.  Specifically, the configuration and specification of which executor (how the plugin is started -- using `os` or some other mechanism like Docker) is now better associated with the properties required by the executor.  The JSON also follows the convention of using `Properties` for arbitrary block of JSON config.
  + Updated the code for parsing the new schema
  + Updated the end to end tester (`scripts/tutorial-test2`) and its config JSON (`scripts/tutorial-start-plugins.json`) to reflect the schema change.
  + Updated the tester script (`scripts/tutorial-test2`) to be the target in `make ci` and send kill signals to the process group (of plugins) started by the CLI utility `infrakit plugin start`.  This ensures proper cleanup of the test.  Note that we made this possible by setting the plugin processes to be in the same process group as the CLI utility (see the config JSON for entries with property `SamePgID` set to `true`).
