### PR TITLE
Plugin management utility - plugin stop

### DIFF
--- a/cmd/cli/plugin.go
+++ b/cmd/cli/plugin.go
@@ -2,8 +2,13 @@ package main
 
 import (
 	"fmt"
+	"io/ioutil"
+	sys_os "os"
+	"strconv"
 	"sync"
+	"syscall"
 
+	log "github.com/Sirupsen/logrus"
 	"github.com/docker/infrakit/pkg/discovery"
 	"github.com/docker/infrakit/pkg/launch"
 	"github.com/docker/infrakit/pkg/launch/os"
@@ -128,7 +133,67 @@ func pluginCommand(plugins func() discovery.Plugins) *cobra.Command {
 		return nil
 	}
 
-	cmd.AddCommand(ls, start)
+	stop := &cobra.Command{
+		Use:   "stop",
+		Short: "Stop named plugins. Args are a list of plugin names.  This assumes plugins are local processes and not containers managed by another daemon, like Docker or runc.",
+	}
+
+	stop.RunE = func(c *cobra.Command, args []string) error {
+
+		allPlugins, err := plugins().List()
+		if err != nil {
+			return err
+		}
+
+		for _, n := range args {
+
+			p, has := allPlugins[n]
+			if !has {
+				log.Warningf("Plugin %s not running", n)
+				continue
+			}
+
+			if p.Protocol != "unix" {
+				log.Warningf("Plugin is not a local process", n)
+				continue
+			}
+
+			// TODO(chungers) -- here we
+			pidFile := p.Address + ".pid"
+
+			buff, err := ioutil.ReadFile(pidFile)
+			if err != nil {
+				log.Warningf("Cannot read PID file for %s: %s", n, pidFile)
+				continue
+			}
+
+			pid, err := strconv.Atoi(string(buff))
+			if err != nil {
+				log.Warningf("Cannot determine PID for %s from file: %s", n, pidFile)
+				continue
+			}
+
+			process, err := sys_os.FindProcess(pid)
+			if err != nil {
+				log.Warningf("Error finding process of plugin %s", n)
+				continue
+			}
+
+			log.Infoln("Stopping", n, "at PID=", pid)
+			if err := process.Signal(syscall.SIGTERM); err == nil {
+				_, err := process.Wait()
+				log.Infoln("Process for", n, "exited")
+				if err != nil {
+					log.Warningln("error=", err)
+				}
+			}
+
+		}
+
+		return nil
+	}
+
+	cmd.AddCommand(ls, start, stop)
 
 	return cmd
 }

--- a/cmd/cli/plugin.go
+++ b/cmd/cli/plugin.go
@@ -181,11 +181,8 @@ func pluginCommand(plugins func() discovery.Plugins) *cobra.Command {
 
 			log.Infoln("Stopping", n, "at PID=", pid)
 			if err := process.Signal(syscall.SIGTERM); err == nil {
-				_, err := process.Wait()
+				process.Wait()
 				log.Infoln("Process for", n, "exited")
-				if err != nil {
-					log.Warningln("error=", err)
-				}
 			}
 
 		}

--- a/pkg/discovery/dir.go
+++ b/pkg/discovery/dir.go
@@ -85,8 +85,10 @@ func (r *dirPluginDiscovery) List() (map[string]*plugin.Endpoint, error) {
 
 			instance, err := r.dirLookup(entry)
 
-			if err != nil && !IsErrNotUnixSocket(err) {
-				log.Warningln("Loading plugin err=", err)
+			if err != nil {
+				if !IsErrNotUnixSocket(err) {
+					log.Warningln("Loading plugin err=", err)
+				}
 				continue
 			}
 

--- a/pkg/discovery/dir.go
+++ b/pkg/discovery/dir.go
@@ -11,6 +11,18 @@ import (
 	"github.com/docker/infrakit/pkg/plugin"
 )
 
+type errNotUnixSocket string
+
+func (e errNotUnixSocket) Error() string {
+	return string(e)
+}
+
+// IsErrNotUnixSocket returns true if the error is due to the file not being a valid unix socket.
+func IsErrNotUnixSocket(e error) bool {
+	_, is := e.(errNotUnixSocket)
+	return is
+}
+
 type dirPluginDiscovery struct {
 	dir  string
 	lock sync.Mutex
@@ -51,7 +63,7 @@ func (r *dirPluginDiscovery) dirLookup(entry os.FileInfo) (*plugin.Endpoint, err
 		}, nil
 	}
 
-	return nil, fmt.Errorf("File is not a socket: %s", entry)
+	return nil, errNotUnixSocket(fmt.Sprintf("File is not a socket: %s", entry))
 }
 
 // List returns a list of plugins known, keyed by the name
@@ -72,8 +84,14 @@ func (r *dirPluginDiscovery) List() (map[string]*plugin.Endpoint, error) {
 		if !entry.IsDir() {
 
 			instance, err := r.dirLookup(entry)
-			if err != nil || instance == nil {
+
+			if err != nil && !IsErrNotUnixSocket(err) {
 				log.Warningln("Loading plugin err=", err)
+				continue
+			}
+
+			if instance == nil {
+				log.Warningln("Plugin in nil=")
 				continue
 			}
 

--- a/pkg/discovery/dir_test.go
+++ b/pkg/discovery/dir_test.go
@@ -13,6 +13,12 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func TestErrNotUnixSocket(t *testing.T) {
+	err := errNotUnixSocket("no socket!")
+	require.Error(t, err)
+	require.True(t, IsErrNotUnixSocket(err))
+}
+
 func blockWhileFileExists(name string) {
 	for {
 		_, err := os.Stat(name)

--- a/scripts/e2e-test-plugins.json
+++ b/scripts/e2e-test-plugins.json
@@ -5,7 +5,7 @@
             "Exec" : "os",
             "Properties": {
                 "Cmd" : "infrakit-group-default --poll-interval 500ms --name group-stateless --log 5 > {{env "LOG_DIR"}}/group-default-{{unixtime}}.log 2>&1 &",
-                "SamePgID" : false
+                "SamePgID" : true
             }
         }
     }

--- a/scripts/e2e-test-plugins.json
+++ b/scripts/e2e-test-plugins.json
@@ -5,7 +5,7 @@
             "Exec" : "os",
             "Properties": {
                 "Cmd" : "infrakit-group-default --poll-interval 500ms --name group-stateless --log 5 > {{env "LOG_DIR"}}/group-default-{{unixtime}}.log 2>&1 &",
-                "SamePgID" : true
+                "SamePgID" : false
             }
         }
     }

--- a/scripts/e2e-test.sh
+++ b/scripts/e2e-test.sh
@@ -142,3 +142,6 @@ infrakit group destroy cattle
 expect_output_lines "0 instances should exist" "infrakit instance describe -q --name instance-file" "0"
 
 echo 'ALL TESTS PASSED'
+
+echo "Stopping plugins"
+infrakit plugin stop group-default instance-file flavor-vanilla


### PR DESCRIPTION
This PR tries to address a common complaint about running Infrakit: starting and stopping of plugins.  Plugin servers now write a `<name>.pid` file in the same plugin discovery directory.  For non-containerized cases, the pid is used by a new command line verb `infrakit plugin stop` to send `SIGTERM` to the plugin processes for force clean shutdown.  On shutting down the PID file is removed cleanly as is with the socket file.
  
  + CLI / mains now write a PID file (see `pkg/cli/serverutil.go`) and cleanup on shutdown.
  + Change discovery to be less noisy when seeing a non-socket file (which can be a pid file).
  + Added a new verb `stop` under `infrakit plugin`.  This simply reads the pid files and send `SIGTERM` to the process: in essence it does `kill -TERM $(cat /plugins/plugin.pid)`.
  + Incorporated this command in the e2e script - `scripts/e2e-test.sh`.

This is useful for stopping the plugins when the starter `infrakit plugin start` exits (no `--wait` option) and the plugins become orphaned (adopted by _init_).  Another applicable scenario is when the config json (e.g. `scripts/e2e-test-plugins.json`) used by the start utility has specified the plugins be running in a separate process group -- which also will leave the plugins running after the starter exits.

Workflow:
```shell
$ ~/projects/src/github.com/docker/infrakit/build/infrakit plugin start --os --config-url file://$PWD/scripts/e2e-test-plugins.json group-default
Starting up group-default
# .... lots of logs
$ ~/projects/src/github.com/docker/infrakit/build/infrakit plugin ls
NAME                	LISTEN
group-stateless     	/Users/me/.infrakit/plugins/group-stateless
~/projects/src/github.com/docker/infrakit$ build/infrakit plugin stop group-stateless
# ... logs
```