### PR TITLE
Handshake early to detect plugin version mismatch

### DIFF
--- a/cmd/cli/flavor.go
+++ b/cmd/cli/flavor.go
@@ -34,8 +34,11 @@ func flavorPluginCommand(plugins func() discovery.Plugins) *cobra.Command {
 			return err
 		}
 
-		flavorPlugin = flavor_plugin.NewClient(plugin.Name(*name), endpoint.Address)
-
+		p, err := flavor_plugin.NewClient(plugin.Name(*name), endpoint.Address)
+		if err != nil {
+			return err
+		}
+		flavorPlugin = p
 		return nil
 	}
 

--- a/cmd/cli/group.go
+++ b/cmd/cli/group.go
@@ -37,8 +37,11 @@ func groupPluginCommand(plugins func() discovery.Plugins) *cobra.Command {
 			return err
 		}
 
-		groupPlugin = group_plugin.NewClient(endpoint.Address)
-
+		p, err := group_plugin.NewClient(endpoint.Address)
+		if err != nil {
+			return err
+		}
+		groupPlugin = p
 		return nil
 	}
 

--- a/cmd/cli/instance.go
+++ b/cmd/cli/instance.go
@@ -32,8 +32,11 @@ func instancePluginCommand(plugins func() discovery.Plugins) *cobra.Command {
 			return err
 		}
 
-		instancePlugin = instance_plugin.NewClient(plugin.Name(*name), endpoint.Address)
-
+		p, err := instance_plugin.NewClient(plugin.Name(*name), endpoint.Address)
+		if err != nil {
+			return err
+		}
+		instancePlugin = p
 		return nil
 	}
 

--- a/cmd/group/main.go
+++ b/cmd/group/main.go
@@ -41,7 +41,7 @@ func main() {
 			if err != nil {
 				return nil, err
 			}
-			return instance_client.NewClient(n, endpoint.Address), nil
+			return instance_client.NewClient(n, endpoint.Address)
 		}
 
 		flavorPluginLookup := func(n plugin.Name) (flavor.Plugin, error) {
@@ -49,7 +49,7 @@ func main() {
 			if err != nil {
 				return nil, err
 			}
-			return flavor_client.NewClient(n, endpoint.Address), nil
+			return flavor_client.NewClient(n, endpoint.Address)
 		}
 
 		cli.RunPlugin(*name, group_server.PluginServer(

--- a/examples/flavor/combo/main.go
+++ b/examples/flavor/combo/main.go
@@ -33,7 +33,7 @@ func main() {
 			if err != nil {
 				return nil, err
 			}
-			return flavor_rpc.NewClient(n, endpoint.Address), nil
+			return flavor_rpc.NewClient(n, endpoint.Address)
 		}
 
 		cli.SetLogLevel(*logLevel)

--- a/pkg/manager/group_plugin_impl.go
+++ b/pkg/manager/group_plugin_impl.go
@@ -22,7 +22,7 @@ func (m *manager) proxyForGroupPlugin(name string) (group.Plugin, error) {
 		if err != nil {
 			return nil, err
 		}
-		return rpc.NewClient(endpoint.Address), nil
+		return rpc.NewClient(endpoint.Address)
 	}), nil
 }
 

--- a/pkg/manager/manager.go
+++ b/pkg/manager/manager.go
@@ -332,7 +332,7 @@ func (m *manager) execPlugins(config GlobalSpec, work func(group.Plugin, group.S
 			return err
 		}
 
-		gp := rpc.NewClient(ep.Address)
+		gp, err := rpc.NewClient(ep.Address)
 		if err != nil {
 			log.Warningln("Cannot contact group", id, " at plugin", name, "endpoint=", ep.Address)
 			return err

--- a/pkg/rpc/client/handshake.go
+++ b/pkg/rpc/client/handshake.go
@@ -25,6 +25,19 @@ type handshakeResult struct {
 	err error
 }
 
+type errVersionMismatch string
+
+// Error implements error interface
+func (e errVersionMismatch) Error() string {
+	return string(e)
+}
+
+// IsErrVersionMismatch return true if the error is from mismatched api versions.
+func IsErrVersionMismatch(e error) bool {
+	_, is := e.(errVersionMismatch)
+	return is
+}
+
 func (c *handshakingClient) handshake() error {
 	c.lock.Lock()
 	defer c.lock.Unlock()
@@ -45,11 +58,11 @@ func (c *handshakingClient) handshake() error {
 						err = nil
 						break
 					} else {
-						err = fmt.Errorf(
+						err = errVersionMismatch(fmt.Sprintf(
 							"Plugin supports %s interface version %s, client requires %s",
 							iface.Name,
 							iface.Version,
-							c.iface.Version)
+							c.iface.Version))
 					}
 				}
 			}

--- a/pkg/rpc/flavor/client.go
+++ b/pkg/rpc/flavor/client.go
@@ -11,8 +11,12 @@ import (
 )
 
 // NewClient returns a plugin interface implementation connected to a remote plugin
-func NewClient(name plugin.Name, socketPath string) flavor.Plugin {
-	return &client{name: name, client: rpc_client.New(socketPath, flavor.InterfaceSpec)}
+func NewClient(name plugin.Name, socketPath string) (flavor.Plugin, error) {
+	rpcClient, err := rpc_client.New(socketPath, flavor.InterfaceSpec)
+	if err != nil {
+		return nil, err
+	}
+	return &client{name: name, client: rpcClient}, nil
 }
 
 type client struct {

--- a/pkg/rpc/flavor/rpc_multi_test.go
+++ b/pkg/rpc/flavor/rpc_multi_test.go
@@ -14,6 +14,13 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func must(p flavor.Plugin, err error) flavor.Plugin {
+	if err != nil {
+		panic(err)
+	}
+	return p
+}
+
 func TestFlavorMultiPluginValidate(t *testing.T) {
 	socketPath := tempSocket()
 	name := filepath.Base(socketPath)
@@ -41,9 +48,9 @@ func TestFlavorMultiPluginValidate(t *testing.T) {
 		}))
 	require.NoError(t, err)
 
-	require.NoError(t, NewClient(plugin.Name(name+"/type1"), socketPath).Validate(inputFlavorProperties1, allocation))
+	require.NoError(t, must(NewClient(plugin.Name(name+"/type1"), socketPath)).Validate(inputFlavorProperties1, allocation))
 
-	err = NewClient(plugin.Name(name+"/type2"), socketPath).Validate(inputFlavorProperties2, allocation)
+	err = must(NewClient(plugin.Name(name+"/type2"), socketPath)).Validate(inputFlavorProperties2, allocation)
 	require.Error(t, err)
 	require.Equal(t, "something-went-wrong", err.Error())
 
@@ -103,14 +110,14 @@ func TestFlavorMultiPluginPrepare(t *testing.T) {
 	))
 	require.NoError(t, err)
 
-	spec, err := NewClient(plugin.Name(name+"/type1"), socketPath).Prepare(
+	spec, err := must(NewClient(plugin.Name(name+"/type1"), socketPath)).Prepare(
 		inputFlavorProperties1,
 		inputInstanceSpec1,
 		allocation)
 	require.NoError(t, err)
 	require.Equal(t, inputInstanceSpec1, spec)
 
-	_, err = NewClient(plugin.Name(name+"/type2"), socketPath).Prepare(
+	_, err = must(NewClient(plugin.Name(name+"/type2"), socketPath)).Prepare(
 		inputFlavorProperties2,
 		inputInstanceSpec2,
 		allocation)
@@ -165,11 +172,11 @@ func TestFlavorMultiPluginHealthy(t *testing.T) {
 		}))
 	require.NoError(t, err)
 
-	health, err := NewClient(plugin.Name(name+"/type1"), socketPath).Healthy(inputProperties1, inputInstance1)
+	health, err := must(NewClient(plugin.Name(name+"/type1"), socketPath)).Healthy(inputProperties1, inputInstance1)
 	require.NoError(t, err)
 	require.Equal(t, flavor.Healthy, health)
 
-	_, err = NewClient(plugin.Name(name+"/type2"), socketPath).Healthy(inputProperties2, inputInstance2)
+	_, err = must(NewClient(plugin.Name(name+"/type2"), socketPath)).Healthy(inputProperties2, inputInstance2)
 	require.Error(t, err)
 	require.Equal(t, "oh-noes", err.Error())
 
@@ -222,12 +229,12 @@ func TestFlavorMultiPluginDrain(t *testing.T) {
 	))
 	require.NoError(t, err)
 
-	require.NoError(t, NewClient(plugin.Name(name+"/type1"), socketPath).Drain(inputProperties1, inputInstance1))
+	require.NoError(t, must(NewClient(plugin.Name(name+"/type1"), socketPath)).Drain(inputProperties1, inputInstance1))
 
 	require.Equal(t, inputProperties1, <-inputPropertiesActual1)
 	require.Equal(t, inputInstance1, <-inputInstanceActual1)
 
-	err = NewClient(plugin.Name(name+"/type2"), socketPath).Drain(inputProperties2, inputInstance2)
+	err = must(NewClient(plugin.Name(name+"/type2"), socketPath)).Drain(inputProperties2, inputInstance2)
 	require.Error(t, err)
 	require.Equal(t, "oh-noes", err.Error())
 

--- a/pkg/rpc/flavor/rpc_test.go
+++ b/pkg/rpc/flavor/rpc_test.go
@@ -72,7 +72,7 @@ func TestFlavorPluginValidate(t *testing.T) {
 	}))
 	require.NoError(t, err)
 
-	require.NoError(t, NewClient(plugin.Name(name), socketPath).Validate(inputFlavorProperties, allocation))
+	require.NoError(t, must(NewClient(plugin.Name(name), socketPath)).Validate(inputFlavorProperties, allocation))
 
 	server.Stop()
 
@@ -94,7 +94,7 @@ func TestFlavorPluginValidateError(t *testing.T) {
 	}))
 	require.NoError(t, err)
 
-	err = NewClient(plugin.Name(name), socketPath).Validate(inputFlavorProperties, allocation)
+	err = must(NewClient(plugin.Name(name), socketPath)).Validate(inputFlavorProperties, allocation)
 	require.Error(t, err)
 	require.Equal(t, "something-went-wrong", err.Error())
 
@@ -128,7 +128,7 @@ func TestFlavorPluginPrepare(t *testing.T) {
 	}))
 	require.NoError(t, err)
 
-	spec, err := NewClient(plugin.Name(name), socketPath).Prepare(
+	spec, err := must(NewClient(plugin.Name(name), socketPath)).Prepare(
 		inputFlavorProperties,
 		inputInstanceSpec,
 		allocation)
@@ -167,7 +167,7 @@ func TestFlavorPluginPrepareError(t *testing.T) {
 	}))
 	require.NoError(t, err)
 
-	_, err = NewClient(plugin.Name(name), socketPath).Prepare(
+	_, err = must(NewClient(plugin.Name(name), socketPath)).Prepare(
 		inputFlavorProperties,
 		inputInstanceSpec,
 		allocation)
@@ -200,7 +200,7 @@ func TestFlavorPluginHealthy(t *testing.T) {
 	}))
 	require.NoError(t, err)
 
-	health, err := NewClient(plugin.Name(name), socketPath).Healthy(inputProperties, inputInstance)
+	health, err := must(NewClient(plugin.Name(name), socketPath)).Healthy(inputProperties, inputInstance)
 	require.NoError(t, err)
 	require.Equal(t, flavor.Healthy, health)
 
@@ -229,7 +229,7 @@ func TestFlavorPluginHealthyError(t *testing.T) {
 	}))
 	require.NoError(t, err)
 
-	_, err = NewClient(plugin.Name(name), socketPath).Healthy(inputProperties, inputInstance)
+	_, err = must(NewClient(plugin.Name(name), socketPath)).Healthy(inputProperties, inputInstance)
 	require.Error(t, err)
 	require.Equal(t, "oh-noes", err.Error())
 
@@ -258,7 +258,7 @@ func TestFlavorPluginDrain(t *testing.T) {
 	}))
 	require.NoError(t, err)
 
-	require.NoError(t, NewClient(plugin.Name(name), socketPath).Drain(inputProperties, inputInstance))
+	require.NoError(t, must(NewClient(plugin.Name(name), socketPath)).Drain(inputProperties, inputInstance))
 
 	require.Equal(t, inputProperties, <-inputPropertiesActual)
 	require.Equal(t, inputInstance, <-inputInstanceActual)
@@ -285,7 +285,7 @@ func TestFlavorPluginDrainError(t *testing.T) {
 	}))
 	require.NoError(t, err)
 
-	err = NewClient(plugin.Name(name), socketPath).Drain(inputProperties, inputInstance)
+	err = must(NewClient(plugin.Name(name), socketPath)).Drain(inputProperties, inputInstance)
 	require.Error(t, err)
 	require.Equal(t, "oh-noes", err.Error())
 

--- a/pkg/rpc/group/client.go
+++ b/pkg/rpc/group/client.go
@@ -6,8 +6,13 @@ import (
 )
 
 // NewClient returns a plugin interface implementation connected to a remote plugin
-func NewClient(socketPath string) group.Plugin {
-	return &client{client: rpc_client.New(socketPath, group.InterfaceSpec)}
+func NewClient(socketPath string) (group.Plugin, error) {
+	rpcClient, err := rpc_client.New(socketPath, group.InterfaceSpec)
+	if err != nil {
+		return nil, err
+	}
+
+	return &client{client: rpcClient}, nil
 }
 
 type client struct {

--- a/pkg/rpc/group/rpc_test.go
+++ b/pkg/rpc/group/rpc_test.go
@@ -37,6 +37,13 @@ func (t *testPlugin) InspectGroups() ([]group.Spec, error) {
 	return t.DoInspectGroups()
 }
 
+func must(p group.Plugin, err error) group.Plugin {
+	if err != nil {
+		panic(err)
+	}
+	return p
+}
+
 func tempSocket() string {
 	dir, err := ioutil.TempDir("", "infrakit-test-")
 	if err != nil {
@@ -63,7 +70,7 @@ func TestGroupPluginCommitGroup(t *testing.T) {
 	}))
 
 	// Make call
-	details, err := NewClient(socketPath).CommitGroup(groupSpec, false)
+	details, err := must(NewClient(socketPath)).CommitGroup(groupSpec, false)
 	require.NoError(t, err)
 	require.Equal(t, "commit details", details)
 
@@ -89,7 +96,7 @@ func TestGroupPluginCommitGroupError(t *testing.T) {
 	}))
 	require.NoError(t, err)
 
-	_, err = NewClient(socketPath).CommitGroup(groupSpec, false)
+	_, err = must(NewClient(socketPath)).CommitGroup(groupSpec, false)
 	require.Error(t, err)
 	require.Equal(t, "error", err.Error())
 
@@ -111,7 +118,7 @@ func TestGroupPluginFreeGroup(t *testing.T) {
 	}))
 	require.NoError(t, err)
 
-	err = NewClient(socketPath).FreeGroup(id)
+	err = must(NewClient(socketPath)).FreeGroup(id)
 	require.NoError(t, err)
 
 	server.Stop()
@@ -131,7 +138,7 @@ func TestGroupPluginFreeGroupError(t *testing.T) {
 	}))
 	require.NoError(t, err)
 
-	err = NewClient(socketPath).FreeGroup(id)
+	err = must(NewClient(socketPath)).FreeGroup(id)
 	require.Error(t, err)
 	require.Equal(t, "no", err.Error())
 
@@ -152,7 +159,7 @@ func TestGroupPluginDestroyGroup(t *testing.T) {
 	}))
 	require.NoError(t, err)
 
-	err = NewClient(socketPath).DestroyGroup(id)
+	err = must(NewClient(socketPath)).DestroyGroup(id)
 	require.NoError(t, err)
 
 	server.Stop()
@@ -172,7 +179,7 @@ func TestGroupPluginDestroyGroupError(t *testing.T) {
 	}))
 	require.NoError(t, err)
 
-	err = NewClient(socketPath).DestroyGroup(id)
+	err = must(NewClient(socketPath)).DestroyGroup(id)
 	require.Error(t, err)
 	require.Equal(t, "no", err.Error())
 
@@ -199,7 +206,7 @@ func TestGroupPluginInspectGroup(t *testing.T) {
 		},
 	}))
 
-	res, err := NewClient(socketPath).DescribeGroup(id)
+	res, err := must(NewClient(socketPath)).DescribeGroup(id)
 	require.NoError(t, err)
 	require.Equal(t, desc, res)
 
@@ -226,7 +233,7 @@ func TestGroupPluginInspectGroupError(t *testing.T) {
 	}))
 	require.NoError(t, err)
 
-	_, err = NewClient(socketPath).DescribeGroup(id)
+	_, err = must(NewClient(socketPath)).DescribeGroup(id)
 	require.Error(t, err)
 	require.Equal(t, "no", err.Error())
 

--- a/pkg/rpc/instance/client.go
+++ b/pkg/rpc/instance/client.go
@@ -9,8 +9,12 @@ import (
 )
 
 // NewClient returns a plugin interface implementation connected to a plugin
-func NewClient(name plugin.Name, socketPath string) instance.Plugin {
-	return &client{name: name, client: rpc_client.New(socketPath, instance.InterfaceSpec)}
+func NewClient(name plugin.Name, socketPath string) (instance.Plugin, error) {
+	rpcClient, err := rpc_client.New(socketPath, instance.InterfaceSpec)
+	if err != nil {
+		return nil, err
+	}
+	return &client{name: name, client: rpcClient}, nil
 }
 
 type client struct {

--- a/pkg/rpc/instance/rpc_multi_test.go
+++ b/pkg/rpc/instance/rpc_multi_test.go
@@ -12,6 +12,13 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func must(i instance.Plugin, err error) instance.Plugin {
+	if err != nil {
+		panic(err)
+	}
+	return i
+}
+
 func TestInstanceTypedPluginValidate(t *testing.T) {
 	socketPath := tempSocket()
 	name := filepath.Base(socketPath)
@@ -43,13 +50,13 @@ func TestInstanceTypedPluginValidate(t *testing.T) {
 		}))
 	require.NoError(t, err)
 
-	err = NewClient(plugin.Name(name+"/type1"), socketPath).Validate(raw1)
+	err = must(NewClient(plugin.Name(name+"/type1"), socketPath)).Validate(raw1)
 	require.NoError(t, err)
 
-	err = NewClient(plugin.Name(name+"/type2"), socketPath).Validate(raw2)
+	err = must(NewClient(plugin.Name(name+"/type2"), socketPath)).Validate(raw2)
 	require.NoError(t, err)
 
-	err = NewClient(plugin.Name(name+"/typeUnknown"), socketPath).Validate(raw2)
+	err = must(NewClient(plugin.Name(name+"/typeUnknown"), socketPath)).Validate(raw2)
 	require.Error(t, err)
 	require.Equal(t, "no-plugin:typeUnknown", err.Error())
 
@@ -89,11 +96,11 @@ func TestInstanceTypedPluginValidateError(t *testing.T) {
 	}))
 	require.NoError(t, err)
 
-	err = NewClient(plugin.Name(name+"/type1"), socketPath).Validate(raw1)
+	err = must(NewClient(plugin.Name(name+"/type1"), socketPath)).Validate(raw1)
 	require.Error(t, err)
 	require.Equal(t, "whoops", err.Error())
 
-	err = NewClient(plugin.Name(name+"/type2"), socketPath).Validate(raw2)
+	err = must(NewClient(plugin.Name(name+"/type2"), socketPath)).Validate(raw2)
 	require.Error(t, err)
 	require.Equal(t, "whoops2", err.Error())
 
@@ -147,15 +154,15 @@ func TestInstanceTypedPluginProvision(t *testing.T) {
 	require.NoError(t, err)
 
 	var id *instance.ID
-	id, err = NewClient(plugin.Name(name+"/type1"), socketPath).Provision(spec1)
+	id, err = must(NewClient(plugin.Name(name+"/type1"), socketPath)).Provision(spec1)
 	require.NoError(t, err)
 	require.Nil(t, id)
 
-	id, err = NewClient(plugin.Name(name+"/type2"), socketPath).Provision(spec2)
+	id, err = must(NewClient(plugin.Name(name+"/type2"), socketPath)).Provision(spec2)
 	require.NoError(t, err)
 	require.Equal(t, "test", string(*id))
 
-	_, err = NewClient(plugin.Name(name+"/error"), socketPath).Provision(spec3)
+	_, err = must(NewClient(plugin.Name(name+"/error"), socketPath)).Provision(spec3)
 	require.Error(t, err)
 	require.Equal(t, "nope", err.Error())
 
@@ -192,10 +199,10 @@ func TestInstanceTypedPluginDestroy(t *testing.T) {
 		}))
 	require.NoError(t, err)
 
-	err = NewClient(plugin.Name(name+"/type1"), socketPath).Destroy(inst1)
+	err = must(NewClient(plugin.Name(name+"/type1"), socketPath)).Destroy(inst1)
 	require.NoError(t, err)
 
-	err = NewClient(plugin.Name(name+"/type2"), socketPath).Destroy(inst2)
+	err = must(NewClient(plugin.Name(name+"/type2"), socketPath)).Destroy(inst2)
 	require.Error(t, err)
 	require.Equal(t, "can't do", err.Error())
 
@@ -250,15 +257,15 @@ func TestInstanceTypedPluginDescribeInstances(t *testing.T) {
 			},
 		}))
 
-	l, err := NewClient(plugin.Name(name+"/type1"), socketPath).DescribeInstances(tags1)
+	l, err := must(NewClient(plugin.Name(name+"/type1"), socketPath)).DescribeInstances(tags1)
 	require.NoError(t, err)
 	require.Equal(t, list1, l)
 
-	l, err = NewClient(plugin.Name(name+"/type2"), socketPath).DescribeInstances(tags2)
+	l, err = must(NewClient(plugin.Name(name+"/type2"), socketPath)).DescribeInstances(tags2)
 	require.NoError(t, err)
 	require.Equal(t, list2, l)
 
-	_, err = NewClient(plugin.Name(name+"/type3"), socketPath).DescribeInstances(tags3)
+	_, err = must(NewClient(plugin.Name(name+"/type3"), socketPath)).DescribeInstances(tags3)
 	require.Error(t, err)
 	require.Equal(t, "bad", err.Error())
 

--- a/pkg/rpc/instance/rpc_test.go
+++ b/pkg/rpc/instance/rpc_test.go
@@ -68,7 +68,7 @@ func TestInstancePluginValidate(t *testing.T) {
 	}))
 	require.NoError(t, err)
 
-	err = NewClient(name, socketPath).Validate(raw)
+	err = must(NewClient(name, socketPath)).Validate(raw)
 	require.NoError(t, err)
 
 	server.Stop()
@@ -94,7 +94,7 @@ func TestInstancePluginValidateError(t *testing.T) {
 	}))
 	require.NoError(t, err)
 
-	err = NewClient(name, socketPath).Validate(raw)
+	err = must(NewClient(name, socketPath)).Validate(raw)
 	require.Error(t, err)
 	require.Equal(t, "whoops", err.Error())
 
@@ -120,7 +120,7 @@ func TestInstancePluginProvisionNil(t *testing.T) {
 	require.NoError(t, err)
 
 	var id *instance.ID
-	id, err = NewClient(name, socketPath).Provision(spec)
+	id, err = must(NewClient(name, socketPath)).Provision(spec)
 	require.NoError(t, err)
 	require.Nil(t, id)
 
@@ -148,7 +148,7 @@ func TestInstancePluginProvision(t *testing.T) {
 	require.NoError(t, err)
 
 	var id *instance.ID
-	id, err = NewClient(name, socketPath).Provision(spec)
+	id, err = must(NewClient(name, socketPath)).Provision(spec)
 	require.NoError(t, err)
 	require.Equal(t, "test", string(*id))
 
@@ -174,7 +174,7 @@ func TestInstancePluginProvisionError(t *testing.T) {
 	}))
 	require.NoError(t, err)
 
-	_, err = NewClient(name, socketPath).Provision(spec)
+	_, err = must(NewClient(name, socketPath)).Provision(spec)
 	require.Error(t, err)
 	require.Equal(t, "nope", err.Error())
 
@@ -198,7 +198,7 @@ func TestInstancePluginDestroy(t *testing.T) {
 	}))
 	require.NoError(t, err)
 
-	err = NewClient(name, socketPath).Destroy(inst)
+	err = must(NewClient(name, socketPath)).Destroy(inst)
 	require.NoError(t, err)
 
 	server.Stop()
@@ -221,7 +221,7 @@ func TestInstancePluginDestroyError(t *testing.T) {
 	}))
 	require.NoError(t, err)
 
-	err = NewClient(name, socketPath).Destroy(inst)
+	err = must(NewClient(name, socketPath)).Destroy(inst)
 	require.Error(t, err)
 	require.Equal(t, "can't do", err.Error())
 
@@ -245,7 +245,7 @@ func TestInstancePluginDescribeInstancesNiInput(t *testing.T) {
 		},
 	}))
 
-	l, err := NewClient(name, socketPath).DescribeInstances(tags)
+	l, err := must(NewClient(name, socketPath)).DescribeInstances(tags)
 	require.NoError(t, err)
 	require.Equal(t, list, l)
 
@@ -272,7 +272,7 @@ func TestInstancePluginDescribeInstances(t *testing.T) {
 	}))
 	require.NoError(t, err)
 
-	l, err := NewClient(name, socketPath).DescribeInstances(tags)
+	l, err := must(NewClient(name, socketPath)).DescribeInstances(tags)
 	require.NoError(t, err)
 	require.Equal(t, list, l)
 
@@ -299,7 +299,7 @@ func TestInstancePluginDescribeInstancesError(t *testing.T) {
 	}))
 	require.NoError(t, err)
 
-	_, err = NewClient(name, socketPath).DescribeInstances(tags)
+	_, err = must(NewClient(name, socketPath)).DescribeInstances(tags)
 	require.Error(t, err)
 	require.Equal(t, "bad", err.Error())
 

--- a/pkg/rpc/server/server_test.go
+++ b/pkg/rpc/server/server_test.go
@@ -46,7 +46,8 @@ func TestUnixSocketServer(t *testing.T) {
 	server, err := StartPluginAtPath(socket, service)
 	require.NoError(t, err)
 
-	c := plugin_rpc.NewClient(name, socket)
+	c, err := plugin_rpc.NewClient(name, socket)
+	require.NoError(t, err)
 
 	err = c.Validate(properties)
 	require.Error(t, err)


### PR DESCRIPTION
This PR is mostly a code refactor to let the RPC client error out early at construction time when there's a version mismatch. 
  + This allows error to happen early before actual spi RPC calls are made.
  + A plugin implementation is still returned, even though future calls will fail unless the the version mismatch is addressed.  We will consider adding mechanism for re-doing handshake thus allowing components to be swapped out on the fly without having to take everything down.
  
Signed-off-by: David Chung <david.chung@docker.com>