### PR TITLE
Workaround for Cobra.Command handling of PersistentPreRunE

### DIFF
--- a/cmd/cli/flavor.go
+++ b/cmd/cli/flavor.go
@@ -28,6 +28,14 @@ func flavorPluginCommand(plugins func() discovery.Plugins) *cobra.Command {
 	name := cmd.PersistentFlags().String("name", "", "Name of plugin")
 
 	cmd.PersistentPreRunE = func(c *cobra.Command, args []string) error {
+		if err := upTree(c, func(x *cobra.Command, argv []string) error {
+			if x.PersistentPreRunE != nil {
+				return x.PersistentPreRunE(x, argv)
+			}
+			return nil
+		}); err != nil {
+			return err
+		}
 
 		endpoint, err := plugins().Find(plugin.Name(*name))
 		if err != nil {

--- a/cmd/cli/group.go
+++ b/cmd/cli/group.go
@@ -31,6 +31,14 @@ func groupPluginCommand(plugins func() discovery.Plugins) *cobra.Command {
 	}
 	name := cmd.PersistentFlags().String("name", DefaultGroupPluginName, "Name of plugin")
 	cmd.PersistentPreRunE = func(c *cobra.Command, args []string) error {
+		if err := upTree(c, func(x *cobra.Command, argv []string) error {
+			if x.PersistentPreRunE != nil {
+				return x.PersistentPreRunE(x, argv)
+			}
+			return nil
+		}); err != nil {
+			return err
+		}
 
 		endpoint, err := plugins().Find(plugin.Name(*name))
 		if err != nil {

--- a/cmd/cli/instance.go
+++ b/cmd/cli/instance.go
@@ -26,6 +26,14 @@ func instancePluginCommand(plugins func() discovery.Plugins) *cobra.Command {
 	}
 	name := cmd.PersistentFlags().String("name", "", "Name of plugin")
 	cmd.PersistentPreRunE = func(c *cobra.Command, args []string) error {
+		if err := upTree(c, func(x *cobra.Command, argv []string) error {
+			if x.PersistentPreRunE != nil {
+				return x.PersistentPreRunE(x, argv)
+			}
+			return nil
+		}); err != nil {
+			return err
+		}
 
 		endpoint, err := plugins().Find(plugin.Name(*name))
 		if err != nil {

--- a/cmd/cli/main.go
+++ b/cmd/cli/main.go
@@ -19,8 +19,9 @@ func main() {
 		Short: "infrakit cli",
 	}
 	logLevel := cmd.PersistentFlags().Int("log", cli.DefaultLogLevel, "Logging level. 0 is least verbose. Max is 5")
-	cmd.PersistentPreRun = func(c *cobra.Command, args []string) {
+	cmd.PersistentPreRunE = func(c *cobra.Command, args []string) error {
 		cli.SetLogLevel(*logLevel)
+		return nil
 	}
 
 	// Don't print usage text for any error returned from a RunE function.  Only print it when explicitly requested.
@@ -56,4 +57,15 @@ func assertNotNil(message string, f interface{}) {
 		log.Error(errors.New(message))
 		os.Exit(1)
 	}
+}
+
+// upTree traverses up the command tree and starts executing the do function in the order from top
+// of the command tree to the bottom.  Cobra commands executes only one level of PersistentPreRunE
+// in reverse order.  This breaks our model of setting log levels at the very top and have the log level
+// set throughout the entire hierarchy of command execution.
+func upTree(c *cobra.Command, do func(*cobra.Command, []string) error) error {
+	if p := c.Parent(); p != nil {
+		return upTree(p, do)
+	}
+	return do(c, c.Flags().Args())
 }

--- a/cmd/cli/manager.go
+++ b/cmd/cli/manager.go
@@ -27,6 +27,14 @@ func managerCommand(plugins func() discovery.Plugins) *cobra.Command {
 		Short: "Access the manager",
 	}
 	cmd.PersistentPreRunE = func(c *cobra.Command, args []string) error {
+		if err := upTree(c, func(x *cobra.Command, argv []string) error {
+			if x.PersistentPreRunE != nil {
+				return x.PersistentPreRunE(x, argv)
+			}
+			return nil
+		}); err != nil {
+			return err
+		}
 
 		// Scan for a manager
 		pm, err := plugins().List()


### PR DESCRIPTION
The command pkg used, `Cobra.Command`, only executes the first `PersistentPreRunE` function, searching from the bottom up the command tree (from leaf subcommands up to the root).  

This creates a problem where for commands like `infrakit manager inspect`, only the `PersistentPreRunE` of the `manager` subcommand is executed, leaving the top level one (where the log level is set) not run at all.  As a result, for deeply nested commands, `--log` doesn't have any effects. 

This PR adds a convenient function `upTree` that is called by the leaf `PersistetPreRunE` to recurse up the tree and then executing some function *in top-to-bottom order*.   This is probably better than patching/forking the library, and not calling the helper function just follows standard Cobra command behavior.

Signed-off-by: David Chung <david.chung@docker.com>