### PR TITLE
Plugin startup config schema change

### DIFF
--- a/examples/flavor/swarm/e2e-plugins.json
+++ b/examples/flavor/swarm/e2e-plugins.json
@@ -2,8 +2,7 @@
     {
         "Plugin" : "group-default",
         "Launch" : {
-            "Exec" : "os",
-            "Properties": {
+            "os": {
                 "Cmd" : "infrakit-group-default --poll-interval 500ms --name group-stateless --log 5 > {{env "LOG_DIR"}}/group-default-{{unixtime}}.log 2>&1 &",
                 "SamePgID" : true
             }
@@ -13,8 +12,7 @@
     {
         "Plugin" : "instance-file",
         "Launch" : {
-            "Exec" : "os",
-            "Properties" : {
+            "os" : {
                 "Cmd" : "infrakit-instance-file --dir {{env "TUTORIAL_DIR"}} --log 5 > {{env "LOG_DIR"}}/instance-file-{{unixtime}}.log 2>&1",
                 "SamePgID" : true
             }
@@ -24,8 +22,7 @@
     {
         "Plugin" : "instance-vagrant",
         "Launch" : {
-            "Exec" : "os",
-            "Properties" : {
+            "os" : {
                 "Cmd" : "infrakit-instance-vagrant --log 5 > {{env "LOG_DIR"}}/instance-vagrant-{{unixtime}}.log 2>&1",
                 "SamePgID" : true
             }
@@ -35,8 +32,7 @@
     {
         "Plugin" : "flavor-vanilla",
         "Launch" : {
-            "Exec" : "os",
-            "Properties" : {
+            "os" : {
                 "Cmd" : "infrakit-flavor-vanilla --log 5 > {{env "LOG_DIR"}}/flavor-vanilla-{{unixtime}}.log 2>&1",
                 "SamePgID" : true
             }
@@ -46,8 +42,7 @@
     {
         "Plugin" : "flavor-swarm",
         "Launch" : {
-            "Exec" : "os",
-            "Properties" : {
+            "os" : {
                 "Cmd" : "infrakit-flavor-swarm --host {{env "SWARM_MANAGER"}} --log 5 > {{env "LOG_DIR"}}/flavor-swarm-{{unixtime}}.log 2>&1",
                 "SamePgID" : true
             }

--- a/pkg/launch/monitor_test.go
+++ b/pkg/launch/monitor_test.go
@@ -69,9 +69,8 @@ func TestMonitorLoopValidRule(t *testing.T) {
 	var receivedArgs *types.Any
 	rule := Rule{
 		Plugin: "hello",
-		Launch: ExecRule{
-			Exec:       "test",
-			Properties: types.AnyValueMust(config),
+		Launch: map[ExecName]*types.Any{
+			"test": types.AnyValueMust(config),
 		},
 	}
 	monitor := NewMonitor(&testLauncher{
@@ -112,9 +111,8 @@ func TestMonitorLoopRuleLookupBehavior(t *testing.T) {
 	var receivedArgs *types.Any
 	rule := Rule{
 		Plugin: "hello",
-		Launch: ExecRule{
-			Exec:       "test",
-			Properties: types.AnyValueMust(config),
+		Launch: map[ExecName]*types.Any{
+			"test": types.AnyValueMust(config),
 		},
 	}
 	monitor := NewMonitor(&testLauncher{

--- a/pkg/launch/os/os.go
+++ b/pkg/launch/os/os.go
@@ -19,8 +19,9 @@ type LaunchConfig struct {
 
 // NewLauncher returns a Launcher that can install and start plugins.  The OS version is simple - it translates
 // plugin names as command names and uses os.Exec
-func NewLauncher() (*Launcher, error) {
+func NewLauncher(n string) (*Launcher, error) {
 	return &Launcher{
+		name:    n,
 		plugins: map[string]state{},
 	}, nil
 }
@@ -31,13 +32,14 @@ type state struct {
 
 // Launcher is a service that implements the launch.Exec interface for starting up os processes.
 type Launcher struct {
+	name    string
 	plugins map[string]state
 	lock    sync.Mutex
 }
 
 // Name returns the name of the launcher
 func (l *Launcher) Name() string {
-	return "os"
+	return l.name
 }
 
 // Exec starts the os process. Returns a signal channel to block on optionally.

--- a/pkg/launch/os/os_test.go
+++ b/pkg/launch/os/os_test.go
@@ -14,7 +14,7 @@ import (
 
 func TestLaunchOSCommand(t *testing.T) {
 
-	launcher, err := NewLauncher()
+	launcher, err := NewLauncher("os")
 	require.NoError(t, err)
 
 	starting, err := launcher.Exec("sleepPlugin", types.AnyValueMust(&LaunchConfig{
@@ -30,7 +30,7 @@ func TestLaunchWithLog(t *testing.T) {
 
 	logfile := filepath.Join(os.TempDir(), fmt.Sprintf("os-test-%v", time.Now().Unix()))
 
-	launcher, err := NewLauncher()
+	launcher, err := NewLauncher("os")
 	require.NoError(t, err)
 
 	starting, err := launcher.Exec("echoPlugin", types.AnyValueMust(&LaunchConfig{

--- a/scripts/e2e-test-plugins.json
+++ b/scripts/e2e-test-plugins.json
@@ -1,22 +1,27 @@
+{{define "rundocker"}}docker run -d --restart always -e INFRAKIT_HOME=/infrakit -e INFRAKIT_PLUGINS_DIR=/infrakit/plugins -v ~/.infrakit:/infrakit --name {{.}} infrakit/devbundle{{end}}
 [
     {
-        "Plugin" : "group-default",
+        "Plugin" : "group-stateless",
         "Launch" : {
-            "Exec" : "os",
-            "Properties": {
-                "Cmd" : "infrakit-group-default --poll-interval 500ms --name group-stateless --log 5 > {{env "LOG_DIR"}}/group-default-{{unixtime}}.log 2>&1 &",
+            "os": {
+                "Cmd" : "infrakit-group-default --poll-interval 500ms --name group-stateless --log 5 > {{env "INFRAKIT_HOME"}}/logs/group-stateless.log 2>&1",
                 "SamePgID" : true
-            }
+            },
+	    "docker-run" : {
+		"Cmd" : "{{template "rundocker" "group-stateless"}} infrakit-group-default --poll-interval 500ms --name group-stateless --log 5"
+	    }
         }
     }
     ,
     {
         "Plugin" : "instance-file",
         "Launch" : {
-            "Exec" : "os",
-            "Properties" : {
-                "Cmd" : "infrakit-instance-file --dir {{env "TUTORIAL_DIR"}} --log 5 > {{env "LOG_DIR"}}/instance-file-{{unixtime}}.log 2>&1",
+            "os" : {
+                "Cmd" : "infrakit-instance-file --dir {{env "INFRAKIT_HOME"}}/instance-file --log 5 > {{env "INFRAKIT_HOME"}}/logs/instance-file.log 2>&1",
                 "SamePgID" : true
+            },
+            "docker-run" : {
+                "Cmd" : "{{template "rundocker" "instance-file"}} infrakit-instance-file --dir {{env "INFRAKIT_HOME"}}/instance-file --log 5"
             }
         }
     }
@@ -24,10 +29,12 @@
     {
         "Plugin" : "instance-vagrant",
         "Launch" : {
-            "Exec" : "os",
-            "Properties" : {
-                "Cmd" : "infrakit-instance-vagrant --log 5 > {{env "LOG_DIR"}}/instance-vagrant-{{unixtime}}.log 2>&1",
+            "os" : {
+                "Cmd" : "infrakit-instance-vagrant --log 5 > {{env "INFRAKIT_HOME"}}/logs/instance-vagrant.log 2>&1",
                 "SamePgID" : true
+            },
+            "docker-run" : {
+                "Cmd" : "{{template "rundocker" "instance-vagrant"}} infrakit-instance-vagrant --log 5"
             }
         }
     }
@@ -35,10 +42,12 @@
     {
         "Plugin" : "flavor-vanilla",
         "Launch" : {
-            "Exec" : "os",
-            "Properties" : {
-                "Cmd" : "infrakit-flavor-vanilla --log 5 > {{env "LOG_DIR"}}/flavor-vanilla-{{unixtime}}.log 2>&1",
+            "os" : {
+                "Cmd" : "infrakit-flavor-vanilla --log 5 > {{env "INFRAKIT_HOME"}}/logs/flavor-vanilla.log 2>&1",
                 "SamePgID" : true
+            },
+            "docker-run" : {
+                "Cmd" : "{{template "rundocker" "flavor-vanilla"}} infrakit-flavor-vanilla --log 5"
             }
         }
     }
@@ -46,10 +55,12 @@
     {
         "Plugin" : "flavor-swarm",
         "Launch" : {
-            "Exec" : "os",
-            "Properties" : {
-                "Cmd" : "infrakit-flavor-swarm --host {{env "SWARM_MANAGER"}} --log 5 > {{env "LOG_DIR"}}/flavor-swarm-{{unixtime}}.log 2>&1",
+            "os" : {
+                "Cmd" : "infrakit-flavor-swarm --host {{env "SWARM_MANAGER"}} --log 5 > {{env "INFRAKIT_HOME"}}/logs/flavor-swarm.log 2>&1",
                 "SamePgID" : true
+            },
+            "docker-run" : {
+                "Cmd" : "{{template "rundocker" "flavor-swarm"}} infrakit-flavor-swarm --host {{env "SWARM_MANAGER"}} --log 5"
             }
         }
     }

--- a/scripts/e2e-test.sh
+++ b/scripts/e2e-test.sh
@@ -24,16 +24,19 @@ cleanup() {
 trap cleanup EXIT
 
 # infrakit directories
-plugins=~/.infrakit/plugins
+
+export INFRAKIT_HOME=~/.infrakit
+
+plugins=$INFRAKIT_HOME/plugins
 mkdir -p $plugins
 rm -rf $plugins/*
 
-configstore=~/.infrakit/configs
+configstore=$INFRAKIT_HOME/configs
 mkdir -p $configstore
 rm -rf $configstore/*
 
 # set the leader -- for os / file based leader detection for manager
-leaderfile=~/.infrakit/leader
+leaderfile=$INFRAKIT_HOME/leader
 echo group > $leaderfile
 
 # start up multiple instances of manager -- typically we want multiple SETS of plugins and managers
@@ -46,19 +49,18 @@ sleep 5  # manager needs to detect leadership
 
 # location of logfiles when plugins are started by the plugin cli
 # the config json below expects LOG_DIR as an environment variable
-LOG_DIR=~/.infrakit/logs
+LOG_DIR=$INFRAKIT_HOME/logs
 mkdir -p $LOG_DIR
 
-# see the config josn 'e2e-test-plugins.json' for reference of environment variable TUTORIAL_DIR
-TUTORIAL_DIR=~/.infrakit/tutorial
-mkdir -p $TUTORIAL_DIR
-rm -rf $TUTORIAL_DIR/*
+# see the config josn 'e2e-test-plugins.json' for reference of environment variable
+INSTANCE_FILE_DIR=$INFRAKIT_HOME/instance-file
+mkdir -p $INSTANCE_FILE_DIR
+rm -rf $INSTANCE_FILE_DIR/*
 
 export LOG_DIR=$LOG_DIR
-export TUTORIAL_DIR=$TUTORIAL_DIR
 
 # note -- on exit, this won't clean up the plugins started by the cli since they will be in a separate process group
-infrakit plugin start --wait --config-url file:///$PWD/scripts/e2e-test-plugins.json --os group-default instance-file flavor-vanilla &
+infrakit plugin start --wait --config-url file:///$PWD/scripts/e2e-test-plugins.json --exec os group-stateless instance-file flavor-vanilla &
 
 starterpid=$!
 echo "plugin start pid=$starterpid"
@@ -130,7 +132,7 @@ sleep 5
 expect_output_lines "10 instances should exist in group" "infrakit group describe cattle -q" "10"
 
 # Terminate 3 instances.
-pushd $TUTORIAL_DIR
+pushd $INSTANCE_FILE_DIR
   rm $(ls | head -3)
 popd
 


### PR DESCRIPTION
This PR changes the schema of plugin launch config to better support different executors for starting up plugins:
  + `os` - uses `sh -c` to start up non-containerized infrakit binaries.
  + `docker-run` also uses `sh -c` but uses Docker as the executor to run the infrakit containers
The change allows a single JSON config to capture different rules by executor.  See `scripts/e2e-test-plugins.json` for details.

In the future other "executors" for starting up plugins will be added -- e.g. tighter Docker integration via API calls or use runc to run the plugins.

TODO - provide full documentation on the config schema and the template in a future release (before reaching v1.0)

Signed-off-by: David Chung <david.chung@docker.com>