### PR TITLE
Clean shutdown of `infrakit plugin start --wait`

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -41,8 +41,14 @@ test:
     - cd $WORKDIR && bash <(curl -s https://codecov.io/bash)
 
 deployment:
+  release:
+    branch: /release-.*/
+    commands:
+      - docker login -e $DOCKER_HUB_EMAIL -u $DOCKER_HUB_USER -p $DOCKER_HUB_PASSWD
+      - DOCKER_PUSH=true DOCKER_TAG_LATEST=false DOCKER_TAG=$(echo $CIRCLE_BRANCH | awk -F - '{print $2}') DOCKER_BUILD_FLAGS="--rm=false" make build-docker
   docker:
     branch: master
     commands:
       - docker login -e $DOCKER_HUB_EMAIL -u $DOCKER_HUB_USER -p $DOCKER_HUB_PASSWD
       - DOCKER_PUSH=true DOCKER_TAG_LATEST=true DOCKER_TAG="master-$CIRCLE_BUILD_NUM" DOCKER_BUILD_FLAGS="--rm=false" make build-docker
+    


### PR DESCRIPTION
The utility `infrakit plugin start` in wait mode (`--wait`) will wait for the plugins it started to shutdown before terminating.  This PR fixes a bug where it hangs even when all the plugins
have been stopped by another `infrakit plugin stop --all`.