### PR TITLE
Rename template function to avoid shadowing of `index`

### DIFF
--- a/pkg/template/funcs.go
+++ b/pkg/template/funcs.go
@@ -76,9 +76,9 @@ func UnixTime() interface{} {
 	return time.Now().Unix()
 }
 
-// Index returns the index of search in array.  -1 if not found or array is not iterable.  An optional true will
+// IndexOf returns the index of search in array.  -1 if not found or array is not iterable.  An optional true will
 // turn on strict type check while by default string representations are used to compare values.
-func Index(srch interface{}, array interface{}, strictOptional ...bool) int {
+func IndexOf(srch interface{}, array interface{}, strictOptional ...bool) int {
 	strict := false
 	if len(strictOptional) > 0 {
 		strict = strictOptional[0]
@@ -153,6 +153,6 @@ func (t *Template) DefaultFuncs() map[string]interface{} {
 		"lines":     SplitLines,
 		"to_json":   ToJSON,
 		"from_json": FromJSON,
-		"index":     Index,
+		"index_of":  IndexOf,
 	}
 }

--- a/pkg/template/funcs_test.go
+++ b/pkg/template/funcs_test.go
@@ -281,29 +281,29 @@ func TestMapEncodeDecode(t *testing.T) {
 	require.Equal(t, expect, actual)
 }
 
-func TestIndex(t *testing.T) {
-	require.Equal(t, -1, Index("a", []string{"x", "y", "z"}))
-	require.Equal(t, 1, Index("y", []string{"x", "y", "z"}))
-	require.Equal(t, -1, Index(25, []string{"x", "y", "z"}))
-	require.Equal(t, -1, Index(25, 26))
-	require.Equal(t, 1, Index("y", []string{"x", "y", "z"}))
-	require.Equal(t, 1, Index("y", []interface{}{"x", "y", "z"}))
-	require.Equal(t, 1, Index(1, []interface{}{0, 1, 2}))
-	require.Equal(t, 1, Index("1", []interface{}{0, 1, 2}))
-	require.Equal(t, 1, Index(1, []interface{}{0, "1", 2}))
-	require.Equal(t, -1, Index("1", []interface{}{0, 1, 2}, true))  // strict case type must match
-	require.Equal(t, 1, Index("1", []interface{}{0, "1", 2}, true)) // strict case type must match
-	require.Equal(t, -1, Index(1, []interface{}{0, "1", 2}, true))  // strict case type must match
+func TestIndexOf(t *testing.T) {
+	require.Equal(t, -1, IndexOf("a", []string{"x", "y", "z"}))
+	require.Equal(t, 1, IndexOf("y", []string{"x", "y", "z"}))
+	require.Equal(t, -1, IndexOf(25, []string{"x", "y", "z"}))
+	require.Equal(t, -1, IndexOf(25, 26))
+	require.Equal(t, 1, IndexOf("y", []string{"x", "y", "z"}))
+	require.Equal(t, 1, IndexOf("y", []interface{}{"x", "y", "z"}))
+	require.Equal(t, 1, IndexOf(1, []interface{}{0, 1, 2}))
+	require.Equal(t, 1, IndexOf("1", []interface{}{0, 1, 2}))
+	require.Equal(t, 1, IndexOf(1, []interface{}{0, "1", 2}))
+	require.Equal(t, -1, IndexOf("1", []interface{}{0, 1, 2}, true))  // strict case type must match
+	require.Equal(t, 1, IndexOf("1", []interface{}{0, "1", 2}, true)) // strict case type must match
+	require.Equal(t, -1, IndexOf(1, []interface{}{0, "1", 2}, true))  // strict case type must match
 
 	v := "1"
-	require.Equal(t, 1, Index(&v, []interface{}{0, "1", 2}))
-	require.Equal(t, 1, Index(&v, []interface{}{0, &v, 2}, true))
-	require.Equal(t, 1, Index(&v, []interface{}{0, &v, 2}))
+	require.Equal(t, 1, IndexOf(&v, []interface{}{0, "1", 2}))
+	require.Equal(t, 1, IndexOf(&v, []interface{}{0, &v, 2}, true))
+	require.Equal(t, 1, IndexOf(&v, []interface{}{0, &v, 2}))
 
 	a := "0"
 	c := "2"
-	require.Equal(t, 1, Index("1", []*string{&a, &v, &c}))
+	require.Equal(t, 1, IndexOf("1", []*string{&a, &v, &c}))
 
 	// This doesn't work because the type information is gone and we have just an address
-	require.Equal(t, -1, Index("1", []interface{}{0, &v, 2}))
+	require.Equal(t, -1, IndexOf("1", []interface{}{0, &v, 2}))
 }

--- a/pkg/template/integration_test.go
+++ b/pkg/template/integration_test.go
@@ -158,3 +158,31 @@ The message is {{str}}
 	require.True(t, context.Bool)
 	require.Equal(t, 23, context.invokes) // note this is private state not accessible in template
 }
+
+func TestIndexIndexOf(t *testing.T) {
+
+	{
+		tt, err := NewTemplate("str://{{ index . 1 }}", Options{})
+		require.NoError(t, err)
+
+		view, err := tt.Render([]string{"a", "b", "c", "d"})
+		require.NoError(t, err)
+		require.Equal(t, "b", view)
+	}
+	{
+		tt, err := NewTemplate(`str://{{ index_of "c" . }}`, Options{})
+		require.NoError(t, err)
+
+		view, err := tt.Render([]string{"a", "b", "c", "d"})
+		require.NoError(t, err)
+		require.Equal(t, "2", view)
+	}
+	{
+		tt, err := NewTemplate(`str://{{ index . 0 | cat "index-" | nospace }}`, Options{})
+		require.NoError(t, err)
+
+		view, err := tt.Render([]string{"a", "b", "c", "d"})
+		require.NoError(t, err)
+		require.Equal(t, "index-a", view)
+	}
+}


### PR DESCRIPTION
This PR renames the template function `index` to `index_of` so that the name does not shadow the global default `index` function in golang template.