### PR TITLE
New template improvements

### DIFF
--- a/dockerfiles/Dockerfile.bundle
+++ b/dockerfiles/Dockerfile.bundle
@@ -2,4 +2,11 @@ FROM alpine:3.5
 
 RUN apk add --update ca-certificates
 
+RUN mkdir -p /infrakit/plugins /infrakit/configs /infrakit/logs
+
+VOLUME /infrakit
+
+ENV INFRAKIT_HOME /infrakit
+ENV INFRAKIT_PLUGINS_DIR /infrakit/plugins
+
 ADD build/* /usr/local/bin/

--- a/pkg/template/integration_test.go
+++ b/pkg/template/integration_test.go
@@ -169,3 +169,13 @@ func TestAddDef(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, "hello: x + y = 125", view)
 }
+
+func TestSourceAndGlobal(t *testing.T) {
+	r := `{{ global \"foo\" 100 }}`
+	s := `{{ source "str://` + r + `" }}foo={{ref "foo"}}`
+	tt, err := NewTemplate("str://"+s, Options{})
+	require.NoError(t, err)
+	view, err := tt.Render(nil)
+	require.NoError(t, err)
+	require.Equal(t, "foo=100", view)
+}

--- a/pkg/template/template.go
+++ b/pkg/template/template.go
@@ -76,6 +76,8 @@ type Template struct {
 
 	registered []Function
 	lock       sync.Mutex
+
+	parent *Template
 }
 
 // NewTemplate fetches the content at the url and returns a template.  If the string begins
@@ -141,6 +143,12 @@ func (t *Template) AddDef(name string, val interface{}, doc ...string) *Template
 		Doc:   strings.Join(doc, " "),
 	}
 	return t
+}
+
+func (t *Template) updateGlobal(name string, value interface{}) {
+	t.lock.Lock()
+	defer t.lock.Unlock()
+	t.binds[name] = value
 }
 
 // Validate parses the template and checks for validity.


### PR DESCRIPTION
This PR contains:
  + Adding a new `source` function that allows a template to source another template, and when the sourced template declares any global variables, the variables are propagated back up to be visible in the enclosing template.  This is useful for patterns that declare common parameters that are used across multiple templates.
  + Added ENV and  VOLUME in Dockerfile