### PR TITLE
Template improvements

### DIFF
--- a/examples/flavor/swarm/flavor.go
+++ b/examples/flavor/swarm/flavor.go
@@ -160,7 +160,7 @@ func (s *baseFlavor) prepare(role string, flavorProperties *types.Any, instanceS
 			log.Warningln("Worker prepare:", err)
 		}
 
-		swarmID := "?"
+		swarmID = "?"
 		if swarmStatus != nil {
 			swarmID = swarmStatus.ID
 		}

--- a/examples/flavor/swarm/flavor.go
+++ b/examples/flavor/swarm/flavor.go
@@ -342,7 +342,7 @@ func (c *templateContext) Funcs() []template.Function {
 			},
 		},
 		{
-			Name:        "SWARM_MANAGER_IP",
+			Name:        "SWARM_MANAGER_ADDR",
 			Description: []string{"IP of the Swarm manager / leader"},
 			Func: func() (string, error) {
 				if c.nodeInfo == nil {

--- a/examples/flavor/swarm/templates.go
+++ b/examples/flavor/swarm/templates.go
@@ -20,7 +20,7 @@ EOF
 kill -s HUP $(cat /var/run/docker.pid)
 sleep 5
 
-{{ if eq INSTANCE_LOGICAL_ID SPEC.SwarmJoinIP }}
+{{ if and ( eq INSTANCE_LOGICAL_ID SPEC.SwarmJoinIP ) (not SWARM_INITIALIZED) }}
 
   {{/* The first node of the special allocations will initialize the swarm. */}}
   docker swarm init --advertise-addr {{ INSTANCE_LOGICAL_ID }}
@@ -34,7 +34,7 @@ sleep 5
 {{ else }}
 
   {{/* The rest of the nodes will join as followers in the manager group. */}}
-  docker swarm join --token {{ SWARM_JOIN_TOKENS.Manager }} {{ SPEC.SwarmJoinIP }}:2377
+  docker swarm join --token {{ SWARM_JOIN_TOKENS.Manager }} {{ SWARM_MANAGER_ADDR }}
 
 {{ end }}
 `
@@ -59,7 +59,7 @@ kill -s HUP $(cat /var/run/docker.pid)
 
 sleep 5
 
-docker swarm join --token {{  SWARM_JOIN_TOKENS.Worker }} {{ SPEC.SwarmJoinIP }}:2377
+docker swarm join --token {{  SWARM_JOIN_TOKENS.Worker }} {{ SWARM_MANAGER_ADDR }}
 
 `
 )

--- a/pkg/template/funcs.go
+++ b/pkg/template/funcs.go
@@ -2,7 +2,6 @@ package template
 
 import (
 	"bytes"
-	"encoding/gob"
 	"encoding/json"
 	"fmt"
 	"reflect"
@@ -15,8 +14,8 @@ import (
 // DeepCopyObject makes a deep copy of the argument, using encoding/gob encode/decode.
 func DeepCopyObject(from interface{}) (interface{}, error) {
 	var mod bytes.Buffer
-	enc := gob.NewEncoder(&mod)
-	dec := gob.NewDecoder(&mod)
+	enc := json.NewEncoder(&mod)
+	dec := json.NewDecoder(&mod)
 	err := enc.Encode(from)
 	if err != nil {
 		return nil, err

--- a/pkg/template/funcs.go
+++ b/pkg/template/funcs.go
@@ -1,6 +1,8 @@
 package template
 
 import (
+	"bytes"
+	"encoding/gob"
 	"encoding/json"
 	"fmt"
 	"reflect"
@@ -9,6 +11,24 @@ import (
 
 	"github.com/jmespath/go-jmespath"
 )
+
+// DeepCopyObject makes a deep copy of the argument, using encoding/gob encode/decode.
+func DeepCopyObject(from interface{}) (interface{}, error) {
+	var mod bytes.Buffer
+	enc := gob.NewEncoder(&mod)
+	dec := gob.NewDecoder(&mod)
+	err := enc.Encode(from)
+	if err != nil {
+		return nil, err
+	}
+
+	copy := reflect.New(reflect.TypeOf(from))
+	err = dec.Decode(copy.Interface())
+	if err != nil {
+		return nil, err
+	}
+	return reflect.Indirect(copy).Interface(), nil
+}
 
 // QueryObject applies a JMESPath query specified by the expression, against the target object.
 func QueryObject(exp string, target interface{}) (interface{}, error) {
@@ -119,8 +139,14 @@ func (t *Template) DefaultFuncs() []Function {
 			Description: []string{
 				"Source / evaluate the template at the input location (as URL).",
 				"This will make all of the global variables declared there visible in this template's context.",
+				"Similar to 'source' in bash, sourcing another template means applying it in the same context ",
+				"as the calling template.  The context (e.g. variables) of the calling template as a result can be mutated.",
 			},
-			Func: func(p string) (string, error) {
+			Func: func(p string, opt ...interface{}) (string, error) {
+				var o interface{}
+				if len(opt) > 0 {
+					o = opt[0]
+				}
 				loc := p
 				if strings.Index(loc, "str://") == -1 {
 					buff, err := getURL(t.url, p)
@@ -133,19 +159,16 @@ func (t *Template) DefaultFuncs() []Function {
 				if err != nil {
 					return "", err
 				}
-				// copy the binds in the parent scope into the child
-				for k, v := range t.binds {
-					sourced.binds[k] = v
-				}
-				// inherit the functions defined for this template
-				for k, v := range t.funcs {
-					sourced.AddFunc(k, v)
-				}
 				// set this as the parent of the sourced template so its global can mutate the globals in this
 				sourced.parent = t
+				sourced.forkFrom(t)
+				sourced.context = t.context
 
+				if o == nil {
+					o = sourced.context
+				}
 				// TODO(chungers) -- let the sourced template define new functions that can be called in the parent.
-				return sourced.Render(nil)
+				return sourced.Render(o)
 			},
 		},
 		{
@@ -153,28 +176,37 @@ func (t *Template) DefaultFuncs() []Function {
 			Description: []string{
 				"Render content found at URL as template and include here.",
 				"The optional second parameter is the context to use when rendering the template.",
+				"Conceptually similar to exec in bash, where the template included is applied using a fork ",
+				"of current context in the calling template.  Any mutations to the context via 'global' will not ",
+				"be visible in the calling template's context.",
 			},
 			Func: func(p string, opt ...interface{}) (string, error) {
 				var o interface{}
 				if len(opt) > 0 {
 					o = opt[0]
 				}
-				loc, err := getURL(t.url, p)
-				if err != nil {
-					return "", err
+				loc := p
+				if strings.Index(loc, "str://") == -1 {
+					buff, err := getURL(t.url, p)
+					if err != nil {
+						return "", err
+					}
+					loc = buff
 				}
 				included, err := NewTemplate(loc, t.options)
 				if err != nil {
 					return "", err
 				}
-				// copy the binds in the parent scope into the child
-				for k, v := range t.binds {
-					included.binds[k] = v
+				dotCopy, err := included.forkFrom(t)
+				if err != nil {
+					return "", err
 				}
-				// inherit the functions defined for this template
-				for k, v := range t.funcs {
-					included.AddFunc(k, v)
+				included.context = dotCopy
+
+				if o == nil {
+					o = included.context
 				}
+
 				return included.Render(o)
 			},
 		},
@@ -193,10 +225,10 @@ func (t *Template) DefaultFuncs() []Function {
 				"Defines a variable with the first argument as name and last argument value as the default.",
 				"It's also ok to pass a third optional parameter, in the middle, as the documentation string.",
 			},
-			Func: func(name string, args ...interface{}) (string, error) {
+			Func: func(name string, args ...interface{}) (Void, error) {
 				if _, has := t.defaults[name]; has {
 					// not sure if this is good, but should complain loudly
-					return "", fmt.Errorf("already defined: %v", name)
+					return voidValue, fmt.Errorf("already defined: %v", name)
 				}
 				var doc string
 				var value interface{}
@@ -210,7 +242,7 @@ func (t *Template) DefaultFuncs() []Function {
 					value = args[1]
 				}
 				t.AddDef(name, value, doc)
-				return "", nil
+				return voidValue, nil
 			},
 		},
 		{
@@ -220,11 +252,9 @@ func (t *Template) DefaultFuncs() []Function {
 				"This is similar to def (which sets the default value).",
 				"Global variables are propagated to all templates that are rendered via the 'include' function.",
 			},
-			Func: func(name string, v interface{}) interface{} {
-				for here := t; here != nil; here = here.parent {
-					here.updateGlobal(name, v)
-				}
-				return ""
+			Func: func(n string, v interface{}) Void {
+				t.Global(n, v)
+				return voidValue
 			},
 		},
 		{
@@ -233,14 +263,7 @@ func (t *Template) DefaultFuncs() []Function {
 				"References / gets the variable named after the first argument.",
 				"The values must be set first by either def or global.",
 			},
-			Func: func(name string) interface{} {
-				if found, has := t.binds[name]; has {
-					return found
-				} else if v, has := t.defaults[name]; has {
-					return v.Value
-				}
-				return nil
-			},
+			Func: t.Ref,
 		},
 		{
 			Name: "q",

--- a/pkg/template/funcs_test.go
+++ b/pkg/template/funcs_test.go
@@ -25,6 +25,23 @@ type testCloud struct {
 	ResourceList []interface{}
 }
 
+func TestDeepCopyObject(t *testing.T) {
+	resource := "disk"
+	input := testCloud{
+		Parameters: []testParameter{{ParameterKey: "foo", ParameterValue: "bar"}},
+		Resources:  []testResource{{ResourceType: "test", ResourceTypePtr: &resource}},
+	}
+
+	copy, err := DeepCopyObject(input)
+	require.NoError(t, err)
+	require.Equal(t, input, copy)
+	inputStr, err := ToJSON(input)
+	require.NoError(t, err)
+	copyStr, err := ToJSON(copy)
+	require.NoError(t, err)
+	require.Equal(t, inputStr, copyStr)
+}
+
 func TestQueryObjectEncodeDecode(t *testing.T) {
 
 	param1 := testParameter{

--- a/pkg/template/template.go
+++ b/pkg/template/template.go
@@ -71,7 +71,7 @@ type Template struct {
 	body     []byte
 	parsed   *template.Template
 	funcs    map[string]interface{}
-	binds    map[string]interface{}
+	globals  map[string]interface{}
 	defaults map[string]defaultValue
 	context  interface{}
 
@@ -118,7 +118,7 @@ func NewTemplateFromBytes(buff []byte, contextURL string, opt Options) (*Templat
 		url:      contextURL,
 		body:     buff,
 		funcs:    map[string]interface{}{},
-		binds:    map[string]interface{}{},
+		globals:  map[string]interface{}{},
 		defaults: map[string]defaultValue{},
 	}, nil
 }
@@ -154,7 +154,7 @@ func (t *Template) AddDef(name string, val interface{}, doc ...string) *Template
 
 // Ref returns the value keyed by name in the context of this template. See 'ref' template function.
 func (t *Template) Ref(name string) interface{} {
-	if found, has := t.binds[name]; has {
+	if found, has := t.globals[name]; has {
 		return found
 	} else if v, has := t.defaults[name]; has {
 		return v.Value
@@ -171,9 +171,9 @@ func (t *Template) forkFrom(parent *Template) (dotCopy interface{}, err error) {
 	t.lock.Lock()
 	defer t.lock.Unlock()
 
-	// copy the binds in the parent scope into the child
-	for k, v := range parent.binds {
-		t.binds[k] = v
+	// copy the globals in the parent scope into the child
+	for k, v := range parent.globals {
+		t.globals[k] = v
 	}
 	// inherit the functions defined for this template
 	for k, v := range parent.funcs {
@@ -196,7 +196,7 @@ func (t *Template) Global(name string, value interface{}) {
 func (t *Template) updateGlobal(name string, value interface{}) {
 	t.lock.Lock()
 	defer t.lock.Unlock()
-	t.binds[name] = value
+	t.globals[name] = value
 }
 
 // Validate parses the template and checks for validity.


### PR DESCRIPTION
This PR improves the handling of contexts and scoping in the case of 'source' vs. 'include'.
  + When one template "sources" another template, it shares its execution context (the context object and global variables) with the called template -- similar to a bash shell script's 'source' command.  This means that a template that calls `global` can mutate the calling template's variables.  This enables the pattern of using `{{ source "common.ikt" }}` to set commonly used global variables.
  + When a template 'includes' another template, the behavior is similar to a shell script invoking `exec`: the calling template 'forks' a copy of its state (the variables and context object) and pass that on to the template for evaluation.  Any `global` function calls in the included template cannot affect the parent template's variables, but the change is visible for all the other templates it sources or includes.

Signed-off-by: David Chung <david.chung@docker.com>