### PR TITLE
Terraform plugin and Logical IDs allocation

### DIFF
--- a/cmd/cli/manager.go
+++ b/cmd/cli/manager.go
@@ -163,7 +163,7 @@ func managerCommand(plugins func() discovery.Plugins) *cobra.Command {
 			return err
 		}
 
-		// the format is pluing.Spec
+		// the format is plugin.Spec
 		out := []plugin.Spec{}
 		for _, spec := range specs {
 

--- a/examples/instance/terraform/plugin.go
+++ b/examples/instance/terraform/plugin.go
@@ -385,7 +385,7 @@ func (p *plugin) Provision(spec instance.Spec) (*instance.ID, error) {
 
 	// Use tag to store the logical id
 	if spec.LogicalID != nil {
-		if m, ok := properties.Value["tags"].(map[string]string); ok {
+		if m, ok := properties.Value["tags"].(map[string]interface{}); ok {
 			m["LogicalID"] = string(*spec.LogicalID)
 		}
 	}
@@ -603,7 +603,11 @@ func terraformLogicalID(v interface{}) *instance.LogicalID {
 	if !ok {
 		return nil
 	}
-	v, exists := m["tags.LogicalID"]
+	tags, ok := m["tags"].(map[string]interface{})
+	if !ok {
+		return nil
+	}
+	v, exists := tags["LogicalID"]
 	if exists {
 		id := instance.LogicalID(fmt.Sprintf("%v", v))
 		return &id


### PR DESCRIPTION
Fixes #391 

- correctly set the LogicalID tag
- fixes the terraformLogicalID function

Tests are passing successfully.