### PR TITLE
Problem: Unable to create non-Docker Group plugin alternative.

### DIFF
--- a/pkg/rpc/server/info.go
+++ b/pkg/rpc/server/info.go
@@ -42,9 +42,6 @@ func NewPluginInfo(receiver interface{}) (*PluginInfo, error) {
 // Register registers an rpc-capable object for introspection and metadata service
 func (m *PluginInfo) Register(receiver interface{}) error {
 	r := &reflector{target: receiver}
-	if err := r.validate(); err != nil {
-		return err
-	}
 	m.reflectors = append(m.reflectors, r)
 	return nil
 }

--- a/pkg/rpc/server/reflector.go
+++ b/pkg/rpc/server/reflector.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"net/http"
 	"reflect"
-	"strings"
 	"time"
 	"unicode"
 	"unicode/utf8"
@@ -42,14 +41,6 @@ func (r *reflector) exampleProperties() *types.Any {
 // Type returns the target's type, taking into account of pointer receiver
 func (r *reflector) targetType() reflect.Type {
 	return reflect.Indirect(reflect.ValueOf(r.target)).Type()
-}
-
-func (r *reflector) validate() error {
-	t := r.targetType()
-	if !strings.Contains(t.PkgPath(), "github.com/docker/infrakit/pkg/rpc") {
-		return fmt.Errorf("object not a standard plugin type: %v", t)
-	}
-	return nil
 }
 
 // Interface returns the plugin type and version.


### PR DESCRIPTION
Solution: Remove RPC server reflector check for Docker-specific "github.com/docker/infrakit/pkg/rpc" string in package path.

Resolves #389 