### PR TITLE
Terraform plugin private IP and logicalID allocation

### DIFF
--- a/examples/instance/terraform/plugin.go
+++ b/examples/instance/terraform/plugin.go
@@ -389,6 +389,20 @@ func (p *plugin) Provision(spec instance.Spec) (*instance.ID, error) {
 			m["LogicalID"] = string(*spec.LogicalID)
 		}
 	}
+	switch properties.Type {
+	case "aws_instance":
+		if p, exists := properties.Value["private_ip"]; exists {
+			if p == "INSTANCE_LOGICAL_ID" {
+				if spec.LogicalID != nil {
+					// set private IP to logical ID
+					properties.Value["private_ip"] = string(*spec.LogicalID)
+				} else {
+					// reset private IP (the tag is not relevant in this context)
+					delete(properties.Value, "private_ip")
+				}
+			}
+		}
+	}
 
 	// merge the inits
 	switch properties.Type {

--- a/examples/instance/terraform/plugin_test.go
+++ b/examples/instance/terraform/plugin_test.go
@@ -48,6 +48,7 @@ func TestUsage(t *testing.T) {
             "key_name": "PUBKEY",
             "vpc_security_group_ids" : ["${aws_security_group.default.id}"],
             "subnet_id": "${aws_subnet.default.id}",
+            "private_ip": "INSTANCE_LOGICAL_ID",
             "tags" :  {
                 "Name" : "web4",
                 "InstancePlugin" : "terraform"


### PR DESCRIPTION
Fixes #393

When using logical ID allocations, if the private_ip property of the terraform plugin is set to INSTANCE_LOGICAL_ID, the property is replaced with the logical ID. Only enabled for AWS.

Usage example:
```
  {
    "Plugin": "group",
    "Properties": {
      "ID": "swarm-manager",
      "Properties": {
        "Allocation": {
          "LogicalIDs": [
            "192.168.2.200",
            "192.168.2.201",
            "192.168.2.202"
          ]
        },
        "Instance": {
          "Plugin": "instance-terraform",
          "Properties": {
            "Type": "aws_instance",
            "Value": {
              "ami": "${lookup(var.aws_amis, var.aws_region)}",
              "instance_type": "${var.aws_instance_type}",
              "key_name": "${var.aws_key_name}",
              "vpc_security_group_ids": ["${aws_security_group.default.id}"],
              "subnet_id": "${aws_subnet.default.id}",
              "private_ip": "INSTANCE_LOGICAL_ID"
              },
              "connection": {
                "user": "${var.aws_connection_user}"
              }
            }
          }
        },
        ...
```
in conjonction with the swarm flavor plugin.

Needs PR #392 to be applied first.