### PR TITLE
Fix combo flavor

### DIFF
--- a/examples/flavor/combo/flavor.go
+++ b/examples/flavor/combo/flavor.go
@@ -36,7 +36,7 @@ func (f flavorCombo) Healthy(flavorProperties *types.Any, inst instance.Descript
 	// flavor.UnknownHealth is returned as soon as any Flavor reports that value.
 
 	s := Spec{}
-	if err := flavorProperties.Decode(s); err != nil {
+	if err := flavorProperties.Decode(&s); err != nil {
 		return flavor.Unknown, err
 	}
 


### PR DESCRIPTION
The plugin is unable to check the health of an
instance because, Decode() needs to be passed a
pointer

Signed-off-by: David Gageot <david@gageot.net>