### PR TITLE
message broker tests with unix sockets; more tests

### DIFF
--- a/pkg/broker/client/sse.go
+++ b/pkg/broker/client/sse.go
@@ -21,6 +21,9 @@ var (
 type Options struct {
 	// SocketDir is the directory to look for socket files for unix:// urls
 	SocketDir string
+
+	// Path is the URL path, if the server's handler is at the mux path (e.g. /events)
+	Path string
 }
 
 func processEvent(msg []byte) []byte {
@@ -78,6 +81,7 @@ func httpClient(urlString string, opt Options) (*url.URL, *http.Client, error) {
 			return nil, nil, err
 		}
 		u.Scheme = "http"
+		u.Path = "/"
 		return u, c, nil
 	}
 
@@ -87,10 +91,13 @@ func httpClient(urlString string, opt Options) (*url.URL, *http.Client, error) {
 
 // Subscribe subscribes to a topic hosted at given url.  It returns a channel of incoming events and errors
 func Subscribe(url, topic string, opt Options) (<-chan *types.Any, <-chan error, error) {
-
 	u, connection, err := httpClient(url, opt)
 	if err != nil {
 		return nil, nil, err
+	}
+
+	if opt.Path != "" {
+		u.Path = opt.Path
 	}
 
 	req, err := http.NewRequest("GET", u.String(), nil)
@@ -116,20 +123,32 @@ func Subscribe(url, topic string, opt Options) (<-chan *types.Any, <-chan error,
 
 		resp, err := connection.Do(req)
 		if err != nil {
+
+			fmt.Println("-===>", err)
 			errCh <- err
 			close(errCh)
 			close(streamCh)
 			return
 		}
 
-		defer resp.Body.Close()
+		defer func() {
+			resp.Body.Close()
+			close(streamCh)
+			close(errCh)
+		}()
+
+		if resp.StatusCode != http.StatusOK {
+			errCh <- fmt.Errorf("http-status:%v", resp.StatusCode)
+			return
+		}
+
 		reader := bufio.NewReader(resp.Body)
 
 		for {
 			// Read each new line and process the type of event
 			line, err := reader.ReadBytes('\n')
 			if err != nil {
-				close(streamCh)
+				errCh <- err
 				return
 			}
 			if bytes.Contains(line, headerData) {

--- a/pkg/broker/client/sse_test.go
+++ b/pkg/broker/client/sse_test.go
@@ -2,7 +2,8 @@ package client
 
 import (
 	"fmt"
-	"net/http"
+	"io/ioutil"
+	"path/filepath"
 	"testing"
 	"time"
 
@@ -10,61 +11,79 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func _TestBrokerMultiSubscribersEarlyDisconnects(t *testing.T) {
+func tempSocket() string {
+	dir, err := ioutil.TempDir("", "infrakit-test-")
+	if err != nil {
+		panic(err)
+	}
 
-	broker := server.NewBroker()
-	go http.ListenAndServe("localhost:6002", broker)
+	return filepath.Join(dir, "broker")
+}
 
+func TestBrokerMultiSubscribersEarlyDisconnects(t *testing.T) {
+
+	socketFile := tempSocket()
+	socket := "unix://broker" + socketFile
+
+	broker, err := server.ListenAndServeOnSocket(socketFile)
+	require.NoError(t, err)
+
+	sync := make(chan struct{})
 	// Start sending events right away, continously
 	go func() {
-		tick := 0
+		<-sync
+		tick := 1
 		for {
 			<-time.After(100 * time.Millisecond)
 			require.NoError(t, broker.Publish("local/time/tick", tick))
 			tick++
 
-			if tick > 30 {
+			if tick == 30 {
 				broker.Stop()
 				return
 			}
 		}
 	}()
 
-	time.Sleep(200 * time.Millisecond)
-
 	received1 := make(chan interface{})
 	received2 := make(chan interface{})
 
-	topic1, _, err := Subscribe("http://localhost:6002/", "local", Options{})
+	opts := Options{SocketDir: filepath.Dir(socketFile)}
+
+	topic1, _, err := Subscribe(socket, "local", opts)
 	require.NoError(t, err)
 	go func() {
+		<-sync
 		// This subscriber will leave after receiving 5 messages
 		for {
 			var val int
 			require.NoError(t, (<-topic1).Decode(&val))
 			received1 <- val
 
-			if val > 10 {
+			if val == 10 {
 				close(received1)
 				return
 			}
 		}
 	}()
 
-	topic2, _, err := Subscribe("http://localhost:6002/?topic=/local/time", "", Options{})
+	topic2, _, err := Subscribe(socket+"/?topic=/local/time", "", opts)
 	require.NoError(t, err)
 	go func() {
+		<-sync
 		for {
 			var val int
 			require.NoError(t, (<-topic2).Decode(&val))
 			received2 <- val
 
-			if val > 20 {
+			if val == 20 {
 				close(received2)
 				return
 			}
 		}
 	}()
+
+	close(sync)
 
 	values1 := []interface{}{}
 	values2 := []interface{}{}
@@ -86,36 +105,61 @@ func _TestBrokerMultiSubscribersEarlyDisconnects(t *testing.T) {
 	require.Equal(t, 20, len(values2))
 }
 
-func _TestBrokerMultiSubscriberCustomObject(t *testing.T) {
+func TestBrokerMultiSubscriberCustomObject(t *testing.T) {
 
 	type event struct {
 		Time    int64
 		Message string
 	}
 
-	broker := server.NewBroker()
-	go http.ListenAndServe("localhost:6003", broker)
+	socketFile := tempSocket()
+	socket := "unix://broker" + socketFile
+
+	broker, err := server.ListenAndServeOnSocket(socketFile)
+	require.NoError(t, err)
 
 	received1 := make(chan event)
 	received2 := make(chan event)
 
-	topic1, _, err := Subscribe("http://localhost:6003/", "local", Options{})
+	opts := Options{SocketDir: filepath.Dir(socketFile)}
+
+	topic1, errs1, err := Subscribe(socket, "local", opts)
 	require.NoError(t, err)
 	go func() {
 		for {
-			var val event
-			require.NoError(t, (<-topic1).Decode(&val))
-			received1 <- val
+			select {
+
+			case e := <-errs1:
+				panic(e)
+			case m, ok := <-topic1:
+				if ok {
+					var val event
+					require.NoError(t, m.Decode(&val))
+					received1 <- val
+				} else {
+					close(received1)
+				}
+			}
 		}
 	}()
 
-	topic2, _, err := Subscribe("http://localhost:6003/", "local/instance1", Options{})
+	topic2, errs2, err := Subscribe(socket, "local/instance1", opts)
 	require.NoError(t, err)
 	go func() {
 		for {
-			var val event
-			require.NoError(t, (<-topic2).Decode(&val))
-			received2 <- val
+			select {
+
+			case e := <-errs2:
+				panic(e)
+			case m, ok := <-topic2:
+				if ok {
+					var val event
+					require.NoError(t, m.Decode(&val))
+					received2 <- val
+				} else {
+					close(received2)
+				}
+			}
 		}
 	}()
 
@@ -134,9 +178,81 @@ func _TestBrokerMultiSubscriberCustomObject(t *testing.T) {
 	for i := 0; i < 5; i++ {
 		a := <-received1
 		b := <-received2
+		require.NotNil(t, a)
+		require.NotEqual(t, "", a.Message)
 		require.Equal(t, a, b)
 	}
 
+	broker.Stop()
+
+}
+
+// This tests the case where the broker is mapped to url route (e.g. /events)
+// In this case, we need to specify the path option in the connection options so that
+// we can properly connect to the broker at the url prefix.
+func TestBrokerMultiSubscriberCustomObjectConnectAtURLPrefix(t *testing.T) {
+
+	type event struct {
+		Time    int64
+		Message string
+	}
+
+	socketFile := tempSocket()
+	socket := "unix://broker" + socketFile
+
+	broker, err := server.ListenAndServeOnSocket(socketFile, "/events")
+	require.NoError(t, err)
+
+	got404 := make(chan struct{})
+	gotData := make(chan struct{})
+
+	opts := Options{SocketDir: filepath.Dir(socketFile)}
+
+	topic1, errs1, err := Subscribe(socket, "local", opts)
+	require.NoError(t, err)
+	go func() {
+		for {
+			select {
+			case <-errs1:
+				close(got404)
+				return
+			case <-topic1:
+				panic("i shouldn't be here... i expect 404")
+			}
+		}
+	}()
+
+	opts.Path = "events"
+	topic2, errs2, err := Subscribe(socket, "local/instance1", opts)
+	require.NoError(t, err)
+	go func() {
+		for {
+			select {
+
+			case e := <-errs2:
+				panic(e)
+			case m := <-topic2:
+				var val event
+				require.NoError(t, m.Decode(&val))
+				require.NotEqual(t, "", val.Message)
+				close(gotData)
+				return
+			}
+		}
+	}()
+
+	go func() {
+		for {
+			<-time.After(10 * time.Millisecond)
+
+			now := time.Now()
+			evt := event{Time: now.UnixNano(), Message: fmt.Sprintf("Now is %v", now)}
+			require.NoError(t, broker.Publish("local/instance1", evt))
+		}
+	}()
+
+	<-got404
+	<-gotData
 	broker.Stop()
 
 }

--- a/pkg/broker/server/server.go
+++ b/pkg/broker/server/server.go
@@ -1,0 +1,27 @@
+package server
+
+import (
+	"net"
+	"net/http"
+)
+
+// ListenAndServeOnSocket starts a minimal server (mostly for testing) listening at the given unix socket path.
+func ListenAndServeOnSocket(socketPath string, optionalURLPattern ...string) (*Broker, error) {
+	urlPattern := "/"
+	if len(optionalURLPattern) > 0 {
+		urlPattern = optionalURLPattern[0]
+	}
+	listener, err := net.Listen("unix", socketPath)
+	if err != nil {
+		return nil, err
+	}
+	broker := NewBroker()
+	mux := http.NewServeMux()
+	mux.Handle(urlPattern, broker)
+	httpServer := &http.Server{
+		Handler: mux,
+	}
+	go httpServer.Serve(listener)
+
+	return broker, nil
+}

--- a/pkg/broker/server/server_test.go
+++ b/pkg/broker/server/server_test.go
@@ -1,0 +1,73 @@
+package server
+
+import (
+	"io/ioutil"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/docker/infrakit/pkg/broker/client"
+	"github.com/stretchr/testify/require"
+)
+
+func tempSocket() string {
+	dir, err := ioutil.TempDir("", "infrakit-test-")
+	if err != nil {
+		panic(err)
+	}
+
+	return filepath.Join(dir, "broker")
+}
+
+func TestListenAndServeOnSocket(t *testing.T) {
+
+	socketFile := tempSocket()
+	socket := "unix://broker" + socketFile
+
+	broker, err := ListenAndServeOnSocket(socketFile)
+	require.NoError(t, err)
+
+	received1 := make(chan interface{})
+	received2 := make(chan interface{})
+
+	opts := client.Options{SocketDir: filepath.Dir(socketFile)}
+	topic1, _, err := client.Subscribe(socket, "local", opts)
+	require.NoError(t, err)
+	go func() {
+		for {
+			any := <-topic1
+			var val interface{}
+			require.NoError(t, any.Decode(&val))
+			received1 <- val
+		}
+	}()
+
+	topic2, _, err := client.Subscribe(socket, "local/time", opts)
+	require.NoError(t, err)
+	go func() {
+		for {
+			var val interface{}
+			require.NoError(t, (<-topic2).Decode(&val))
+			received2 <- val
+		}
+	}()
+
+	go func() {
+		for {
+			require.NoError(t, broker.Publish("local/time/now", time.Now().UnixNano()))
+			<-time.After(100 * time.Millisecond)
+		}
+	}()
+
+	// Test a few rounds to make sure all subscribers get the same messages each round.
+	for i := 0; i < 5; i++ {
+		a := <-received1
+		b := <-received2
+		require.NotNil(t, a)
+		require.NotNil(t, b)
+		require.Equal(t, a, b)
+	}
+
+	broker.Stop()
+
+}

--- a/pkg/broker/server/sse_test.go
+++ b/pkg/broker/server/sse_test.go
@@ -2,7 +2,7 @@ package server
 
 import (
 	"fmt"
-	"net/http"
+	"path/filepath"
 	"strings"
 	"testing"
 	"time"
@@ -11,15 +11,19 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func _TestBrokerMultiSubscribers(t *testing.T) {
+func TestBrokerMultiSubscribers(t *testing.T) {
+	socketFile := tempSocket()
+	socket := "unix://broker" + socketFile
 
-	broker := NewBroker()
-	go http.ListenAndServe("localhost:7000", broker)
+	broker, err := ListenAndServeOnSocket(socketFile)
+	require.NoError(t, err)
 
 	received1 := make(chan interface{})
 	received2 := make(chan interface{})
 
-	topic1, _, err := client.Subscribe("http://localhost:7000/", "local", client.Options{})
+	opts := client.Options{SocketDir: filepath.Dir(socketFile)}
+
+	topic1, _, err := client.Subscribe(socket, "local", opts)
 	require.NoError(t, err)
 	go func() {
 		for {
@@ -29,7 +33,7 @@ func _TestBrokerMultiSubscribers(t *testing.T) {
 		}
 	}()
 
-	topic2, _, err := client.Subscribe("http://localhost:7000/", "local/time", client.Options{})
+	topic2, _, err := client.Subscribe(socket, "local/time", opts)
 	require.NoError(t, err)
 	go func() {
 		for {
@@ -59,15 +63,19 @@ func _TestBrokerMultiSubscribers(t *testing.T) {
 
 }
 
-func _TestBrokerMultiSubscribersProducers(t *testing.T) {
+func TestBrokerMultiSubscribersProducers(t *testing.T) {
+	socketFile := tempSocket()
+	socket := "unix://broker" + socketFile
 
-	broker := NewBroker()
-	go http.ListenAndServe("localhost:7001", broker)
+	broker, err := ListenAndServeOnSocket(socketFile)
+	require.NoError(t, err)
 
 	received1 := make(chan interface{})
 	received2 := make(chan interface{})
 
-	topic1, _, err := client.Subscribe("http://localhost:7001/", "local", client.Options{})
+	opts := client.Options{SocketDir: filepath.Dir(socketFile)}
+
+	topic1, _, err := client.Subscribe(socket, "local", opts)
 	require.NoError(t, err)
 	go func() {
 		for {
@@ -77,7 +85,7 @@ func _TestBrokerMultiSubscribersProducers(t *testing.T) {
 		}
 	}()
 
-	topic2, _, err := client.Subscribe("http://localhost:7001/?topic=/local/time", "", client.Options{})
+	topic2, _, err := client.Subscribe(socket+"/?topic=/local/time", "", opts)
 	require.NoError(t, err)
 	go func() {
 		for {
@@ -87,7 +95,7 @@ func _TestBrokerMultiSubscribersProducers(t *testing.T) {
 		}
 	}()
 
-	topic3, _, err := client.Subscribe("http://localhost:7001", "cluster/time", client.Options{})
+	topic3, _, err := client.Subscribe(socket, "cluster/time", opts)
 	require.NoError(t, err)
 	go func() {
 		panic(<-topic3)


### PR DESCRIPTION
This PR re-enables the tests that were previously disabled due to timeouts on CircleCI.
Various bug fixes and changed the broker to listen on unix socket and better errors with proper cleanup on disconnect / errors.

Signed-off-by: David Chung <david.chung@docker.com>