### PR TITLE
[WIP] Use Finite State Machines to manage instance/provisioning lifecycle

### DIFF
--- a/pkg/fsm/errors.go
+++ b/pkg/fsm/errors.go
@@ -15,3 +15,27 @@ type unknownState Index
 func (e unknownState) Error() string {
 	return fmt.Sprintf("unknown state index: %d", e)
 }
+
+type unknownTransition Signal
+
+func (e unknownTransition) Error() string {
+	return fmt.Sprintf("no transition defined for signal %d", e)
+}
+
+type unknownSignal Signal
+
+func (e unknownSignal) Error() string {
+	return fmt.Sprintf("signal in action not found in transitions %d", e)
+}
+
+type nilAction Signal
+
+func (e nilAction) Error() string {
+	return fmt.Sprintf("nil action corresponding to signal %d", e)
+}
+
+type noTransitions Spec
+
+func (e noTransitions) Error() string {
+	return fmt.Sprintf("no transitions defined: states=%d", len(e.states))
+}

--- a/pkg/fsm/errors.go
+++ b/pkg/fsm/errors.go
@@ -1,0 +1,17 @@
+package fsm
+
+import (
+	"fmt"
+)
+
+type errDuplicateState Index
+
+func (e errDuplicateState) Error() string {
+	return fmt.Sprintf("duplicated state index: %d", e)
+}
+
+type unknownState Index
+
+func (e unknownState) Error() string {
+	return fmt.Sprintf("unknown state index: %d", e)
+}

--- a/pkg/fsm/flap.go
+++ b/pkg/fsm/flap.go
@@ -1,0 +1,30 @@
+package fsm
+
+func newFlaps() *flaps {
+	return &flaps{
+		index: make(map[[2]Index]int),
+	}
+}
+
+type flaps struct {
+	index map[[2]Index]int
+}
+
+func (f *flaps) record(a, b Index) {
+	key := [2]Index{b, a} // next to complete the flap = b -> a
+	f.index[key] = f.index[key] + 1
+}
+
+func (f *flaps) reset(a, b Index) {
+	for _, key := range [][2]Index{{a, b}, {b, a}} {
+		delete(f.index, key)
+	}
+}
+
+func (f *flaps) count(a, b Index) int {
+	total := 0
+	for _, key := range [][2]Index{{a, b}, {b, a}} {
+		total = f.index[key] + total
+	}
+	return total / 2
+}

--- a/pkg/fsm/flap_test.go
+++ b/pkg/fsm/flap_test.go
@@ -1,0 +1,56 @@
+package fsm
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestFlap(t *testing.T) {
+
+	const (
+		a Index = iota
+		b
+		c
+		x
+		y
+	)
+
+	counter := &flaps{index: map[[2]Index]int{}}
+	require.Equal(t, 0, counter.count(a, b))
+
+	counter.record(a, b)
+	counter.record(b, a)
+	require.Equal(t, 1, counter.count(a, b))
+
+	counter.record(a, b)
+	require.Equal(t, 1, counter.count(a, b))
+	counter.record(b, a)
+	require.Equal(t, 2, counter.count(a, b))
+	counter.record(a, b)
+	counter.record(b, a)
+	require.Equal(t, 3, counter.count(a, b))
+
+	counter.reset(a, b)
+	require.Equal(t, 0, counter.count(b, a))
+	require.Equal(t, 0, counter.count(a, b))
+
+	counter.record(x, y)
+	require.Equal(t, 0, counter.count(x, y))
+	require.Equal(t, 0, counter.count(y, x))
+	counter.record(y, x)
+	require.Equal(t, 1, counter.count(x, y))
+	require.Equal(t, 1, counter.count(y, x))
+	counter.record(x, y)
+	require.Equal(t, 1, counter.count(x, y))
+	counter.record(y, x)
+	require.Equal(t, 2, counter.count(x, y))
+
+	counter.reset(x, y)
+	for i := 0; i < 5; i++ {
+		counter.record(x, y)
+		// some time later
+		counter.record(y, x)
+	}
+	require.Equal(t, 5, counter.count(y, x))
+}

--- a/pkg/fsm/fsm.go
+++ b/pkg/fsm/fsm.go
@@ -1,0 +1,123 @@
+package fsm
+
+import (
+	"sort"
+)
+
+type Index int
+
+// Action is the action to take when a signal is received, prior to transition
+// to the next state.  The error returned by the function is an exception which
+// will put the state machine in an error state.  This error state is not the same
+// as some application-specific error state which is a state defined to correspond
+// to some external event indicating a real-world error event (as opposed to a
+// programming error here).
+type Action func() error
+
+// Tick is a unit of time. Time is in relative terms and synchronized with an actual
+// timer that's provided by the client.
+type Tick int64
+
+type Expiry struct {
+	TTL   Tick
+	Raise Signal
+}
+
+type State struct {
+	Index       Index
+	Transitions map[Signal]Index
+	Actions     map[Signal]Action
+	TTL         Expiry
+}
+
+type Signal int
+
+func Define(s State, more ...State) (spec Spec, err error) {
+	m := map[Index]State{
+		s.Index: s,
+	}
+
+	for _, s := range more {
+		if _, has := m[s.Index]; has {
+			err = errDuplicateState(s.Index)
+			return
+		}
+		m[s.Index] = s
+	}
+
+	// check referential integrity
+	if err = checkReferences(m); err != nil {
+		return
+	}
+
+	spec.states = m
+	return
+}
+
+func checkReferences(m map[Index]State) error {
+	for _, s := range m {
+		for _, i := range s.Transitions {
+			if _, has := m[i]; !has {
+				return unknownState(i)
+			}
+		}
+	}
+	return nil
+}
+
+type Limit int
+
+type Spec struct {
+	states   map[Index]State
+	maxFlaps map[[2]Index]Limit
+}
+
+type Flap struct {
+	States [2]Index
+	Count  int
+}
+
+// CheckFlapping - Limit is the maximum of a->b b->a transitions allowable.  For detecting
+// oscillations between two adjacent states (no hops)
+func (spec *Spec) CheckFlapping(checks []Flap) Spec {
+	if spec.maxFlaps == nil {
+		spec.maxFlaps = map[[2]Index]Limit{}
+	}
+	for _, check := range checks {
+		copy := []int{int(check.States[0]), int(check.States[1])}
+		sort.Ints(copy)
+		spec.maxFlaps[[2]Index{Index(copy[0]), Index(copy[1])}] = Limit(check.Count)
+	}
+	return *spec
+}
+
+type set struct {
+	spec Spec
+}
+
+func NewSet(spec Spec) *set {
+	return &set{
+		spec: spec,
+	}
+}
+
+func (s *set) New(initial Index) Instance {
+	return &instance{
+		state:  initial,
+		parent: s,
+	}
+}
+
+type Instance interface {
+	Signal(Signal) error
+}
+
+type instance struct {
+	state  Index
+	parent *set
+	error  error
+}
+
+func (i instance) Signal(s Signal) error {
+	return nil
+}

--- a/pkg/fsm/fsm.go
+++ b/pkg/fsm/fsm.go
@@ -12,7 +12,7 @@ type Index int
 // as some application-specific error state which is a state defined to correspond
 // to some external event indicating a real-world error event (as opposed to a
 // programming error here).
-type Action func() error
+type Action func(Instance)
 
 // Tick is a unit of time. Time is in relative terms and synchronized with an actual
 // timer that's provided by the client.

--- a/pkg/fsm/fsm_test.go
+++ b/pkg/fsm/fsm_test.go
@@ -73,14 +73,12 @@ func TestSimple(t *testing.T) {
 	)
 
 	saidHi := make(chan struct{})
-	var sayHi Action = func() error {
+	var sayHi Action = func(Instance) {
 		close(saidHi)
-		return nil
 	}
 	saidBye := make(chan struct{})
-	var sayBye Action = func() error {
+	var sayBye Action = func(Instance) {
 		close(saidBye)
-		return nil
 	}
 
 	spec, err := Define(
@@ -123,14 +121,14 @@ func TestSimple(t *testing.T) {
 	next, action, err := spec.transition(on, turn_off)
 	require.NoError(t, err)
 	require.Equal(t, sleep, next)
-	action()
+	action(nil)
 	<-saidBye
 
 	// check transitions
 	next, action, err = spec.transition(off, turn_on)
 	require.NoError(t, err)
 	require.Equal(t, on, next)
-	action()
+	action(nil)
 	<-saidHi
 
 	// not allowed transition
@@ -157,25 +155,20 @@ func TestFsmUsage(t *testing.T) {
 		state_decommissioned
 	)
 
-	createInstance := func() error {
+	createInstance := func(Instance) {
 		t.Log("creating instance")
-		return nil
 	}
-	deleteInstance := func() error {
+	deleteInstance := func(Instance) {
 		t.Log("delete instance")
-		return nil
 	}
-	cleanup := func() error {
+	cleanup := func(Instance) {
 		t.Log("cleanup")
-		return nil
 	}
-	recordFlapping := func() error {
+	recordFlapping := func(Instance) {
 		t.Log("flap is if this happens more than multiples of 2 calls")
-		return nil
 	}
-	sendAlert := func() error {
+	sendAlert := func(Instance) {
 		t.Log("alert")
-		return nil
 	}
 
 	fsm, err := Define(

--- a/pkg/fsm/fsm_test.go
+++ b/pkg/fsm/fsm_test.go
@@ -1,0 +1,171 @@
+package fsm
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestDefinition(t *testing.T) {
+
+	const (
+		turn_on Signal = iota
+		turn_off
+
+		on Index = iota
+		off
+	)
+
+	m := map[Index]State{
+		on: {
+			Index: on,
+			Transitions: map[Signal]Index{
+				turn_off: off,
+			},
+		},
+	}
+
+	require.Error(t, checkReferences(m))
+
+	// add missing
+	m[off] = State{
+		Index: off,
+		Transitions: map[Signal]Index{
+			turn_on: on,
+		},
+	}
+
+	require.NoError(t, checkReferences(m))
+
+	states := []State{}
+	for _, s := range m {
+		states = append(states, s)
+	}
+
+	spec, err := Define(states[0], states[1:]...)
+	require.NoError(t, err)
+
+	spec = spec.CheckFlapping([]Flap{
+		{States: [2]Index{on, off}, Count: 100},
+	})
+
+	t.Log(spec)
+}
+
+func TestFsmUsage(t *testing.T) {
+
+	const (
+		signal_specified Signal = iota
+		signal_create
+		signal_found
+		signal_healthy
+		signal_unhealthy
+		signal_startover
+		signal_stop
+
+		state_specified Index = iota
+		state_creating
+		state_up
+		state_running
+		state_down
+		state_decommissioned
+	)
+
+	createInstance := func() error {
+		t.Log("creating instance")
+		return nil
+	}
+	deleteInstance := func() error {
+		t.Log("delete instance")
+		return nil
+	}
+	cleanup := func() error {
+		t.Log("cleanup")
+		return nil
+	}
+	recordFlapping := func() error {
+		t.Log("flap is if this happens more than multiples of 2 calls")
+		return nil
+	}
+	sendAlert := func() error {
+		t.Log("alert")
+		return nil
+	}
+
+	fsm, err := Define(
+		State{
+			Index: state_specified,
+			Transitions: map[Signal]Index{
+				signal_create:    state_creating,
+				signal_found:     state_up,
+				signal_healthy:   state_running,
+				signal_unhealthy: state_down,
+			},
+			Actions: map[Signal]Action{
+				signal_create: createInstance,
+			},
+			TTL: Expiry{1000, signal_create},
+		},
+		State{
+			Index: state_creating,
+			Transitions: map[Signal]Index{
+				signal_found:     state_up,
+				signal_startover: state_specified,
+			},
+			Actions: map[Signal]Action{
+				signal_startover: cleanup,
+			},
+			TTL: Expiry{1000, signal_startover},
+		},
+		State{
+			Index: state_up,
+			Transitions: map[Signal]Index{
+				signal_healthy:   state_running,
+				signal_unhealthy: state_down,
+			},
+			Actions: map[Signal]Action{
+				signal_unhealthy: recordFlapping, // note flapping between up and down
+			},
+		},
+		State{
+			Index: state_down,
+			Transitions: map[Signal]Index{
+				signal_startover: state_specified,
+				signal_healthy:   state_running,
+			},
+			Actions: map[Signal]Action{
+				signal_startover: cleanup,
+				signal_healthy:   recordFlapping, // note flapping between up and down
+			},
+			TTL: Expiry{10, signal_startover},
+		},
+		State{
+			Index: state_running,
+			Transitions: map[Signal]Index{
+				signal_healthy:   state_running,
+				signal_unhealthy: state_down, // do we want threshold e.g. more than N signals?
+				signal_stop:      state_decommissioned,
+			},
+			Actions: map[Signal]Action{
+				signal_unhealthy: sendAlert,
+				signal_stop:      deleteInstance,
+			},
+		},
+		State{
+			Index: state_decommissioned,
+		},
+	)
+
+	require.NoError(t, err)
+
+	// set is a collection of fsm intances that follow the same rules.
+	set := NewSet(fsm.CheckFlapping([]Flap{
+		{States: [2]Index{state_running, state_down}, Count: 10},
+	}))
+
+	// allocates a new instance of a fsm with an initial state.
+	instance := set.New(state_specified)
+
+	require.NotNil(t, instance)
+
+}

--- a/pkg/fsm/instance.go
+++ b/pkg/fsm/instance.go
@@ -1,0 +1,55 @@
+package fsm
+
+type Instance interface {
+	ID() uint64
+	State() (Index, bool)
+}
+
+type instance struct {
+	id       id
+	state    Index
+	parent   *Set
+	error    error
+	flaps    flaps
+	start    Time
+	deadline Time
+	index    int // index used in the deadlines queue
+}
+
+func (i instance) ID() uint64 {
+	return uint64(i.id)
+}
+
+func (i instance) State() (Index, bool) {
+	result := make(chan Index)
+	// we have to ask the set which actually holds the instance (this was returned by copy)
+	i.parent.reads <- func(view Set) {
+		if instance, has := view.members[i.id]; has {
+			result <- instance.state
+		}
+		close(result)
+	}
+	v, ok := <-result
+	return v, ok
+}
+
+func (i instance) Signal(s Signal) error {
+	return nil
+}
+
+func (i *instance) update(next Index, now Time, ttl Tick) {
+	i.flaps.record(i.state, next)
+	i.state = next
+	i.start = now
+	if ttl > 0 {
+		i.deadline = now + Time(ttl)
+	} else {
+		i.deadline = 0
+	}
+}
+
+func (i instance) raise(s Signal, inputs map[Signal]chan<- *event) {
+	if ch, has := inputs[s]; has {
+		ch <- &event{instance: i.id, signal: s}
+	}
+}

--- a/pkg/fsm/queue.go
+++ b/pkg/fsm/queue.go
@@ -1,0 +1,56 @@
+package fsm
+
+import (
+	"container/heap"
+)
+
+// A queue implements heap.Interface and holds instances prioritized by deadline (if > 0)
+type queue []*instance
+
+func newQueue() *queue {
+	h := &queue{}
+	heap.Init(h)
+	return h
+}
+
+func (pq *queue) enqueue(instance *instance) {
+	heap.Push(pq, instance)
+}
+
+func (pq *queue) dequeue() *instance {
+	v := heap.Pop(pq)
+	return v.(*instance)
+}
+
+func (pq *queue) update(instance *instance) {
+	heap.Fix(pq, instance.index)
+}
+
+func (pq queue) Len() int { return len(pq) }
+
+func (pq queue) Less(i, j int) bool {
+	// We want Pop to give us the highest, not lowest, priority so we use greater than here.
+	return pq[i].deadline < pq[j].deadline
+}
+
+func (pq queue) Swap(i, j int) {
+	pq[i], pq[j] = pq[j], pq[i]
+	pq[i].index = i
+	pq[j].index = j
+}
+
+func (pq *queue) Push(v interface{}) {
+	n := len(*pq)
+	instance := v.(*instance)
+	instance.index = n
+	*pq = append(*pq, instance)
+}
+
+func (pq *queue) Pop() interface{} {
+	old := *pq
+	n := len(old)
+	instance := old[n-1]
+	instance.index = -1 // for safety
+	*pq = old[0 : n-1]
+	return instance
+}

--- a/pkg/fsm/queue_test.go
+++ b/pkg/fsm/queue_test.go
@@ -1,0 +1,37 @@
+package fsm
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestQueue(t *testing.T) {
+
+	// Tests the priority queue by deadline
+
+	q := newQueue()
+
+	q.enqueue(&instance{deadline: Time(1)})
+	q.enqueue(&instance{deadline: Time(3)})
+	q.enqueue(&instance{deadline: Time(2)})
+
+	x := &instance{deadline: Time(5)}
+	q.enqueue(x)
+
+	q.enqueue(&instance{deadline: Time(5)})
+	q.enqueue(&instance{deadline: Time(4)})
+	q.enqueue(&instance{deadline: Time(4)})
+	q.enqueue(&instance{deadline: Time(20)})
+
+	x.deadline = -1
+	q.update(x)
+	q.update(&instance{deadline: Time(200), index: 5}) // no effect -- not tracked.
+
+	sorted := []int{}
+	for q.Len() > 0 {
+		sorted = append(sorted, int(q.dequeue().deadline))
+	}
+
+	require.Equal(t, []int{-1, 1, 2, 3, 4, 4, 5, 20}, sorted)
+}

--- a/pkg/fsm/set.go
+++ b/pkg/fsm/set.go
@@ -1,0 +1,223 @@
+package fsm
+
+import (
+	"time"
+)
+
+// NewSet returns a new set
+func NewSet(spec *Spec, tick <-chan time.Time) *Set {
+	set := &Set{
+		spec:    *spec,
+		stop:    make(chan struct{}),
+		members: map[id]*instance{},
+		reads:   make(chan func(Set)),
+		add:     make(chan Index),
+		delete:  make(chan id),
+		errors:  make(chan error),
+		new:     make(chan Instance),
+	}
+	if tick != nil {
+		go set.run(tick)
+	}
+	return set
+}
+
+// Set is a collection of fsm instances that follow a given spec.  This is
+// the primary interface to manipulate the instances... by sending signals to it via channels.
+type Set struct {
+	spec    Spec
+	now     Time
+	next    id
+	members map[id]*instance
+	reads   chan func(Set) // given a view which is a copy of the Set
+	stop    chan struct{}
+	add     chan Index // add an instance with initial state
+	new     chan Instance
+	delete  chan id // delete an instance with id
+	errors  chan error
+}
+
+func (s *Set) Size() int {
+	result := make(chan int)
+	s.reads <- func(view Set) {
+		result <- len(view.members)
+	}
+	return <-result
+}
+
+func (s *Set) Add(initial Index) Instance {
+	s.add <- initial
+	return <-s.new
+}
+
+func (s *Set) Delete(instance Instance) {
+	s.delete <- id(instance.ID())
+}
+
+func (s *Set) Stop() {
+	if s.stop != nil {
+		close(s.stop)
+	}
+}
+
+type id uint64
+type event struct {
+	instance id
+	signal   Signal
+}
+
+func (s *Set) run(tick <-chan time.Time) map[Signal]chan<- *event {
+
+	// Start up the goroutines to merge all the events/triggers.
+	// Note we use merge channel for performance (over the slower reflect.Select) and for readability.
+	collector := make(chan *event)
+	inputs := map[Signal]chan<- *event{}
+	for _, signal := range s.spec.signals {
+		input := make(chan *event)
+		inputs[signal] = input
+		go func() {
+			for {
+				event, ok := <-input
+				if !ok {
+					return
+				}
+				collector <- event
+			}
+		}()
+	}
+
+loop:
+	for {
+		select {
+
+		case <-s.stop:
+			break loop
+
+		case <-tick:
+
+			// update the 'clock'
+			s.now++
+
+			// go through a list of instances that have deadline and raise signals if expired
+
+		case initial := <-s.add:
+
+			// add a new instance
+			id := s.next
+			s.next++
+
+			new := &instance{
+				id:     id,
+				state:  initial,
+				parent: s,
+				flaps:  *newFlaps(),
+			}
+
+			s.members[id] = new
+			s.new <- new
+
+		case id := <-s.delete:
+
+			// delete an instance
+			delete(s.members, id)
+
+		case event, ok := <-collector:
+
+			// state transition events
+			if !ok {
+				break loop
+			}
+
+			// process events here.
+			if instance, has := s.members[event.instance]; has {
+
+				// check for TTL
+				if instance.expired(s.now) {
+
+					// raise the signal instead of continuing
+					if ttl, ok := s.spec.expiry(instance.state); ok {
+						instance.raise(ttl.Raise, inputs)
+					}
+
+					continue loop
+				}
+
+				current := instance.state
+				next, action, err := s.spec.transition(current, event.signal)
+				if err != nil {
+					select {
+					case s.errors <- err:
+					default:
+					}
+				}
+
+				// any flap detection?
+				limit := s.spec.flap(current, next)
+				if limit.Count > 0 {
+					if instance.flaps.count(current, next) > limit.Count {
+						instance.raise(limit.Raise, inputs)
+
+						continue loop
+					}
+				}
+
+				// call action before transitiion
+				action()
+
+				ttl := Tick(0)
+				// check for TTL
+				if exp, ok := s.spec.expiry(next); ok {
+					ttl = exp.TTL
+				}
+
+				instance.update(next, s.now, ttl)
+			}
+
+		case reader := <-s.reads:
+			// For reads on the Set itself.  All the reads are serialized.
+			view := *s // a copy (not quite deep copy) of the set
+			reader(view)
+		}
+	}
+
+	return inputs
+}
+
+type Instance interface {
+	ID() uint64
+}
+
+type instance struct {
+	id     id
+	state  Index
+	parent *Set
+	error  error
+	flaps  flaps
+	start  Time
+	ttl    Tick
+}
+
+func (i instance) ID() uint64 {
+	return uint64(i.id)
+}
+
+func (i instance) expired(now Time) bool {
+	return Tick(now-i.start) >= i.ttl
+}
+
+func (i instance) Signal(s Signal) error {
+	return nil
+}
+
+func (i *instance) update(next Index, now Time, ttl Tick) {
+	i.flaps.record(i.state, next)
+	i.state = next
+	i.start = now
+	i.ttl = ttl
+}
+
+func (i instance) raise(s Signal, inputs map[Signal]chan<- *event) {
+	if ch, has := inputs[s]; has {
+		ch <- &event{instance: i.id, signal: s}
+	}
+}


### PR DESCRIPTION
The current group plugin suffers from a number of problems like #345, #409, #423 and many of these problems are related to the tracking of states of instances as they change due to external signals like instance creation, health check, request to update, etc.  A lot of this is better managed via fsm - finite state machines with some additional requirements:
  + state transitions happen via signals received into the system
  + a state can have a TTL and when expired, another signal is triggered.  This is useful for implementing waits on asynchronous, long-running provisioning tasks; also cool-downs can be implemented this way.
  + we should detect *flapping* that is oscillation between states (e.g. healthy->unhealthy->healthy) and when a limit is reached, raise a signal.

Very roughly, an example state machine might look like this:

```
	const (
		signal_specified Signal = iota
		signal_create
		signal_found
		signal_healthy
		signal_unhealthy
		signal_startover
		signal_stop

		state_specified Index = iota
		state_creating
		state_up
		state_running
		state_down
		state_decommissioned
	)

	createInstance := func(Instance) {
		t.Log("creating instance")
	}
	deleteInstance := func(Instance) {
		t.Log("delete instance")
	}
	cleanup := func(Instance) {
		t.Log("cleanup")
	}
	recordFlapping := func(Instance) {
		t.Log("flap is if this happens more than multiples of 2 calls")
	}
	sendAlert := func(Instance) {
		t.Log("alert")
	}

	fsm, err := Define(
		State{
			Index: state_specified,
			Transitions: map[Signal]Index{
				signal_create:    state_creating,
				signal_found:     state_up,
				signal_healthy:   state_running,
				signal_unhealthy: state_down,
			},
			Actions: map[Signal]Action{
				signal_create: createInstance,
			},
			TTL: Expiry{1000, signal_create},
		},
		State{
			Index: state_creating,
			Transitions: map[Signal]Index{
				signal_found:     state_up,
				signal_startover: state_specified,
			},
			Actions: map[Signal]Action{
				signal_startover: cleanup,
			},
			TTL: Expiry{1000, signal_startover},
		},
		State{
			Index: state_up,
			Transitions: map[Signal]Index{
				signal_healthy:   state_running,
				signal_unhealthy: state_down,
			},
			Actions: map[Signal]Action{
				signal_unhealthy: recordFlapping, // note flapping between up and down
			},
		},
		State{
			Index: state_down,
			Transitions: map[Signal]Index{
				signal_startover: state_specified,
				signal_healthy:   state_running,
			},
			Actions: map[Signal]Action{
				signal_startover: cleanup,
				signal_healthy:   recordFlapping, // note flapping between up and down
			},
			TTL: Expiry{10, signal_startover},
		},
		State{
			Index: state_running,
			Transitions: map[Signal]Index{
				signal_healthy:   state_running,
				signal_unhealthy: state_down, // do we want threshold e.g. more than N signals?
				signal_stop:      state_decommissioned,
			},
			Actions: map[Signal]Action{
				signal_unhealthy: sendAlert,
				signal_stop:      deleteInstance,
			},
		},
		State{
			Index: state_decommissioned,
		},
	)

	require.NoError(t, err)

	// set is a collection of fsm intances that follow the same rules.
	set := NewSet(fsm.CheckFlappingMust([]Flap{
		{States: [2]Index{state_running, state_down}, Count: 10},
	}), time.Tick(1*time.Second))
```

There will be reconciliation loop that handles the state transitions of all the instances as responding to events from channels.   

This is very much a Work In Progress.  A lot of the APIs and implementations will change as needed.   Hopefully this implementation will fix a lot of the issues associated with the current group plugin.

