### PR TITLE
Proper handling of event topic validation in the HTTP handler

### DIFF
--- a/cmd/cli/event.go
+++ b/cmd/cli/event.go
@@ -274,6 +274,8 @@ func eventCommand(plugins func() discovery.Plugins) *cobra.Command {
 					return fmt.Errorf("not a subscriber: %s, %v", target, plugin)
 				}
 
+				log.Infoln("Subscribing to", eventTopic)
+
 				stream, err := client.SubscribeOn(eventTopic)
 				if err != nil {
 					return fmt.Errorf("cannot subscribe: %s, err=%v", topic, err)

--- a/pkg/broker/server/interceptor.go
+++ b/pkg/broker/server/interceptor.go
@@ -1,0 +1,74 @@
+package server
+
+import (
+	"fmt"
+	"net/http"
+	"strings"
+
+	log "github.com/Sirupsen/logrus"
+)
+
+// Interceptor implements http Handler and is used to intercept incoming requests to subscribe
+// to topics and perform some validations before allowing the subscription to be established.
+// Tasks that the interceptor can do include authn and authz, topic validation, etc.
+type Interceptor struct {
+
+	// Do is the body of the http handler -- required
+	Do http.HandlerFunc
+
+	// Pre is called to before actual subscription to a topic happens.
+	// This is the hook where validation and authentication / authorization checks happen.
+	Pre func(topic string, headers map[string][]string) error
+
+	// Post is called when the client disconnects.  This is optional.
+	Post func(topic string)
+}
+
+// ServeHTTP calls the before and after subscribe methods.
+func (i *Interceptor) ServeHTTP(rw http.ResponseWriter, req *http.Request) {
+
+	topic := clean(req.URL.Query().Get("topic"))
+
+	// need to strip out the / because it was added by the client
+	if strings.Index(topic, "/") == 0 {
+		topic = topic[1:]
+	}
+
+	err := i.Pre(topic, req.Header)
+	if err != nil {
+		log.Warningln("Error:", err)
+		http.Error(rw, err.Error(), getStatusCode(err))
+		return
+	}
+
+	i.Do.ServeHTTP(rw, req)
+
+	if i.Post != nil {
+		i.Post(topic)
+	}
+}
+
+func getStatusCode(e error) int {
+	switch e.(type) {
+	case ErrInvalidTopic:
+		return http.StatusNotFound
+	case ErrNotAuthorized:
+		return http.StatusUnauthorized
+	default:
+		return http.StatusInternalServerError
+	}
+}
+
+// ErrInvalidTopic is the error raised when topic is invalid
+type ErrInvalidTopic string
+
+func (e ErrInvalidTopic) Error() string {
+	return fmt.Sprintf("invalid topic: %s", string(e))
+}
+
+// ErrNotAuthorized is the error raised when the user isn't authorized
+type ErrNotAuthorized string
+
+func (e ErrNotAuthorized) Error() string {
+	return fmt.Sprintf("not authorized: %s", string(e))
+}

--- a/pkg/broker/server/sse.go
+++ b/pkg/broker/server/sse.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"fmt"
 	"net/http"
-	"strings"
 	"time"
 
 	log "github.com/Sirupsen/logrus"
@@ -160,19 +159,6 @@ func (b *Broker) ServeHTTP(rw http.ResponseWriter, req *http.Request) {
 	}
 }
 
-//checkPath Compare the subscribed topic with the published topic to see if the message can be sent to the client.
-func (b *Broker) checkPath(subscribedPath string, publishedPath string) bool {
-	if subscribedPath != "/" {
-		pPath := strings.Split(publishedPath, "/")
-		for i, sliceTopic := range strings.Split(subscribedPath, "/") {
-			if pPath[i] != sliceTopic {
-				return false
-			}
-		}
-	}
-	return true
-}
-
 func (b *Broker) run() {
 	for {
 		select {
@@ -258,10 +244,6 @@ func (b *Broker) run() {
 
 						panic("assert-failed")
 					}
-					// Make sure that the topic subscribed to by the client is the upper topic of the topic being notified or the topic exactly matched.
-					// if !b.checkPath(key, event.topic) {
-					// 	return false
-					// }
 
 					for ch := range chset {
 						select {

--- a/pkg/broker/server/sse.go
+++ b/pkg/broker/server/sse.go
@@ -70,7 +70,7 @@ func (b *Broker) Stop() {
 }
 
 func clean(topic string) string {
-	if len(topic) == 0 {
+	if len(topic) == 0 || topic == "." {
 		return "/"
 	}
 
@@ -200,7 +200,7 @@ func (b *Broker) run() {
 
 			b.clients.Insert(subscription.topic, subs)
 			b.count++
-			log.Infof("Connected: topic=%s. %d registered clients, ch=%v", subscription.topic, b.count, subscription.ch)
+			log.Infof("Connected: topic=%s => %d registered clients, ch=%v", subscription.topic, b.count, subscription.ch)
 
 		case subscription := <-b.closingClients:
 
@@ -221,7 +221,7 @@ func (b *Broker) run() {
 					}
 
 					b.count--
-					log.Infof("Disconnected: topic=%s. %d registered clients, ch=%v", subscription.topic, b.count, subscription.ch)
+					log.Infof("Disconnected: topic=%s => %d registered clients, ch=%v", subscription.topic, b.count, subscription.ch)
 				}
 			}
 

--- a/pkg/broker/server/sse.go
+++ b/pkg/broker/server/sse.go
@@ -259,9 +259,9 @@ func (b *Broker) run() {
 						panic("assert-failed")
 					}
 					// Make sure that the topic subscribed to by the client is the upper topic of the topic being notified or the topic exactly matched.
-					if !b.checkPath(key, event.topic) {
-						return false
-					}
+					// if !b.checkPath(key, event.topic) {
+					// 	return false
+					// }
 
 					for ch := range chset {
 						select {

--- a/pkg/rpc/event/rpc_test.go
+++ b/pkg/rpc/event/rpc_test.go
@@ -194,6 +194,15 @@ func TestEventPluginPublishSubscribe(t *testing.T) {
 	err = validator.Validate(types.PathFromString("storage"))
 	require.NoError(t, err)
 
+	err = validator.Validate(types.PathFromString("storage/instance"))
+	require.NoError(t, err)
+
+	err = validator.Validate(types.PathFromString("storage/instance/create"))
+	require.NoError(t, err)
+
+	err = validator.Validate(types.PathFromString("storage/instance/c"))
+	require.Error(t, err)
+
 	err = validator.Validate(types.PathFromString("stor"))
 	require.Error(t, err)
 

--- a/pkg/rpc/event/rpc_test.go
+++ b/pkg/rpc/event/rpc_test.go
@@ -170,15 +170,35 @@ func TestEventPluginPublishSubscribe(t *testing.T) {
 	require.NotNil(t, pub1)
 	require.NotNil(t, pub2)
 
-	server, err := rpc_server.StartPluginAtPath(socketPath, PluginServerWithTypes(
+	var impl rpc_server.VersionedInterface = PluginServerWithTypes(
 		map[string]event.Plugin{
 			"compute": plugin0,
 			"storage": plugin1,
-		}))
+		})
+
+	server, err := rpc_server.StartPluginAtPath(socketPath, impl)
 	require.NoError(t, err)
 
 	<-calledPublisher0
 	<-calledPublisher1
+
+	validator, is := impl.(event.Validator)
+	require.True(t, is)
+
+	err = validator.Validate(types.PathFromString(""))
+	require.NoError(t, err)
+
+	err = validator.Validate(types.PathFromString("compute"))
+	require.NoError(t, err)
+
+	err = validator.Validate(types.PathFromString("storage"))
+	require.NoError(t, err)
+
+	err = validator.Validate(types.PathFromString("stor"))
+	require.Error(t, err)
+
+	err = validator.Validate(types.PathFromString("computer"))
+	require.Error(t, err)
 
 	client := must(NewClient(socketPath)).(event.Subscriber)
 	require.NotNil(t, client)

--- a/pkg/rpc/event/service.go
+++ b/pkg/rpc/event/service.go
@@ -87,15 +87,26 @@ func self(p types.Path) bool {
 
 // Validate returns an error if the topic path is invalid
 func (p *Event) Validate(topic types.Path) error {
-	// if this gives a valid child then we consider it ok
+	// case where the topic can have sub topics
 	children, err := p.list(topic)
 	if err != nil {
 		return err
 	}
 
-	if len(children) > 0 {
+	// It can be zero length
+	if children != nil {
 		return nil
 	}
+
+	// case where the topic is exact
+	children, err = p.list(topic.Dir())
+	if err != nil {
+		return err
+	}
+	if len(children) > 0 && children[0] == topic.Base() {
+		return nil
+	}
+
 	return broker.ErrInvalidTopic(topic.String())
 }
 

--- a/pkg/rpc/event/service.go
+++ b/pkg/rpc/event/service.go
@@ -4,6 +4,7 @@ import (
 	"net/http"
 	"sort"
 
+	broker "github.com/docker/infrakit/pkg/broker/server"
 	"github.com/docker/infrakit/pkg/spi"
 	"github.com/docker/infrakit/pkg/spi/event"
 	"github.com/docker/infrakit/pkg/types"
@@ -84,18 +85,28 @@ func self(p types.Path) bool {
 	return false
 }
 
-// List return a set of sub topics given the top level one
-func (p *Event) List(_ *http.Request, req *ListRequest, resp *ListResponse) error {
+// Validate returns an error if the topic path is invalid
+func (p *Event) Validate(topic types.Path) error {
+	// if this gives a valid child then we consider it ok
+	children, err := p.list(topic)
+	if err != nil {
+		return err
+	}
 
-	req.Topic = req.Topic.Clean()
+	if len(children) > 0 {
+		return nil
+	}
+	return broker.ErrInvalidTopic(topic.String())
+}
 
+func (p *Event) list(topic types.Path) ([]string, error) {
 	nodes := []string{}
 	// the . case - list the typed plugins and the default's first level.
-	if self(req.Topic) {
+	if self(topic) {
 		if p.plugin != nil {
-			n, err := p.plugin.List(req.Topic)
+			n, err := p.plugin.List(topic)
 			if err != nil {
-				return err
+				return nil, err
 			}
 			nodes = append(nodes, n...)
 		}
@@ -103,32 +114,40 @@ func (p *Event) List(_ *http.Request, req *ListRequest, resp *ListResponse) erro
 			nodes = append(nodes, k)
 		}
 		sort.Strings(nodes)
-		resp.Nodes = nodes
-		return nil
+		return nodes, nil
 	}
 
-	c, has := p.typedPlugins[req.Topic[0]]
+	c, has := p.typedPlugins[topic[0]]
 	if !has {
 
 		if p.plugin == nil {
-			return nil
+			return nil, nil
 		}
 
-		nodes, err := p.plugin.List(req.Topic)
+		nodes, err := p.plugin.List(topic)
 		if err != nil {
-			return err
+			return nil, err
 		}
 		sort.Strings(nodes)
-		resp.Nodes = nodes
-		return nil
+		return nodes, nil
 	}
 
-	nodes, err := c.List(req.Topic[1:])
+	nodes, err := c.List(topic[1:])
 	if err != nil {
-		return err
+		return nil, err
 	}
 
 	sort.Strings(nodes)
+	return nodes, nil
+}
+
+// List return a set of sub topics given the top level one
+func (p *Event) List(_ *http.Request, req *ListRequest, resp *ListResponse) error {
+	req.Topic = req.Topic.Clean()
+	nodes, err := p.list(req.Topic)
+	if err != nil {
+		return err
+	}
 	resp.Nodes = nodes
 	return nil
 }

--- a/pkg/spi/event/spi.go
+++ b/pkg/spi/event/spi.go
@@ -19,6 +19,13 @@ type Plugin interface {
 	List(topic types.Path) (child []string, err error)
 }
 
+// Validator is the interface for validating the topic
+type Validator interface {
+
+	// Validate validates the topic
+	Validate(topic types.Path) error
+}
+
 // Publisher is the interface that event sources also implement to be assigned
 // a publish function.
 type Publisher interface {

--- a/pkg/types/reflect.go
+++ b/pkg/types/reflect.go
@@ -80,48 +80,6 @@ func List(path []string, object interface{}) []string {
 	return list
 }
 
-// List lists the members at the path
-func List0(path []string, object interface{}) []string {
-	list := []string{}
-	v := get(path, object)
-	if v == nil {
-		return list
-	}
-
-	val := reflect.Indirect(reflect.ValueOf(v))
-
-	if any, is := v.(*Any); is {
-		var temp interface{}
-		if err := any.Decode(&temp); err == nil {
-			val = reflect.ValueOf(temp)
-		}
-	}
-
-	switch val.Kind() {
-	case reflect.Slice:
-		// this is a slice, so return the name as '[%d]'
-		for i := 0; i < val.Len(); i++ {
-			list = append(list, fmt.Sprintf("[%d]", i))
-		}
-
-	case reflect.Map:
-		for _, k := range val.MapKeys() {
-			list = append(list, k.String())
-		}
-
-	case reflect.Struct:
-		vt := val.Type()
-		for i := 0; i < vt.NumField(); i++ {
-			if vt.Field(i).PkgPath == "" {
-				list = append(list, vt.Field(i).Name)
-			}
-		}
-	}
-
-	sort.Strings(list)
-	return list
-}
-
 func put(p []string, value interface{}, store map[string]interface{}) bool {
 	if len(p) == 0 {
 		return false

--- a/pkg/types/reflect_test.go
+++ b/pkg/types/reflect_test.go
@@ -56,10 +56,7 @@ func TestMap(t *testing.T) {
 		},
 	}, get(PathFromString("region/us-west-1/vpc/vpc1/network/"), m))
 
-	require.Equal(t, 100, get(PathFromString("region/us-west-2/metrics/instances/count"), m))
-
 	require.Equal(t, []string{"region"}, List(PathFromString("."), m))
-	require.Equal(t, []string{}, List(PathFromString("region/us-west-1/bogus"), m))
 	require.Equal(t, []string{}, List(PathFromString("region/us-west-1/vpc/vpc1/network/network1/id"), m))
 	require.Equal(t, []string{"id"}, List(PathFromString("region/us-west-1/vpc/vpc1/network/network1"), m))
 	require.Equal(t, []string{"us-west-1", "us-west-2"}, List(PathFromString("region/"), m))
@@ -72,6 +69,15 @@ func TestMap(t *testing.T) {
 	require.Equal(t, "b", Get(PathFromString("region/us-west-2/instances/[1]"), m))
 	require.Equal(t, "a", Get(PathFromString("region/us-west-2/instances[0]"), m))
 	require.Equal(t, "b", Get(PathFromString("region/us-west-2/instances[1]"), m))
+
+	// noexistent value list returns nil
+	require.Equal(t, []string(nil), List(PathFromString("region-not-found"), m))
+	require.Equal(t, []string(nil), List(PathFromString("region/us-west-1/bogus"), m))
+	require.Equal(t, []string(nil), List(PathFromString("region/us-west-2/nonexist"), m))
+
+	// existing non-list value list returns empty list
+	require.Equal(t, 100, get(PathFromString("region/us-west-2/metrics/instances/count"), m))
+	require.Equal(t, []string{}, List(PathFromString("region/us-west-2/metrics/instances/count"), m))
 
 }
 


### PR DESCRIPTION
Closes #425 

This PR:
  + Introduces an interceptor in broker package that can intercept incoming HTTP request and performs validation on the topic to subscribe before allowing actual subscription to proceed.  This opens up the possibility for library users to implement topic validation and client authentication with making any assumptions about the schema of the topic inside the `pkg/broker` package.
  + Introduces a simple `Validator` interface that is implemented by the RPC object, which can access the event plugin for a list of valid topics and the http sse implementation. 
  + Added simple logic to call the validators which for a given topic path in the http request, tests the validity of the topic via the Validators inside the interceptor's `Pre` function.  Reject and returns a HTTP 404 if the topic is not a valid topic.
  + Make the behavior of listing more consistent.  Specifically, if a given path does not result in a valid value, then nil is returned.  If a valid value exists at the path, then the *listability* of the value determines the result:  a slice, a map, a struct or a `*types.Any` (which will be decoded/unpacked), will result in a `[]string` of length 0 or greater.  If a value is not listable (e.g. a function, a simple value like a string, int), an empty string slice is returned.
  + Added some tests to ensure the behavior is enforced.
  + Removed the code that was checking paths inside the broker's message dispatching code. 

Example of the client command line output, using the timer example:

```
~/projects/src/github.com/docker/infrakit$ infrakit event ls -a
total 9:
event-time/timer/hr/1
event-time/timer/min/1
event-time/timer/min/30
event-time/timer/min/5
event-time/timer/msec/100
event-time/timer/msec/500
event-time/timer/sec/1
event-time/timer/sec/30
event-time/timer/sec/5
~/projects/src/github.com/docker/infrakit$ infrakit event tail event-time/timer/
INFO[0000] Using str://{{.}} for rendering view.        
INFO[0000] Connecting to broker url= unix://event-time topic= timer opts= {/Users/davidchung/.infrakit/plugins /events} 
{event-time/timer/msec/100 timer 100ms 2017-03-12 15:33:32.836766869 -0700 PDT 2017-03-12 15:33:32.843499864 -0700 PDT 100000000 <nil>}
{event-time/timer/msec/100 timer 100ms 2017-03-12 15:33:32.93599657 -0700 PDT 2017-03-12 15:33:32.936559323 -0700 PDT 100000000 <nil>}
{event-time/timer/msec/100 timer 100ms 2017-03-12 15:33:33.039209908 -0700 PDT 2017-03-12 15:33:33.039621312 -0700 PDT 100000000 <nil>}
```

and partial string match which was acceptable in the pkg/broker radix tree is now constrained by path:

```
~/projects/src/github.com/docker/infrakit$ infrakit event tail event-time/ti
INFO[0000] Using str://{{.}} for rendering view.        
INFO[0000] Connecting to broker url= unix://event-time topic= ti opts= {/Users/davidchung/.infrakit/plugins /events} 
INFO[0000] Server disconnected -- topic= event-time/ti  
{event-time/ti error  0001-01-01 00:00:00 +0000 UTC 2017-03-12 15:33:43.281807236 -0700 PDT <nil> http-status:404}
~
```

Also bad topic:

```
~/projects/src/github.com/docker/infrakit$ infrakit event tail event-time/i-dont-exist
INFO[0000] Using str://{{.}} for rendering view.        
INFO[0000] Connecting to broker url= unix://event-time topic= i-dont-exist opts= {/Users/davidchung/.infrakit/plugins /events} 
INFO[0000] Server disconnected -- topic= event-time/i-dont-exist 
{event-time/i-dont-exist error  0001-01-01 00:00:00 +0000 UTC 2017-03-12 15:37:26.142224002 -0700 PDT <nil> http-status:404}
```
  
