### PR TITLE
pkg/types/path Distinguish between /topicA  and /topicA/

### DIFF
--- a/pkg/broker/server/server_test.go
+++ b/pkg/broker/server/server_test.go
@@ -31,7 +31,7 @@ func TestListenAndServeOnSocket(t *testing.T) {
 	received2 := make(chan interface{})
 
 	opts := client.Options{SocketDir: filepath.Dir(socketFile)}
-	topic1, _, err := client.Subscribe(socket, "local", opts)
+	topic1, _, err := client.Subscribe(socket, "local/", opts)
 	require.NoError(t, err)
 	go func() {
 		for {
@@ -42,7 +42,7 @@ func TestListenAndServeOnSocket(t *testing.T) {
 		}
 	}()
 
-	topic2, _, err := client.Subscribe(socket, "local/time", opts)
+	topic2, _, err := client.Subscribe(socket, "local/time/", opts)
 	require.NoError(t, err)
 	go func() {
 		for {

--- a/pkg/broker/server/sse_test.go
+++ b/pkg/broker/server/sse_test.go
@@ -24,7 +24,7 @@ func TestBrokerMultiSubscribers(t *testing.T) {
 
 	opts := client.Options{SocketDir: filepath.Dir(socketFile)}
 
-	topic1, _, err := client.Subscribe(socket, "local", opts)
+	topic1, _, err := client.Subscribe(socket, "local/", opts)
 	require.NoError(t, err)
 	go func() {
 		for {
@@ -34,7 +34,7 @@ func TestBrokerMultiSubscribers(t *testing.T) {
 		}
 	}()
 
-	topic2, _, err := client.Subscribe(socket, "local/time", opts)
+	topic2, _, err := client.Subscribe(socket, "local/time/", opts)
 	require.NoError(t, err)
 	go func() {
 		for {
@@ -77,7 +77,7 @@ func TestBrokerMultiSubscribersProducers(t *testing.T) {
 	opts := client.Options{SocketDir: filepath.Dir(socketFile)}
 
 	sync := make(chan struct{})
-	topic1, _, err := client.Subscribe(socket, "local", opts)
+	topic1, _, err := client.Subscribe(socket, "local/", opts)
 	require.NoError(t, err)
 	go func() {
 		<-sync
@@ -88,7 +88,7 @@ func TestBrokerMultiSubscribersProducers(t *testing.T) {
 		}
 	}()
 
-	topic2, _, err := client.Subscribe(socket+"/?topic=/local/time", "", opts)
+	topic2, _, err := client.Subscribe(socket+"/?topic=/local/time/", "", opts)
 	require.NoError(t, err)
 	go func() {
 		<-sync
@@ -99,7 +99,7 @@ func TestBrokerMultiSubscribersProducers(t *testing.T) {
 		}
 	}()
 
-	topic3, _, err := client.Subscribe(socket, "cluster/time", opts)
+	topic3, _, err := client.Subscribe(socket, "cluster/time/", opts)
 	require.NoError(t, err)
 	go func() {
 		<-sync

--- a/pkg/rpc/event/rpc_test.go
+++ b/pkg/rpc/event/rpc_test.go
@@ -191,7 +191,13 @@ func TestEventPluginPublishSubscribe(t *testing.T) {
 	err = validator.Validate(types.PathFromString("compute"))
 	require.NoError(t, err)
 
+	err = validator.Validate(types.PathFromString("compute/"))
+	require.NoError(t, err)
+
 	err = validator.Validate(types.PathFromString("storage"))
+	require.NoError(t, err)
+
+	err = validator.Validate(types.PathFromString("storage/"))
 	require.NoError(t, err)
 
 	err = validator.Validate(types.PathFromString("storage/instance"))
@@ -212,10 +218,10 @@ func TestEventPluginPublishSubscribe(t *testing.T) {
 	client := must(NewClient(socketPath)).(event.Subscriber)
 	require.NotNil(t, client)
 
-	compute, err := client.SubscribeOn(types.PathFromString("compute"))
+	compute, err := client.SubscribeOn(types.PathFromString("compute/"))
 	require.NoError(t, err)
 
-	storage, err := client.SubscribeOn(types.PathFromString("storage"))
+	storage, err := client.SubscribeOn(types.PathFromString("storage/"))
 	require.NoError(t, err)
 
 	all, err := client.SubscribeOn(types.PathFromString("."))

--- a/pkg/types/path.go
+++ b/pkg/types/path.go
@@ -75,7 +75,10 @@ func (p Path) Clean() Path {
 	}
 	if len(copy) == 0 {
 		copy = []string{"."}
+	} else if this[len(this)-1] == "" || this[len(this)-1] == "." {
+		copy = append(copy, "")
 	}
+
 	return Path(copy)
 }
 
@@ -127,6 +130,10 @@ func (p Path) JoinString(child string) Path {
 // Join joins the child to the parent
 func (p Path) Join(child Path) Path {
 	pp := p.Clean()
+	this := []string(pp)
+	if this[len(this)-1] == "" {
+		pp = Path(this[:len(this)-1])
+	}
 	return Path(append(pp, []string(child)...))
 }
 
@@ -140,6 +147,9 @@ func (p Path) Rel(path Path) Path {
 
 	this := []string(p.Clean())
 	parent := []string(path.Clean())
+	if parent[len(parent)-1] == "" {
+		parent = parent[:len(parent)-1]
+	}
 	if len(this) < len(parent) {
 		return NullPath
 	}

--- a/pkg/types/path_test.go
+++ b/pkg/types/path_test.go
@@ -22,14 +22,14 @@ func TestPath(t *testing.T) {
 	require.True(t, PathFromString(".").Dot())
 	require.False(t, PathFromString("./a").Dot())
 
-	require.Equal(t, PathFromString("a/b/c/d"), PathFromString("a/b/c/d/").Clean())
-	require.Equal(t, PathFromString("a/b/c/d"), PathFromString("a/b/c/d/.").Clean())
+	//	require.Equal(t, PathFromString("a/b/c/d"), PathFromString("a/b/c/d/").Clean())
+	require.Equal(t, PathFromString("a/b/c/d/"), PathFromString("a/b/c/d/.").Clean())
 	require.Equal(t, PathFromString("a/b/c"), PathFromString("a/b/c/d/..").Clean())
-	require.Equal(t, PathFromString("a/b/c"), PathFromString("a/b/c/d/../").Clean())
-	require.Equal(t, PathFromString("a/b/c"), PathFromString("./a/b/c/d/../").Clean())
+	require.Equal(t, PathFromString("a/b/c/"), PathFromString("a/b/c/d/../").Clean())
+	require.Equal(t, PathFromString("a/b/c/"), PathFromString("./a/b/c/d/../").Clean())
 	require.Equal(t, PathFromString("."), PathFromString("a/..").Clean())
 
-	require.Equal(t, PathFromString("a/b/c/d"), PathFromString("a/b/c/d/").Clean())
+	require.Equal(t, PathFromString("a/b/c/d/"), PathFromString("a/b/c/d/").Clean())
 	require.Equal(t, PathFromString("a/b/c/d"), PathFromString("a/b/c/").JoinString("d"))
 	require.Equal(t, PathFromString("a/b/c/d/x/y"), PathFromString("a/b/c/").Join(PathFromString("d/x/y")))
 

--- a/pkg/types/path_test.go
+++ b/pkg/types/path_test.go
@@ -22,7 +22,6 @@ func TestPath(t *testing.T) {
 	require.True(t, PathFromString(".").Dot())
 	require.False(t, PathFromString("./a").Dot())
 
-	//	require.Equal(t, PathFromString("a/b/c/d"), PathFromString("a/b/c/d/").Clean())
 	require.Equal(t, PathFromString("a/b/c/d/"), PathFromString("a/b/c/d/.").Clean())
 	require.Equal(t, PathFromString("a/b/c"), PathFromString("a/b/c/d/..").Clean())
 	require.Equal(t, PathFromString("a/b/c/"), PathFromString("a/b/c/d/../").Clean())


### PR DESCRIPTION
@chungers In #429, behavior seems to be different from what we were discussing.
It can not distinguish between topic /A and topic /A/.
Therefore, subscribing `/toppicA` will always subscribe all of `/topicA/` and below subtopic, you can not subscribe only `/topicA`.
I added test `TestBrokerSubscriberExactMatchTopic`. This is the test I want to do in this PR.

Signed-off-by: Yuji Oshima <yuji.oshima0x3fd@gmail.com>