### PR TITLE
build: Use Go 1.8 for container builds as well

### DIFF
--- a/dockerfiles/Dockerfile.build
+++ b/dockerfiles/Dockerfile.build
@@ -1,4 +1,4 @@
-FROM golang:1.7.5-alpine
+FROM golang:1.8-alpine
 
 RUN apk add --update git make
 RUN go get github.com/rancher/trash


### PR DESCRIPTION
594813c updated the CircleCI build to 1.8. This PR also
changes the containerised builds.

Signed-off-by: Rolf Neugebauer <rolf.neugebauer@docker.com>