### PR TITLE
Add launch index in flavor.Prepare call

### DIFF
--- a/docs/plugins/flavor.md
+++ b/docs/plugins/flavor.md
@@ -1,6 +1,6 @@
 # Flavor plugin API
 
-<!-- SOURCE-CHECKSUM pkg/spi/flavor/* 76aecf22acb4af73f36857bb2fad861896ae0b62 -->
+<!-- SOURCE-CHECKSUM pkg/spi/flavor/* e27841cf1ead137533b608b3ccc90ab72596532a -->
 
 ## API
 
@@ -52,6 +52,10 @@ may add, remove, or modify any fields in the Instance `Spec` by returning the de
   "Allocation": {
     "Size": 1,
     "LogicalIDs": ["logical_id_1"]
+  },
+  "Index" : {
+    "Group" : "workers",
+    "Sequence" : 100
   }
 }
 ```
@@ -60,6 +64,7 @@ Parameters:
 - `Properties`: A JSON object representing the Flavor.  The schema is defined by the Flavor plugin in use.
 - `Spec`: The [Spec](types.md#instance-spec) of the Instance being prepared.
 - `Allocation`: An [Allocation](types.md#allocation)
+- `Index`: an [Index](types.md#index)
 
 #### Response
 ```json

--- a/docs/plugins/types.md
+++ b/docs/plugins/types.md
@@ -13,6 +13,17 @@ Fields:
 - `Size`: An integer, the number of instances to maintain in the Group.
 - `LogicalIDs`: An array of strings, the logical identifeirs to maintain in the group.
 
+# Index
+Index is a context object that is used to denote the instance's relationship with respect to the group it belongs.
+An Index has two fields: a group ID and a sequence number.  The group ID is the identifier of the group, while the
+sequence number represents the order in which the instance is created with respect to the group.  So for a group of
+size N, the sequence number will be 0, 1, 2, ... N-1.  This can be used by the flavor plugin to determine which one
+of the instances, as represented by a fixed set of nodes (e.g. pets, or stateful nodes), the current instance is.
+In cases where provisioning instances where IP addresses cannot be assigned upfront, this provides a mechanism for
+looking up which IP address a particular node represents if given a list of IP addresses as a result of instance
+creations for this group.  A similar concept can be found in AWS Autoscaling group's Launch index.
+
+
 # Group ID
 A globally-unique string identifier for an Group.
 

--- a/examples/flavor/combo/flavor.go
+++ b/examples/flavor/combo/flavor.go
@@ -136,7 +136,8 @@ func mergeSpecs(initial instance.Spec, specs []instance.Spec) (instance.Spec, er
 
 func (f flavorCombo) Prepare(flavor *types.Any,
 	inst instance.Spec,
-	allocation group_types.AllocationMethod) (instance.Spec, error) {
+	allocation group_types.AllocationMethod,
+	index group_types.Index) (instance.Spec, error) {
 
 	combo := Spec{}
 	err := flavor.Decode(&combo)
@@ -154,7 +155,7 @@ func (f flavorCombo) Prepare(flavor *types.Any,
 			return inst, err
 		}
 
-		flavorOutput, err := plugin.Prepare(pluginSpec.Properties, clone, allocation)
+		flavorOutput, err := plugin.Prepare(pluginSpec.Properties, clone, allocation, index)
 		if err != nil {
 			return inst, err
 		}

--- a/examples/flavor/swarm/flavor.go
+++ b/examples/flavor/swarm/flavor.go
@@ -270,6 +270,7 @@ func (s *baseFlavor) prepare(role string, flavorProperties *types.Any, instanceS
 			flavorSpec:   spec,
 			instanceSpec: instanceSpec,
 			allocation:   allocation,
+			index:        index,
 			swarmStatus:  swarmStatus,
 			nodeInfo:     node,
 			link:         *link,
@@ -408,6 +409,7 @@ type templateContext struct {
 	flavorSpec   Spec
 	instanceSpec instance.Spec
 	allocation   group_types.AllocationMethod
+	index        group_types.Index
 	swarmStatus  *swarm.Swarm
 	nodeInfo     *swarm.Node
 	link         types.Link
@@ -445,6 +447,13 @@ func (c *templateContext) Funcs() []template.Function {
 			Description: []string{"The allocations contain fields such as the size of the group or the list of logical ids."},
 			Func: func() interface{} {
 				return c.allocation
+			},
+		},
+		{
+			Name:        "INDEX",
+			Description: []string{"The launch index of this instance. Contains the group ID and the sequence number of instance."},
+			Func: func() interface{} {
+				return c.index
 			},
 		},
 		{

--- a/examples/flavor/swarm/flavor.go
+++ b/examples/flavor/swarm/flavor.go
@@ -210,7 +210,8 @@ func (s *baseFlavor) Healthy(flavorProperties *types.Any, inst instance.Descript
 }
 
 func (s *baseFlavor) prepare(role string, flavorProperties *types.Any, instanceSpec instance.Spec,
-	allocation group_types.AllocationMethod) (instance.Spec, error) {
+	allocation group_types.AllocationMethod,
+	index group_types.Index) (instance.Spec, error) {
 
 	spec := Spec{}
 

--- a/examples/flavor/swarm/flavor_test.go
+++ b/examples/flavor/swarm/flavor_test.go
@@ -11,6 +11,7 @@ import (
 	mock_client "github.com/docker/infrakit/pkg/mock/docker/docker/client"
 	group_types "github.com/docker/infrakit/pkg/plugin/group/types"
 	"github.com/docker/infrakit/pkg/spi/flavor"
+	"github.com/docker/infrakit/pkg/spi/group"
 	"github.com/docker/infrakit/pkg/spi/instance"
 	"github.com/docker/infrakit/pkg/template"
 	"github.com/docker/infrakit/pkg/types"
@@ -117,10 +118,12 @@ func TestWorker(t *testing.T) {
 	client.EXPECT().NodeInspectWithRaw(gomock.Any(), nodeID).Return(nodeInfo, nil, nil).AnyTimes()
 	client.EXPECT().Close().AnyTimes()
 
+	index := group_types.Index{Group: group.ID("group"), Sequence: 0}
 	details, err := flavorImpl.Prepare(
 		types.AnyString(`{}`),
 		instance.Spec{Tags: map[string]string{"a": "b"}},
-		group_types.AllocationMethod{Size: 5})
+		group_types.AllocationMethod{Size: 5},
+		index)
 	require.NoError(t, err)
 	require.Equal(t, "b", details.Tags["a"])
 
@@ -188,11 +191,13 @@ func TestManager(t *testing.T) {
 	client.EXPECT().NodeInspectWithRaw(gomock.Any(), nodeID).Return(nodeInfo, nil, nil).AnyTimes()
 	client.EXPECT().Close().AnyTimes()
 
+	index := group_types.Index{Group: group.ID("group"), Sequence: 0}
 	id := instance.LogicalID("127.0.0.1")
 	details, err := flavorImpl.Prepare(
 		types.AnyString(`{"Attachments": {"127.0.0.1": [{"ID": "a", "Type": "gpu"}]}}`),
 		instance.Spec{Tags: map[string]string{"a": "b"}, LogicalID: &id},
-		group_types.AllocationMethod{LogicalIDs: []instance.LogicalID{"127.0.0.1"}})
+		group_types.AllocationMethod{LogicalIDs: []instance.LogicalID{"127.0.0.1"}},
+		index)
 	require.NoError(t, err)
 	require.Equal(t, "b", details.Tags["a"])
 
@@ -208,11 +213,13 @@ func TestManager(t *testing.T) {
 	require.Contains(t, details.Init, associationID)
 
 	// another instance -- note that this id is not the first in the allocation list of logical ids.
+	index = group_types.Index{Group: group.ID("group"), Sequence: 1}
 	id = instance.LogicalID("172.200.100.2")
 	details, err = flavorImpl.Prepare(
 		types.AnyString(`{"Attachments": {"172.200.100.2": [{"ID": "a", "Type": "gpu"}]}}`),
 		instance.Spec{Tags: map[string]string{"a": "b"}, LogicalID: &id},
-		group_types.AllocationMethod{LogicalIDs: []instance.LogicalID{"172.200.100.1", "172.200.100.2"}})
+		group_types.AllocationMethod{LogicalIDs: []instance.LogicalID{"172.200.100.1", "172.200.100.2"}},
+		index)
 	require.NoError(t, err)
 
 	require.Contains(t, details.Init, swarmInfo.JoinTokens.Manager)

--- a/examples/flavor/swarm/manager.go
+++ b/examples/flavor/swarm/manager.go
@@ -55,6 +55,7 @@ func (s *ManagerFlavor) Validate(flavorProperties *types.Any, allocation group_t
 
 // Prepare sets up the provisioner / instance plugin's spec based on information about the swarm to join.
 func (s *ManagerFlavor) Prepare(flavorProperties *types.Any,
-	instanceSpec instance.Spec, allocation group_types.AllocationMethod) (instance.Spec, error) {
-	return s.baseFlavor.prepare("manager", flavorProperties, instanceSpec, allocation)
+	instanceSpec instance.Spec, allocation group_types.AllocationMethod,
+	index group_types.Index) (instance.Spec, error) {
+	return s.baseFlavor.prepare("manager", flavorProperties, instanceSpec, allocation, index)
 }

--- a/examples/flavor/swarm/worker.go
+++ b/examples/flavor/swarm/worker.go
@@ -33,8 +33,9 @@ type WorkerFlavor struct {
 
 // Prepare sets up the provisioner / instance plugin's spec based on information about the swarm to join.
 func (s *WorkerFlavor) Prepare(flavorProperties *types.Any, instanceSpec instance.Spec,
-	allocation group_types.AllocationMethod) (instance.Spec, error) {
-	return s.baseFlavor.prepare("worker", flavorProperties, instanceSpec, allocation)
+	allocation group_types.AllocationMethod,
+	index group_types.Index) (instance.Spec, error) {
+	return s.baseFlavor.prepare("worker", flavorProperties, instanceSpec, allocation, index)
 }
 
 // Drain in the case of worker will force a node removal in the swarm.

--- a/examples/flavor/vanilla/flavor.go
+++ b/examples/flavor/vanilla/flavor.go
@@ -44,7 +44,8 @@ func (f vanillaFlavor) Drain(flavorProperties *types.Any, inst instance.Descript
 
 func (f vanillaFlavor) Prepare(flavor *types.Any,
 	instance instance.Spec,
-	allocation group_types.AllocationMethod) (instance.Spec, error) {
+	allocation group_types.AllocationMethod,
+	index group_types.Index) (instance.Spec, error) {
 
 	s := Spec{}
 	err := flavor.Decode(&s)

--- a/examples/flavor/zookeeper/flavor.go
+++ b/examples/flavor/zookeeper/flavor.go
@@ -159,7 +159,8 @@ func (z zkFlavor) Drain(flavorProperties *types.Any, inst instance.Description) 
 
 func (z zkFlavor) Prepare(flavorProperties *types.Any,
 	spec instance.Spec,
-	allocation group_types.AllocationMethod) (instance.Spec, error) {
+	allocation group_types.AllocationMethod,
+	index group_types.Index) (instance.Spec, error) {
 
 	properties, err := parseSpec(flavorProperties)
 	if err != nil {

--- a/pkg/mock/spi/flavor/flavor.go
+++ b/pkg/mock/spi/flavor/flavor.go
@@ -53,15 +53,15 @@ func (_mr *_MockPluginRecorder) Healthy(arg0, arg1 interface{}) *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "Healthy", arg0, arg1)
 }
 
-func (_m *MockPlugin) Prepare(_param0 *types.Any, _param1 instance.Spec, _param2 types0.AllocationMethod) (instance.Spec, error) {
-	ret := _m.ctrl.Call(_m, "Prepare", _param0, _param1, _param2)
+func (_m *MockPlugin) Prepare(_param0 *types.Any, _param1 instance.Spec, _param2 types0.AllocationMethod, _param3 types0.Index) (instance.Spec, error) {
+	ret := _m.ctrl.Call(_m, "Prepare", _param0, _param1, _param2, _param3)
 	ret0, _ := ret[0].(instance.Spec)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-func (_mr *_MockPluginRecorder) Prepare(arg0, arg1, arg2 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "Prepare", arg0, arg1, arg2)
+func (_mr *_MockPluginRecorder) Prepare(arg0, arg1, arg2, arg3 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "Prepare", arg0, arg1, arg2, arg3)
 }
 
 func (_m *MockPlugin) Validate(_param0 *types.Any, _param1 types0.AllocationMethod) error {

--- a/pkg/plugin/group/group.go
+++ b/pkg/plugin/group/group.go
@@ -101,13 +101,14 @@ func (p *plugin) CommitGroup(config group.Spec, pretend bool) (string, error) {
 
 	var supervisor Supervisor
 	if settings.config.Allocation.Size != 0 {
-		supervisor = NewScalingGroup(scaled, settings.config.Allocation.Size, p.pollInterval, p.maxParallelNum)
+		supervisor = NewScalingGroup(config.ID, scaled, settings.config.Allocation.Size, p.pollInterval, p.maxParallelNum)
 	} else if len(settings.config.Allocation.LogicalIDs) > 0 {
-		supervisor = NewQuorum(scaled, settings.config.Allocation.LogicalIDs, p.pollInterval)
+		supervisor = NewQuorum(config.ID, scaled, settings.config.Allocation.LogicalIDs, p.pollInterval)
 	} else {
 		panic("Invalid empty allocation method")
 	}
 
+	scaled.supervisor = supervisor
 	if !pretend {
 		p.groups.put(config.ID, &groupContext{supervisor: supervisor, scaled: scaled, settings: settings})
 		go supervisor.Run()

--- a/pkg/plugin/group/quorum.go
+++ b/pkg/plugin/group/quorum.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 	log "github.com/Sirupsen/logrus"
+	"github.com/docker/infrakit/pkg/spi/group"
 	"github.com/docker/infrakit/pkg/spi/instance"
 	"reflect"
 	"sync"
@@ -13,6 +14,7 @@ import (
 // TODO(wfarner): Converge this implementation with scaler.go, they share a lot of behavior.
 
 type quorum struct {
+	id           group.ID
 	scaled       Scaled
 	LogicalIDs   []instance.LogicalID
 	pollInterval time.Duration
@@ -20,8 +22,9 @@ type quorum struct {
 }
 
 // NewQuorum creates a supervisor for a group of instances operating in a quorum.
-func NewQuorum(scaled Scaled, logicalIDs []instance.LogicalID, pollInterval time.Duration) Supervisor {
+func NewQuorum(id group.ID, scaled Scaled, logicalIDs []instance.LogicalID, pollInterval time.Duration) Supervisor {
 	return &quorum{
+		id:           id,
 		scaled:       scaled,
 		LogicalIDs:   logicalIDs,
 		pollInterval: pollInterval,
@@ -63,6 +66,10 @@ func (q *quorum) Run() {
 			return
 		}
 	}
+}
+
+func (q *quorum) ID() group.ID {
+	return q.id
 }
 
 func (q *quorum) Size() uint {

--- a/pkg/plugin/group/quorum_test.go
+++ b/pkg/plugin/group/quorum_test.go
@@ -2,6 +2,7 @@ package group
 
 import (
 	mock_group "github.com/docker/infrakit/pkg/mock/plugin/group"
+	"github.com/docker/infrakit/pkg/spi/group"
 	"github.com/docker/infrakit/pkg/spi/instance"
 	"github.com/golang/mock/gomock"
 	"testing"
@@ -30,8 +31,9 @@ func TestQuorumOK(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 
+	groupID := group.ID("quorum")
 	scaled := mock_group.NewMockScaled(ctrl)
-	quorum := NewQuorum(scaled, logicalIDs, 1*time.Millisecond)
+	quorum := NewQuorum(groupID, scaled, logicalIDs, 1*time.Millisecond)
 
 	gomock.InOrder(
 		scaled.EXPECT().List().Return([]instance.Description{a, b, c}, nil),
@@ -49,8 +51,10 @@ func TestRestoreQuorum(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 
+	groupID := group.ID("quorum")
+
 	scaled := mock_group.NewMockScaled(ctrl)
-	quorum := NewQuorum(scaled, logicalIDs, 1*time.Millisecond)
+	quorum := NewQuorum(groupID, scaled, logicalIDs, 1*time.Millisecond)
 
 	logicalID := *c.LogicalID
 	gomock.InOrder(
@@ -72,8 +76,10 @@ func TestRemoveUnknown(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 
+	groupID := group.ID("quorum")
+
 	scaled := mock_group.NewMockScaled(ctrl)
-	quorum := NewQuorum(scaled, logicalIDs, 1*time.Millisecond)
+	quorum := NewQuorum(groupID, scaled, logicalIDs, 1*time.Millisecond)
 
 	gomock.InOrder(
 		scaled.EXPECT().List().Return([]instance.Description{a, c, b}, nil),

--- a/pkg/plugin/group/scaled.go
+++ b/pkg/plugin/group/scaled.go
@@ -5,6 +5,7 @@ import (
 	"sync"
 
 	log "github.com/Sirupsen/logrus"
+	group_types "github.com/docker/infrakit/pkg/plugin/group/types"
 	"github.com/docker/infrakit/pkg/spi/flavor"
 	"github.com/docker/infrakit/pkg/spi/instance"
 	"github.com/docker/infrakit/pkg/types"
@@ -34,6 +35,8 @@ type Scaled interface {
 }
 
 type scaledGroup struct {
+	supervisor Supervisor
+	scaler     *scaler
 	settings   groupSettings
 	memberTags map[string]string
 	lock       sync.Mutex
@@ -72,9 +75,14 @@ func (s *scaledGroup) CreateOne(logicalID *instance.LogicalID) {
 		Properties: types.AnyCopy(settings.config.Instance.Properties),
 	}
 
+	index := group_types.Index{
+		Group:    s.supervisor.ID(),
+		Sequence: s.supervisor.Size(),
+	}
 	spec, err := settings.flavorPlugin.Prepare(types.AnyCopy(settings.config.Flavor.Properties),
 		spec,
-		settings.config.Allocation)
+		settings.config.Allocation,
+		index)
 	if err != nil {
 		log.Errorf("Failed to Prepare instance: %s", err)
 		return

--- a/pkg/plugin/group/scaler.go
+++ b/pkg/plugin/group/scaler.go
@@ -7,10 +7,12 @@ import (
 	"time"
 
 	log "github.com/Sirupsen/logrus"
+	"github.com/docker/infrakit/pkg/spi/group"
 	"github.com/docker/infrakit/pkg/spi/instance"
 )
 
 type scaler struct {
+	id             group.ID
 	scaled         Scaled
 	size           uint
 	pollInterval   time.Duration
@@ -21,8 +23,9 @@ type scaler struct {
 
 // NewScalingGroup creates a supervisor that monitors a group of instances on a provisioner, attempting to maintain a
 // desired size.
-func NewScalingGroup(scaled Scaled, size uint, pollInterval time.Duration, maxParallelNum uint) Supervisor {
+func NewScalingGroup(id group.ID, scaled Scaled, size uint, pollInterval time.Duration, maxParallelNum uint) Supervisor {
 	return &scaler{
+		id:             id,
 		scaled:         scaled,
 		size:           size,
 		pollInterval:   pollInterval,
@@ -205,6 +208,10 @@ func (s *scaler) Run() {
 			return
 		}
 	}
+}
+
+func (s *scaler) ID() group.ID {
+	return s.id
 }
 
 func (s *scaler) Size() uint {

--- a/pkg/plugin/group/scaler_test.go
+++ b/pkg/plugin/group/scaler_test.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	mock_group "github.com/docker/infrakit/pkg/mock/plugin/group"
+	"github.com/docker/infrakit/pkg/spi/group"
 	"github.com/docker/infrakit/pkg/spi/instance"
 	"github.com/golang/mock/gomock"
 )
@@ -27,8 +28,10 @@ func TestScaleUp(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 
+	groupID := group.ID("scaler")
+
 	scaled := mock_group.NewMockScaled(ctrl)
-	scaler := NewScalingGroup(scaled, 3, 1*time.Millisecond, 0)
+	scaler := NewScalingGroup(groupID, scaled, 3, 1*time.Millisecond, 0)
 
 	gomock.InOrder(
 		scaled.EXPECT().List().Return([]instance.Description{a, b, c}, nil),
@@ -49,8 +52,10 @@ func TestBufferScaleUp(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 
+	groupID := group.ID("scaler")
+
 	scaled := mock_group.NewMockScaled(ctrl)
-	scaler := NewScalingGroup(scaled, 3, 1*time.Millisecond, 1)
+	scaler := NewScalingGroup(groupID, scaled, 3, 1*time.Millisecond, 1)
 
 	gomock.InOrder(
 		scaled.EXPECT().List().Return([]instance.Description{a, b, c}, nil),
@@ -71,8 +76,10 @@ func TestScaleDown(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 
+	groupID := group.ID("scaler")
+
 	scaled := mock_group.NewMockScaled(ctrl)
-	scaler := NewScalingGroup(scaled, 2, 1*time.Millisecond, 0)
+	scaler := NewScalingGroup(groupID, scaled, 2, 1*time.Millisecond, 0)
 
 	gomock.InOrder(
 		scaled.EXPECT().List().Return([]instance.Description{c, b}, nil),
@@ -94,8 +101,10 @@ func TestBufferScaleDown(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 
+	groupID := group.ID("scaler")
+
 	scaled := mock_group.NewMockScaled(ctrl)
-	scaler := NewScalingGroup(scaled, 2, 1*time.Millisecond, 1)
+	scaler := NewScalingGroup(groupID, scaled, 2, 1*time.Millisecond, 1)
 
 	gomock.InOrder(
 		scaled.EXPECT().List().Return([]instance.Description{c, b}, nil),
@@ -117,8 +126,10 @@ func TestLabel(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 
+	groupID := group.ID("scaler")
+
 	scaled := mock_group.NewMockScaled(ctrl)
-	scaler := NewScalingGroup(scaled, 2, 1*time.Millisecond, 1)
+	scaler := NewScalingGroup(groupID, scaled, 2, 1*time.Millisecond, 1)
 
 	gomock.InOrder(
 		scaled.EXPECT().List().Do(func() {
@@ -135,8 +146,10 @@ func TestFailToLabel(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 
+	groupID := group.ID("scaler")
+
 	scaled := mock_group.NewMockScaled(ctrl)
-	scaler := NewScalingGroup(scaled, 2, 1*time.Millisecond, 1)
+	scaler := NewScalingGroup(groupID, scaled, 2, 1*time.Millisecond, 1)
 
 	gomock.InOrder(
 		scaled.EXPECT().List().Do(func() {
@@ -152,8 +165,10 @@ func TestFailToList(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 
+	groupID := group.ID("scaler")
+
 	scaled := mock_group.NewMockScaled(ctrl)
-	scaler := NewScalingGroup(scaled, 2, 1*time.Millisecond, 1)
+	scaler := NewScalingGroup(groupID, scaled, 2, 1*time.Millisecond, 1)
 
 	gomock.InOrder(
 		scaled.EXPECT().List().Return(nil, errors.New("Unable to list")),

--- a/pkg/plugin/group/state.go
+++ b/pkg/plugin/group/state.go
@@ -14,6 +14,8 @@ import (
 type Supervisor interface {
 	util.RunStop
 
+	ID() group.ID
+
 	Size() uint
 
 	PlanUpdate(scaled Scaled, settings groupSettings, newSettings groupSettings) (updatePlan, error)

--- a/pkg/plugin/group/testplugin.go
+++ b/pkg/plugin/group/testplugin.go
@@ -144,7 +144,8 @@ func (t testFlavor) Validate(flavorProperties *types.Any, allocation group_types
 
 func (t testFlavor) Prepare(flavorProperties *types.Any,
 	spec instance.Spec,
-	allocation group_types.AllocationMethod) (instance.Spec, error) {
+	allocation group_types.AllocationMethod,
+	index group_types.Index) (instance.Spec, error) {
 
 	s := flavorSchema{}
 	err := flavorProperties.Decode(&s)

--- a/pkg/plugin/group/types/types.go
+++ b/pkg/plugin/group/types/types.go
@@ -25,6 +25,17 @@ type AllocationMethod struct {
 	LogicalIDs []instance.LogicalID
 }
 
+// Index is the index of the instance's creation.  It provides a context for knowing
+// what is being created.
+type Index struct {
+
+	// Group is the name of the group
+	Group group.ID
+
+	// Sequence is a sequence number that's per instance.
+	Sequence uint
+}
+
 // InstancePlugin is the structure that describes an instance plugin.
 type InstancePlugin struct {
 	Plugin     plugin.Name

--- a/pkg/rpc/flavor/client.go
+++ b/pkg/rpc/flavor/client.go
@@ -34,11 +34,11 @@ func (c client) Validate(flavorProperties *types.Any, allocation group_types.All
 // Prepare allows the Flavor to modify the provisioning instructions for an instance.  For example, a
 // helper could be used to place additional tags on the machine, or generate a specialized Init command based on
 // the flavor configuration.
-func (c client) Prepare(flavorProperties *types.Any,
-	spec instance.Spec, allocation group_types.AllocationMethod) (instance.Spec, error) {
+func (c client) Prepare(flavorProperties *types.Any, spec instance.Spec,
+	allocation group_types.AllocationMethod, index group_types.Index) (instance.Spec, error) {
 
 	_, flavorType := c.name.GetLookupAndType()
-	req := PrepareRequest{Type: flavorType, Properties: flavorProperties, Spec: spec, Allocation: allocation}
+	req := PrepareRequest{Type: flavorType, Properties: flavorProperties, Spec: spec, Allocation: allocation, Index: index}
 	resp := PrepareResponse{}
 	err := c.client.Call("Flavor.Prepare", req, &resp)
 	if err != nil {

--- a/pkg/rpc/flavor/service.go
+++ b/pkg/rpc/flavor/service.go
@@ -150,7 +150,7 @@ func (p *Flavor) Prepare(_ *http.Request, req *PrepareRequest, resp *PrepareResp
 	if c == nil {
 		return fmt.Errorf("no-plugin:%s", req.Type)
 	}
-	spec, err := c.Prepare(req.Properties, req.Spec, req.Allocation)
+	spec, err := c.Prepare(req.Properties, req.Spec, req.Allocation, req.Index)
 	if err != nil {
 		return err
 	}

--- a/pkg/rpc/flavor/types.go
+++ b/pkg/rpc/flavor/types.go
@@ -26,6 +26,7 @@ type PrepareRequest struct {
 	Properties *types.Any
 	Spec       instance.Spec
 	Allocation group_types.AllocationMethod
+	Index      group_types.Index
 }
 
 // PrepareResponse is the rpc wrapper of the result of Prepare

--- a/pkg/spi/flavor/spi.go
+++ b/pkg/spi/flavor/spi.go
@@ -36,7 +36,9 @@ type Plugin interface {
 	// Prepare allows the Flavor to modify the provisioning instructions for an instance.  For example, a
 	// helper could be used to place additional tags on the machine, or generate a specialized Init command based on
 	// the flavor configuration.
-	Prepare(flavorProperties *types.Any, spec instance.Spec, allocation group_types.AllocationMethod) (instance.Spec, error)
+	Prepare(flavorProperties *types.Any, spec instance.Spec,
+		allocation group_types.AllocationMethod,
+		createContext group_types.Index) (instance.Spec, error)
 
 	// Healthy determines the Health of this Flavor on an instance.
 	Healthy(flavorProperties *types.Any, inst instance.Description) (Health, error)

--- a/pkg/testing/flavor/plugin.go
+++ b/pkg/testing/flavor/plugin.go
@@ -15,7 +15,7 @@ type Plugin struct {
 
 	// DoPrepare implements Prepare via function
 	DoPrepare func(flavorProperties *types.Any, spec instance.Spec,
-		allocation group_types.AllocationMethod) (instance.Spec, error)
+		allocation group_types.AllocationMethod, index group_types.Index) (instance.Spec, error)
 
 	// DoHealthy implements Healthy via function
 	DoHealthy func(flavorProperties *types.Any, inst instance.Description) (flavor.Health, error)
@@ -34,9 +34,10 @@ func (t *Plugin) Validate(flavorProperties *types.Any, allocation group_types.Al
 // the flavor configuration.
 func (t *Plugin) Prepare(flavorProperties *types.Any,
 	spec instance.Spec,
-	allocation group_types.AllocationMethod) (instance.Spec, error) {
+	allocation group_types.AllocationMethod,
+	index group_types.Index) (instance.Spec, error) {
 
-	return t.DoPrepare(flavorProperties, spec, allocation)
+	return t.DoPrepare(flavorProperties, spec, allocation, index)
 }
 
 // Healthy determines the Health of this Flavor on an instance.


### PR DESCRIPTION
For stateful groups (pets) we have always assumed that members have stable, fixed, IP addresses which are used as logical identifiers.  This works ok for platforms that support assigning IP addresses during instance creation.  However, on some platforms, assigning IP addresses is not possible and our assumption breaks down:  the original `flavor.Prepare` actually has no information or context as to *which one* of the stateful set is being created -- because we would not know in advance what our logical ids are and therefore the `AllocationMethods:LogicalIDs` will be empty.

This PR adds an `Index` object to provide this missing context so that the plugin can still have a sense of *which one* of the group members it is trying to create.  When the Index is known, we can use a combination of metadata, request reverse proxy, for the instance to know who it is and be able to query additional contextual information like indexing into a list of provisioned IP addresses for that group, etc.   A good analogy of this is the `launch-index` metadata in AWS.. for an instance launched in an autoscaling group it is possible to determine the instance's own launch index via ` curl http://169.254.169.254/latest/meta-data/ami-launch-index`.   Passing this information from the group to the flavor plugin allows the flavor plugin to prepare the instance with this information -- for example -- via user data and write that information to a file on disk, etc.

For the moment, only the Flavor plugin SPI has been modified to including this new index.

Closes #252 

Signed-off-by: David Chung <david.chung@docker.com>