### PR TITLE
template clean up

### DIFF
--- a/cmd/cli/event.go
+++ b/cmd/cli/event.go
@@ -6,7 +6,6 @@ import (
 
 	log "github.com/Sirupsen/logrus"
 	"github.com/docker/infrakit/pkg/discovery"
-	"github.com/docker/infrakit/pkg/discovery/local"
 	metadata_template "github.com/docker/infrakit/pkg/plugin/metadata/template"
 	"github.com/docker/infrakit/pkg/rpc/client"
 	event_rpc "github.com/docker/infrakit/pkg/rpc/event"
@@ -193,9 +192,7 @@ func eventCommand(plugins func() discovery.Plugins) *cobra.Command {
 		RunE: func(c *cobra.Command, args []string) error {
 
 			log.Infof("Using %v for rendering view.", templateURL)
-			engine, err := template.NewTemplate(templateURL, template.Options{
-				SocketDir: local.Dir(),
-			})
+			engine, err := template.NewTemplate(templateURL, template.Options{})
 			if err != nil {
 				return err
 			}

--- a/cmd/cli/manager.go
+++ b/cmd/cli/manager.go
@@ -6,7 +6,6 @@ import (
 
 	log "github.com/Sirupsen/logrus"
 	"github.com/docker/infrakit/pkg/discovery"
-	"github.com/docker/infrakit/pkg/discovery/local"
 	"github.com/docker/infrakit/pkg/manager"
 	"github.com/docker/infrakit/pkg/plugin"
 	metadata_template "github.com/docker/infrakit/pkg/plugin/metadata/template"
@@ -87,9 +86,7 @@ func managerCommand(plugins func() discovery.Plugins) *cobra.Command {
 		templateURL := args[0]
 
 		log.Infof("Using %v for reading template\n", templateURL)
-		engine, err := template.NewTemplate(templateURL, template.Options{
-			SocketDir: local.Dir(),
-		})
+		engine, err := template.NewTemplate(templateURL, template.Options{})
 		if err != nil {
 			return err
 		}

--- a/cmd/cli/plugin.go
+++ b/cmd/cli/plugin.go
@@ -11,7 +11,6 @@ import (
 
 	log "github.com/Sirupsen/logrus"
 	"github.com/docker/infrakit/pkg/discovery"
-	"github.com/docker/infrakit/pkg/discovery/local"
 	"github.com/docker/infrakit/pkg/launch"
 	"github.com/docker/infrakit/pkg/launch/os"
 	"github.com/docker/infrakit/pkg/plugin"
@@ -59,9 +58,7 @@ func pluginCommand(plugins func() discovery.Plugins) *cobra.Command {
 
 	start.RunE = func(c *cobra.Command, args []string) error {
 
-		configTemplate, err := template.NewTemplate(*configURL, template.Options{
-			SocketDir: local.Dir(),
-		})
+		configTemplate, err := template.NewTemplate(*configURL, template.Options{})
 		if err != nil {
 			return err
 		}

--- a/cmd/cli/resource.go
+++ b/cmd/cli/resource.go
@@ -6,7 +6,6 @@ import (
 
 	log "github.com/Sirupsen/logrus"
 	"github.com/docker/infrakit/pkg/discovery"
-	"github.com/docker/infrakit/pkg/discovery/local"
 	"github.com/docker/infrakit/pkg/plugin"
 	resource_plugin "github.com/docker/infrakit/pkg/rpc/resource"
 	"github.com/docker/infrakit/pkg/spi/resource"
@@ -139,9 +138,7 @@ func resourcePluginCommand(plugins func() discovery.Plugins) *cobra.Command {
 
 func readSpecFromTemplateURL(templateURL string) (*resource.Spec, error) {
 	log.Infof("Reading template from %v", templateURL)
-	engine, err := template.NewTemplate(templateURL, template.Options{
-		SocketDir: local.Dir(),
-	})
+	engine, err := template.NewTemplate(templateURL, template.Options{})
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/cli/template.go
+++ b/cmd/cli/template.go
@@ -6,7 +6,6 @@ import (
 
 	log "github.com/Sirupsen/logrus"
 	"github.com/docker/infrakit/pkg/discovery"
-	"github.com/docker/infrakit/pkg/discovery/local"
 	metadata_template "github.com/docker/infrakit/pkg/plugin/metadata/template"
 	"github.com/docker/infrakit/pkg/template"
 	"github.com/spf13/cobra"
@@ -22,9 +21,7 @@ func templateCommand(plugins func() discovery.Plugins) *cobra.Command {
 		RunE: func(cmd *cobra.Command, args []string) error {
 
 			log.Infof("Using %v for reading template\n", templateURL)
-			engine, err := template.NewTemplate(templateURL, template.Options{
-				SocketDir: local.Dir(),
-			})
+			engine, err := template.NewTemplate(templateURL, template.Options{})
 			if err != nil {
 				return err
 			}

--- a/examples/flavor/swarm/main.go
+++ b/examples/flavor/swarm/main.go
@@ -24,9 +24,7 @@ func init() {
 		})
 }
 
-var defaultTemplateOptions = template.Options{
-	SocketDir: local.Dir(),
-}
+var defaultTemplateOptions = template.Options{}
 
 func main() {
 

--- a/examples/instance/vagrant/main.go
+++ b/examples/instance/vagrant/main.go
@@ -7,7 +7,6 @@ import (
 
 	log "github.com/Sirupsen/logrus"
 	"github.com/docker/infrakit/pkg/cli"
-	"github.com/docker/infrakit/pkg/discovery/local"
 	"github.com/docker/infrakit/pkg/plugin/metadata"
 	instance_plugin "github.com/docker/infrakit/pkg/rpc/instance"
 	metadata_plugin "github.com/docker/infrakit/pkg/rpc/metadata"
@@ -33,9 +32,7 @@ func main() {
 	templFile := cmd.Flags().String("template", "", "Vagrant Template file, in URL form")
 	cmd.RunE = func(c *cobra.Command, args []string) error {
 
-		opts := template.Options{
-			SocketDir: local.Dir(),
-		}
+		opts := template.Options{}
 
 		var templ *template.Template
 		if *templFile == "" {

--- a/pkg/discovery/discovery_test.go
+++ b/pkg/discovery/discovery_test.go
@@ -1,0 +1,13 @@
+package discovery
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestErrNotUnixSocket(t *testing.T) {
+	err := ErrNotUnixSocket("no socket!")
+	require.Error(t, err)
+	require.True(t, IsErrNotUnixSocket(err))
+}

--- a/pkg/plugin/resource/plugin.go
+++ b/pkg/plugin/resource/plugin.go
@@ -7,7 +7,6 @@ import (
 	"strings"
 
 	log "github.com/Sirupsen/logrus"
-	"github.com/docker/infrakit/pkg/discovery/local"
 	plugin_base "github.com/docker/infrakit/pkg/plugin"
 	"github.com/docker/infrakit/pkg/spi/instance"
 	"github.com/docker/infrakit/pkg/spi/resource"
@@ -76,7 +75,7 @@ func (p *plugin) Commit(config resource.Spec, pretend bool) (string, error) {
 			continue
 		}
 
-		template, err := template.NewTemplate("str://"+resourceConfigs[name].properties, template.Options{SocketDir: local.Dir()})
+		template, err := template.NewTemplate("str://"+resourceConfigs[name].properties, template.Options{})
 		if err != nil {
 			return "", fmt.Errorf("Failed to parse template '%s' for resource '%s': %s", resourceConfigs[name].properties, name, err)
 		}
@@ -272,7 +271,7 @@ func getProvisioningOrder(resourceConfigs map[string]resourceConfig) ([]string, 
 	}
 
 	for name, resourceConfig := range resourceConfigs {
-		template, err := template.NewTemplate("str://"+resourceConfig.properties, template.Options{SocketDir: local.Dir()})
+		template, err := template.NewTemplate("str://"+resourceConfig.properties, template.Options{})
 		if err != nil {
 			return nil, fmt.Errorf("Failed to parse template for resource '%s': %s", name, err)
 		}

--- a/pkg/plugin/resource/plugin_test.go
+++ b/pkg/plugin/resource/plugin_test.go
@@ -7,7 +7,6 @@ import (
 	"reflect"
 	"testing"
 
-	"github.com/docker/infrakit/pkg/discovery/local"
 	plugin_base "github.com/docker/infrakit/pkg/plugin"
 	"github.com/docker/infrakit/pkg/plugin/group/util"
 	"github.com/docker/infrakit/pkg/spi/instance"
@@ -377,7 +376,7 @@ func TestGetProvisioningOrder(t *testing.T) {
 
 func TestGetResourceDependencies(t *testing.T) {
 	newTemplate := func(s string) *template.Template {
-		t, err := template.NewTemplate("str://"+s, template.Options{SocketDir: local.Dir()})
+		t, err := template.NewTemplate("str://"+s, template.Options{})
 		if err != nil {
 			panic(err)
 		}

--- a/pkg/template/fetch.go
+++ b/pkg/template/fetch.go
@@ -7,11 +7,10 @@ import (
 	"net/http"
 	"net/url"
 	"os"
-	"path/filepath"
 )
 
 // Fetch fetchs content from the given URL string.  Supported schemes are http:// https:// file:// unix://
-func Fetch(s string, opt Options, customize func(*http.Request)) ([]byte, error) {
+func Fetch(s string, opt Options) ([]byte, error) {
 	u, err := url.Parse(s)
 	if err != nil {
 		return nil, err
@@ -21,17 +20,17 @@ func Fetch(s string, opt Options, customize func(*http.Request)) ([]byte, error)
 		return ioutil.ReadFile(u.Path)
 
 	case "http", "https":
-		return doHTTPGet(u, customize, &http.Client{})
+		return doHTTPGet(u, opt.CustomizeFetch, &http.Client{})
 
 	case "unix":
 		// unix: will look for a socket that matches the host name at a
 		// directory path set by environment variable.
-		c, err := socketClient(u, opt.SocketDir)
+		c, err := socketClient(u)
 		if err != nil {
 			return nil, err
 		}
 		u.Scheme = "http"
-		return doHTTPGet(u, customize, c)
+		return doHTTPGet(u, opt.CustomizeFetch, c)
 	}
 
 	return nil, fmt.Errorf("unsupported url:%s", s)
@@ -55,8 +54,8 @@ func doHTTPGet(u *url.URL, customize func(*http.Request), client *http.Client) (
 	return ioutil.ReadAll(resp.Body)
 }
 
-func socketClient(u *url.URL, socketDir string) (*http.Client, error) {
-	socketPath := filepath.Join(socketDir, u.Host)
+func socketClient(u *url.URL) (*http.Client, error) {
+	socketPath := u.Path
 	if f, err := os.Stat(socketPath); err != nil {
 		return nil, err
 	} else if f.Mode()&os.ModeSocket == 0 {

--- a/pkg/template/funcs.go
+++ b/pkg/template/funcs.go
@@ -181,7 +181,8 @@ func (t *Template) DefaultFuncs() []Function {
 				"Source / evaluate the template at the input location (as URL).",
 				"This will make all of the global variables declared there visible in this template's context.",
 				"Similar to 'source' in bash, sourcing another template means applying it in the same context ",
-				"as the calling template.  The context (e.g. variables) of the calling template as a result can be mutated.",
+				"as the calling template.  The context (e.g. variables) of the calling template as a result can",
+				"be mutated.",
 			},
 			Func: func(p string, opt ...interface{}) (string, error) {
 				headers, context := headersAndContext(opt...)
@@ -193,7 +194,15 @@ func (t *Template) DefaultFuncs() []Function {
 					}
 					loc = buff
 				}
-				sourced, err := NewTemplateCustom(loc, t.options, func(req *http.Request) { setHeaders(req, headers) })
+
+				prev := t.options.CustomizeFetch
+				t.options.CustomizeFetch = func(req *http.Request) {
+					setHeaders(req, headers)
+					if prev != nil {
+						prev(req)
+					}
+				}
+				sourced, err := NewTemplate(loc, t.options)
 				if err != nil {
 					return "", err
 				}
@@ -228,7 +237,16 @@ func (t *Template) DefaultFuncs() []Function {
 					}
 					loc = buff
 				}
-				included, err := NewTemplateCustom(loc, t.options, func(req *http.Request) { setHeaders(req, headers) })
+
+				prev := t.options.CustomizeFetch
+				t.options.CustomizeFetch = func(req *http.Request) {
+					setHeaders(req, headers)
+					if prev != nil {
+						prev(req)
+					}
+				}
+
+				included, err := NewTemplate(loc, t.options)
 				if err != nil {
 					return "", err
 				}


### PR DESCRIPTION
This PR makes better use of options for customizing http requests for fetch; Also removed are confusing uses of discovery's socket directory as socketDir used by templates.

Signed-off-by: David Chung <david.chung@docker.com>