### PR TITLE
restrict hostname checks to softlayer only

### DIFF
--- a/examples/instance/terraform/plugin.go
+++ b/examples/instance/terraform/plugin.go
@@ -332,6 +332,34 @@ func ensureUniqueFile(dir string) string {
 	return n
 }
 
+// Special processing of hostname on some platforms. Where supported, you can
+// add a special @hostname_prefix that will allow the setting of hostname in given format
+// TODO - expand this to formatting string
+func (p *plugin) optionalProcessHostname(properties *SpecPropertiesFormat, name string) {
+	switch properties.Type {
+	case "softlayer_virtual_guest": // # list the platforms here
+	default:
+		return
+	}
+
+	// Use the given hostname value as a prefix if it is a non-empty string
+	if hostnamePrefix, is := properties.Value["@hostname_prefix"].(string); is {
+		hostnamePrefix = strings.Trim(hostnamePrefix, " ")
+		// Use the default behavior if hostnamePrefix was either not a string, or an empty string
+		if hostnamePrefix == "" {
+			properties.Value["hostname"] = name
+		} else {
+			// Remove "instance-" from "instance-XXXX", then append that string to the hostnamePrefix to create the new hostname
+			properties.Value["hostname"] = fmt.Sprintf("%s-%s", hostnamePrefix, strings.Replace(name, "instance-", "", -1))
+		}
+	} else {
+		properties.Value["hostname"] = name
+	}
+	// Delete hostnamePrefix so it will not be written in the *.tf.json file
+	delete(properties.Value, "@hostname_prefix")
+	log.Debugln("Adding hostname to properties: hostname=", properties.Value["hostname"])
+}
+
 // Provision creates a new instance based on the spec.
 func (p *plugin) Provision(spec instance.Spec) (*instance.ID, error) {
 	// Simply writes a file and call terraform apply
@@ -359,22 +387,7 @@ func (p *plugin) Provision(spec instance.Spec) (*instance.ID, error) {
 		}
 	}
 
-	// Use the given hostname value as a prefix if it is a non-empty string
-	if hostnamePrefix, is := properties.Value["@hostname_prefix"].(string); is {
-		hostnamePrefix = strings.Trim(hostnamePrefix, " ")
-		// Use the default behavior if hostnamePrefix was either not a string, or an empty string
-		if hostnamePrefix == "" {
-			properties.Value["hostname"] = name
-		} else {
-			// Remove "instance-" from "instance-XXXX", then append that string to the hostnamePrefix to create the new hostname
-			properties.Value["hostname"] = fmt.Sprintf("%s-%s", hostnamePrefix, strings.Replace(name, "instance-", "", -1))
-		}
-	} else {
-		properties.Value["hostname"] = name
-	}
-	// Delete hostnamePrefix so it will not be written in the *.tf.json file
-	delete(properties.Value, "@hostname_prefix")
-	log.Debugln("Adding hostname to properties: hostname=", properties.Value["hostname"])
+	p.optionalProcessHostname(&properties, name)
 
 	switch properties.Type {
 	case "aws_instance", "azurerm_virtual_machine", "digitalocean_droplet", "google_compute_instance":

--- a/examples/instance/terraform/plugin_test.go
+++ b/examples/instance/terraform/plugin_test.go
@@ -178,18 +178,6 @@ func run(t *testing.T, resourceType, properties string) {
 	m := testingData.(map[string]interface{})
 	value, _ := m["value"].(map[string]interface{})
 
-	// If a hostname was specified, the expectation is that the hostname is appended with the timestamp from the ID
-	if value["@hostname_prefix"] != nil && strings.Trim(value["@hostname_prefix"].(string), " ") != "" {
-		newID := strings.Replace(string(*id), "instance-", "", -1)
-		expectedHostname := "softlayer-hostname-" + newID
-		require.Equal(t, expectedHostname, props["hostname"])
-	} else {
-		// If no hostname was specified, the hostname should equal the ID
-		require.Equal(t, string(*id), props["hostname"])
-	}
-	// Verify the hostname prefix key/value is no longer in the props
-	require.Nil(t, props["@hostname_prefix"])
-
 	switch resourceType {
 	case "softlayer_virtual_guest":
 		require.Equal(t, conv([]interface{}{
@@ -199,6 +187,19 @@ func run(t *testing.T, resourceType, properties string) {
 			"Name:" + string(*id),
 		}), conv(props["tags"].([]interface{})))
 		require.Equal(t, instanceSpec.Init, props["user_metadata"])
+
+		// If a hostname was specified, the expectation is that the hostname is appended with the timestamp from the ID
+		if value["@hostname_prefix"] != nil && strings.Trim(value["@hostname_prefix"].(string), " ") != "" {
+			newID := strings.Replace(string(*id), "instance-", "", -1)
+			expectedHostname := "softlayer-hostname-" + newID
+			require.Equal(t, expectedHostname, props["hostname"])
+		} else {
+			// If no hostname was specified, the hostname should equal the ID
+			require.Equal(t, string(*id), props["hostname"])
+		}
+		// Verify the hostname prefix key/value is no longer in the props
+		require.Nil(t, props["@hostname_prefix"])
+
 	case "aws_instance":
 		require.Equal(t, map[string]interface{}{
 			"InstancePlugin": "terraform",


### PR DESCRIPTION
Apparently adding hostname prefix field in the properties for softlayer broke AWS because of extra `hostname` that is not allowed.  This PR moves the logic to a separate function and modified the tests to hopefully better isolate these special cases.

Signed-off-by: David Chung <david.chung@docker.com>

@JacobFrericks @ndegory 