### PR TITLE
Terraform plugin - base64 encoded userdata for AWS and DigitalOcean

### DIFF
--- a/examples/instance/terraform/plugin.go
+++ b/examples/instance/terraform/plugin.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"bufio"
+	"encoding/base64"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -25,9 +26,9 @@ import (
 // This example uses terraform as the instance plugin.
 // It is very similar to the file instance plugin.  When we
 // provision an instance, we write a *.tf.json file in the directory
-// and call terra apply.  For describing instances, we parse the
-// result of terra show.  Destroying an instance is simply removing a
-// tf.json file and call terra apply again.
+// and call terraform apply.  For describing instances, we parse the
+// result of terraform show.  Destroying an instance is simply removing a
+// tf.json file and call terraform apply again.
 
 type plugin struct {
 	Dir       string
@@ -324,7 +325,7 @@ func (p *plugin) ensureUniqueFile() string {
 
 func ensureUniqueFile(dir string) string {
 	n := fmt.Sprintf("instance-%d", time.Now().Unix())
-	// if we can open then we have to try again...  the file cannot exist currently
+	// if we can open then we have to try again... the file cannot exist currently
 	if f, err := os.Open(filepath.Join(dir, n) + ".tf.json"); err == nil {
 		f.Close()
 		return ensureUniqueFile(dir)
@@ -434,7 +435,7 @@ func (p *plugin) Provision(spec instance.Spec) (*instance.ID, error) {
 	// merge the inits
 	switch properties.Type {
 	case "aws_instance", "digitalocean_droplet":
-		addUserData(properties.Value, "user_data", spec.Init)
+		addUserData(properties.Value, "user_data", base64.StdEncoding.EncodeToString([]byte(spec.Init)))
 	case "softlayer_virtual_guest":
 		addUserData(properties.Value, "user_metadata", spec.Init)
 	case "azurerm_virtual_machine":

--- a/examples/instance/terraform/plugin_test.go
+++ b/examples/instance/terraform/plugin_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"encoding/base64"
 	"encoding/json"
 	"io/ioutil"
 	"os"
@@ -207,7 +208,7 @@ func run(t *testing.T, resourceType, properties string) {
 			"label2":         "value2",
 			"Name":           string(*id),
 		}, props["tags"])
-		require.Equal(t, instanceSpec.Init, props["user_data"])
+		require.Equal(t, base64.StdEncoding.EncodeToString([]byte(instanceSpec.Init)), props["user_data"])
 	}
 
 	// label resources


### PR DESCRIPTION
## context
Terraform accepts the userdata for AWS and DigitalOcean raw or base64 encoded (since https://github.com/hashicorp/terraform/pull/6140). The latter is safer because it won't be interpreted by Terraform and won't lead to JSON parsing issues.

If not already encoded, a user data script can fail the `terraform apply` phase on the generated tf.json file. In particular, the syntax ${var:-default} in the user_data field (from an `Init` field in the InfraKit configuration) leads to an error when parsing the colon character.

## content of the PR
- user data is base64 encoded by default for AWS and DigitalOcean with the Terraform instance plugin
