### PR TITLE
Updating tags to only contain valid characters

### DIFF
--- a/examples/flavor/swarm/flavor.go
+++ b/examples/flavor/swarm/flavor.go
@@ -265,7 +265,7 @@ func (s *baseFlavor) prepare(role string, flavorProperties *types.Any, instanceS
 			swarmID = swarmStatus.ID
 		}
 
-		link = types.NewLink().WithContext("swarm/" + swarmID + "/" + role)
+		link = types.NewLink().WithContext("swarm::" + swarmID + "::" + role)
 		context := &templateContext{
 			flavorSpec:   spec,
 			instanceSpec: instanceSpec,

--- a/examples/instance/terraform/plugin.go
+++ b/examples/instance/terraform/plugin.go
@@ -625,7 +625,9 @@ func terraformTags(v interface{}, key string) map[string]string {
 			value := fmt.Sprintf("%v", v)
 			if strings.Contains(value, ":") {
 				log.Debugln("terraformTags system tags detected v=", v)
-				vv := strings.Split(value, ":")
+				// This assumes that the first colon is separating the key and the value of the tag.
+				// This is done so that colons are valid characters in the value.
+				vv := strings.SplitN(value, ":", 2)
 				if len(vv) == 2 {
 					tags[vv[0]] = vv[1]
 				} else {

--- a/examples/instance/terraform/plugin.go
+++ b/examples/instance/terraform/plugin.go
@@ -103,7 +103,7 @@ JSON looks like below, where the value of `value` is the instance body of the TF
             "vpc_security_group_ids" : ["${aws_security_group.default.id}"],
             "subnet_id": "${aws_subnet.default.id}",
             "tags" :  {
-                "Name" : "web4",
+                "name" : "web4",
                 "InstancePlugin" : "terraform"
             },
             "connection" : {
@@ -383,8 +383,17 @@ func (p *plugin) Provision(spec instance.Spec) (*instance.ID, error) {
 	// set the tags.
 	// add a name
 	if spec.Tags != nil {
-		if _, has := spec.Tags["Name"]; !has {
-			spec.Tags["Name"] = string(id)
+		switch properties.Type {
+		case "softlayer_virtual_guest":
+			// Set the "name" tag to be lowercase to meet platform requirements
+			if _, has := spec.Tags["name"]; !has {
+				spec.Tags["name"] = string(id)
+			}
+		default:
+			// Set the first character of the "Name" tag to be uppercase to meet platform requirements
+			if _, has := spec.Tags["Name"]; !has {
+				spec.Tags["Name"] = string(id)
+			}
 		}
 	}
 

--- a/examples/instance/terraform/plugin_test.go
+++ b/examples/instance/terraform/plugin_test.go
@@ -185,7 +185,7 @@ func run(t *testing.T, resourceType, properties string) {
 			"terraform_demo_swarm_mgr_sl",
 			"label1:value1",
 			"label2:value2",
-			"Name:" + string(*id),
+			"name:" + string(*id),
 		}), conv(props["tags"].([]interface{})))
 		require.Equal(t, instanceSpec.Init, props["user_metadata"])
 
@@ -233,7 +233,7 @@ func run(t *testing.T, resourceType, properties string) {
 			"label1:changed1",
 			"label2:value2",
 			"label3:value3",
-			"Name:" + string(*id),
+			"name:" + string(*id),
 		}), conv(props["tags"].([]interface{})))
 	case "aws_instance":
 		require.Equal(t, map[string]interface{}{
@@ -258,7 +258,7 @@ func run(t *testing.T, resourceType, properties string) {
 					"label1":                      "changed1",
 					"label2":                      "value2",
 					"label3":                      "value3",
-					"Name":                        string(*id),
+					"name":                        string(*id),
 				},
 			},
 		}, list)

--- a/pkg/plugin/group/types/types.go
+++ b/pkg/plugin/group/types/types.go
@@ -2,9 +2,10 @@ package types
 
 import (
 	"crypto/sha1"
-	"encoding/base64"
+	"encoding/base32"
 	"encoding/json"
 	"fmt"
+	"strings"
 
 	"github.com/docker/infrakit/pkg/plugin"
 	"github.com/docker/infrakit/pkg/spi/group"
@@ -109,5 +110,10 @@ func (c Spec) InstanceHash() string {
 	hasher := sha1.New()
 	hasher.Write(stableFormat(c.Instance))
 	hasher.Write(stableFormat(c.Flavor))
-	return base64.URLEncoding.EncodeToString(hasher.Sum(nil))
+	encoded := base32.StdEncoding.EncodeToString(hasher.Sum(nil))
+	// Only valid characters are [a-z][0-9] for support on specific platforms
+	encoded = strings.ToLower(encoded)
+	// Remove extra padding
+	encoded = strings.TrimRight(encoded, "=")
+	return encoded
 }

--- a/pkg/plugin/group/types/types_test.go
+++ b/pkg/plugin/group/types/types_test.go
@@ -2,8 +2,11 @@ package types
 
 import (
 	"encoding/json"
-	"github.com/stretchr/testify/require"
+	"fmt"
+	"regexp"
 	"testing"
+
+	"github.com/stretchr/testify/require"
 )
 
 const (
@@ -77,4 +80,13 @@ func TestInstanceHash(t *testing.T) {
 	require.Equal(t, hash(specA), hash(specA))
 	require.Equal(t, hash(specA), hash(reordered))
 	require.NotEqual(t, hash(specA), hash(different))
+	VerifyValidCharsInHash(t, hash(specA))
+	VerifyValidCharsInHash(t, hash(reordered))
+	VerifyValidCharsInHash(t, hash(different))
+}
+
+func VerifyValidCharsInHash(t *testing.T, hash string) {
+	regex := "[a-z0-9]"
+	validString := regexp.MustCompile(regex)
+	require.True(t, validString.MatchString(hash), fmt.Sprintf("Invalid characters found in string: %v. Valid characters are %v", hash, regex))
 }

--- a/pkg/types/link.go
+++ b/pkg/types/link.go
@@ -7,7 +7,7 @@ import (
 )
 
 const (
-	letters = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789"
+	letters = "abcdefghijklmnopqrstuvwxyz0123456789"
 )
 
 func init() {

--- a/pkg/types/link_test.go
+++ b/pkg/types/link_test.go
@@ -1,0 +1,26 @@
+package types
+
+import (
+	"fmt"
+	"regexp"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestRandomAlphaNumericString(t *testing.T) {
+	VerifyRandomAlphaNumericString(t, 15)
+	VerifyRandomAlphaNumericString(t, 150)
+}
+
+// VerifyRandomAlphaNumericString Verifies the length and characters of the string created from randomAlphaNumericString with the given length
+func VerifyRandomAlphaNumericString(t *testing.T, length int) {
+	actual := randomAlphaNumericString(length)
+	// Verify the length is as expected
+	require.Equal(t, length, len(actual), fmt.Sprintf("Unexpected length of string %v: Expected %v but was %v\n", actual, length, len(actual)))
+
+	// Verify the characters are as expected
+	regex := "[a-z0-9]"
+	validString := regexp.MustCompile(regex)
+	require.True(t, validString.MatchString(actual), fmt.Sprintf("Invalid characters found in string: %v. Valid characters are %v", actual, regex))
+}


### PR DESCRIPTION
This PR changes the tag chars to be `[a-z][0-9], -, _` so that all tag values adhere to the supported tag chars defined in issue #449