### PR TITLE
API Change - Instance plugin to optionally output instance details

### DIFF
--- a/cmd/cli/base/output.go
+++ b/cmd/cli/base/output.go
@@ -1,0 +1,41 @@
+package base
+
+import (
+	"fmt"
+	"io"
+
+	"github.com/docker/infrakit/pkg/types"
+	"github.com/ghodss/yaml"
+	"github.com/spf13/pflag"
+)
+
+// RawOutputFunc is a function that writes some data to the output writer
+type RawOutputFunc func(w io.Writer, v interface{}) (rendered bool, err error)
+
+// RawOutput returns the flagset and the func for printing output
+func RawOutput() (*pflag.FlagSet, RawOutputFunc) {
+
+	fs := pflag.NewFlagSet("output", pflag.ExitOnError)
+
+	raw := fs.BoolP("raw", "r", false, "True to dump to output instead of executing")
+	yamlDoc := fs.BoolP("yaml", "y", false, "True if input is in yaml format; json is the default")
+
+	return fs, func(w io.Writer, v interface{}) (rendered bool, err error) {
+		if !*raw {
+			return false, nil
+		}
+
+		any, err := types.AnyValue(v)
+		if err != nil {
+			return false, err
+		}
+
+		buff := any.Bytes()
+		if *yamlDoc {
+			buff, err = yaml.JSONToYAML(buff)
+		}
+
+		fmt.Fprintln(w, string(buff))
+		return true, nil
+	}
+}

--- a/cmd/cli/base/template.go
+++ b/cmd/cli/base/template.go
@@ -159,21 +159,6 @@ func TemplateProcessor(plugins func() discovery.Plugins) (*pflag.FlagSet, ToJSON
 				return
 			}
 
-			// if *yamlDoc {
-
-			// 	// Convert this to json if it's not in JSON -- the default is for the template to be in YAML
-			// 	converted, e := yaml.YAMLToJSON([]byte(view))
-			// 	log.Debug("converting yaml to json", "before", view, "after", string(converted))
-
-			// 	if e != nil {
-			// 		err = e
-			// 		return
-			// 	}
-
-			// 	view = string(converted)
-			// 	log.Debug("view", "rendered", view)
-			// }
-
 			log.Debug("rendered", "view", view)
 			if *dump {
 				fmt.Println("Final:")

--- a/cmd/cli/manager/manager.go
+++ b/cmd/cli/manager/manager.go
@@ -76,7 +76,7 @@ func Command(plugins func() discovery.Plugins) *cobra.Command {
 			return nil
 		},
 	}
-	pretend := cmd.PersistentFlags().Bool("pretend", true, "Don't actually make changes; explain where appropriate")
+	pretend := cmd.PersistentFlags().Bool("pretend", false, "Don't actually make changes; explain where appropriate")
 
 	///////////////////////////////////////////////////////////////////////////////////
 	// commit

--- a/docs/plugins/instance.md
+++ b/docs/plugins/instance.md
@@ -1,6 +1,6 @@
 # Instance plugin API
 
-<!-- SOURCE-CHECKSUM pkg/spi/instance/* af33b7b157a24a90e4ecef4b99c997a4039edf78b62e84554a47a6e3eca2e1e15d9e523f7d16455e -->
+<!-- SOURCE-CHECKSUM pkg/spi/instance/* af33b7b157a24a90e4ecef4b99c997a4039edf7832ae259bfe527c06caec5455f3c083481586eda2 -->
 
 ## API
 

--- a/docs/plugins/instance.md
+++ b/docs/plugins/instance.md
@@ -1,6 +1,6 @@
 # Instance plugin API
 
-<!-- SOURCE-CHECKSUM pkg/spi/instance/* befb47292c2f062637d65e9777d88c322856baf650feb6b527cd3a4242f86d3482b656246051d2ca -->
+<!-- SOURCE-CHECKSUM pkg/spi/instance/* af33b7b157a24a90e4ecef4b99c997a4039edf78b62e84554a47a6e3eca2e1e15d9e523f7d16455e -->
 
 ## API
 
@@ -115,13 +115,14 @@ Fetches details about Instances.
 #### Request
 ```json
 {
-  "Tags": {"tag_key": "tag_value"}
+  "Tags": {"tag_key": "tag_value"},
+  "Properties" : true
 }
 ```
 
 Parameters:
 - `Tags`: Instance tags to match.  If multiple tags are specified, only Instances matching all tags are returned.
-
+- `Properties`: Boolean to indicate whether the client requests additional details via the `Description.Properties` field.
 #### Response
 ```json
 {
@@ -129,7 +130,8 @@ Parameters:
     {
       "ID": "instance_id",
       "LogicalID": "logical_id",
-      "Tags": {"tag_key": "tag_value"}
+      "Tags": {"tag_key": "tag_value"},
+      "Properties" : { "some_status" : "ok", "some_state" : 10 }
     }
   ]
 }

--- a/examples/instance/file/plugin.go
+++ b/examples/instance/file/plugin.go
@@ -142,7 +142,7 @@ func (p *plugin) Destroy(instance instance.ID) error {
 
 // DescribeInstances returns descriptions of all instances matching all of the provided tags.
 // TODO - need to define the fitlering of tags => AND or OR of matches?
-func (p *plugin) DescribeInstances(tags map[string]string) ([]instance.Description, error) {
+func (p *plugin) DescribeInstances(tags map[string]string, properties bool) ([]instance.Description, error) {
 	log.Debugln("describe-instances", tags)
 	entries, err := afero.ReadDir(p.fs, p.Dir)
 	if err != nil {
@@ -166,6 +166,11 @@ scan:
 			continue scan
 		}
 
+		if properties {
+			if blob, err := types.AnyValue(inst.Spec); err == nil {
+				inst.Properties = blob
+			}
+		}
 		if len(tags) == 0 {
 			result = append(result, inst.Description)
 		} else {

--- a/examples/instance/file/plugin_test.go
+++ b/examples/instance/file/plugin_test.go
@@ -87,7 +87,7 @@ func run(t *testing.T, properties string) {
 		"label3": "value3",
 	}, parsed.Description.Tags)
 
-	list, err := fileinst.DescribeInstances(map[string]string{"label1": "changed1"})
+	list, err := fileinst.DescribeInstances(map[string]string{"label1": "changed1"}, false)
 	require.NoError(t, err)
 	require.Equal(t, []instance.Description{
 		{
@@ -99,7 +99,7 @@ func run(t *testing.T, properties string) {
 	err = fileinst.Destroy(*id)
 	require.NoError(t, err)
 
-	list, err = fileinst.DescribeInstances(map[string]string{"label1": "changed1"})
+	list, err = fileinst.DescribeInstances(map[string]string{"label1": "changed1"}, false)
 	require.NoError(t, err)
 	require.Equal(t, []instance.Description{}, list)
 

--- a/examples/instance/maas/instance.go
+++ b/examples/instance/maas/instance.go
@@ -294,7 +294,7 @@ func (m maasPlugin) Destroy(id instance.ID) error {
 }
 
 // DescribeInstances returns descriptions of all instances matching all of the provided tags.
-func (m maasPlugin) DescribeInstances(tags map[string]string) ([]instance.Description, error) {
+func (m maasPlugin) DescribeInstances(tags map[string]string, properties bool) ([]instance.Description, error) {
 	var ret []instance.Description
 	nodeListing := m.MaasObj.GetSubObject("nodes")
 	listNodeObjects, err := nodeListing.CallGet("list", url.Values{})

--- a/examples/instance/maas/instance_test.go
+++ b/examples/instance/maas/instance_test.go
@@ -108,7 +108,7 @@ func TestProvision_and_Destroy(t *testing.T) {
 	id, err := maasPlugin.Provision(instanceSpec)
 	require.NoError(t, err)
 
-	list, err := maasPlugin.DescribeInstances(map[string]string{"label1": "value1"})
+	list, err := maasPlugin.DescribeInstances(map[string]string{"label1": "value1"}, false)
 	require.NoError(t, err)
 	require.Equal(t, []instance.Description{
 		{
@@ -125,7 +125,7 @@ func TestProvision_and_Destroy(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	list, err = maasPlugin.DescribeInstances(map[string]string{"label1": "value1"})
+	list, err = maasPlugin.DescribeInstances(map[string]string{"label1": "value1"}, false)
 	require.NoError(t, err)
 	require.Equal(t, []instance.Description{
 		{
@@ -137,7 +137,7 @@ func TestProvision_and_Destroy(t *testing.T) {
 		},
 	}, list)
 
-	list, err = maasPlugin.DescribeInstances(map[string]string{"label3": "changed"})
+	list, err = maasPlugin.DescribeInstances(map[string]string{"label3": "changed"}, false)
 	require.NoError(t, err)
 	require.Equal(t, []instance.Description{
 		{

--- a/examples/instance/terraform/plugin.go
+++ b/examples/instance/terraform/plugin.go
@@ -556,7 +556,7 @@ func (p *plugin) Destroy(instance instance.ID) error {
 }
 
 // DescribeInstances returns descriptions of all instances matching all of the provided tags.
-func (p *plugin) DescribeInstances(tags map[string]string) ([]instance.Description, error) {
+func (p *plugin) DescribeInstances(tags map[string]string, properties bool) ([]instance.Description, error) {
 	log.Debugln("describe-instances", tags)
 
 	show, err := p.terraformShow()

--- a/examples/instance/terraform/plugin_test.go
+++ b/examples/instance/terraform/plugin_test.go
@@ -244,7 +244,7 @@ func run(t *testing.T, resourceType, properties string) {
 		}, props["tags"])
 	}
 
-	list, err := terraform.DescribeInstances(map[string]string{"label1": "changed1"})
+	list, err := terraform.DescribeInstances(map[string]string{"label1": "changed1"}, false)
 	require.NoError(t, err)
 
 	switch resourceType {
@@ -279,7 +279,7 @@ func run(t *testing.T, resourceType, properties string) {
 	err = terraform.Destroy(*id)
 	require.NoError(t, err)
 
-	list, err = terraform.DescribeInstances(map[string]string{"label1": "changed1"})
+	list, err = terraform.DescribeInstances(map[string]string{"label1": "changed1"}, false)
 	require.NoError(t, err)
 	require.Equal(t, []instance.Description{}, list)
 }

--- a/examples/instance/vagrant/instance.go
+++ b/examples/instance/vagrant/instance.go
@@ -214,7 +214,7 @@ func (v vagrantPlugin) Destroy(id instance.ID) error {
 }
 
 // DescribeInstances returns descriptions of all instances matching all of the provided tags.
-func (v vagrantPlugin) DescribeInstances(tags map[string]string) ([]instance.Description, error) {
+func (v vagrantPlugin) DescribeInstances(tags map[string]string, properties bool) ([]instance.Description, error) {
 	files, err := ioutil.ReadDir(v.VagrantfilesDir)
 	if err != nil {
 		return nil, err

--- a/pkg/mock/spi/instance/instance.go
+++ b/pkg/mock/spi/instance/instance.go
@@ -30,15 +30,15 @@ func (_m *MockPlugin) EXPECT() *_MockPluginRecorder {
 	return _m.recorder
 }
 
-func (_m *MockPlugin) DescribeInstances(_param0 map[string]string) ([]instance.Description, error) {
-	ret := _m.ctrl.Call(_m, "DescribeInstances", _param0)
+func (_m *MockPlugin) DescribeInstances(_param0 map[string]string, _param1 bool) ([]instance.Description, error) {
+	ret := _m.ctrl.Call(_m, "DescribeInstances", _param0, _param1)
 	ret0, _ := ret[0].([]instance.Description)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-func (_mr *_MockPluginRecorder) DescribeInstances(arg0 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "DescribeInstances", arg0)
+func (_mr *_MockPluginRecorder) DescribeInstances(arg0, arg1 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "DescribeInstances", arg0, arg1)
 }
 
 func (_m *MockPlugin) Destroy(_param0 instance.ID) error {

--- a/pkg/plugin/group/integration_test.go
+++ b/pkg/plugin/group/integration_test.go
@@ -148,7 +148,7 @@ func TestNoopUpdate(t *testing.T) {
 	_, err = grp.CommitGroup(minions, false)
 	require.NoError(t, err)
 
-	instances, err := plugin.DescribeInstances(memberTags(minions.ID))
+	instances, err := plugin.DescribeInstances(memberTags(minions.ID), false)
 	require.NoError(t, err)
 	require.Equal(t, 3, len(instances))
 	for _, i := range instances {
@@ -206,7 +206,7 @@ func TestRollingUpdate(t *testing.T) {
 
 	awaitGroupConvergence(t, grp)
 
-	instances, err := plugin.DescribeInstances(memberTags(updated.ID))
+	instances, err := plugin.DescribeInstances(memberTags(updated.ID), false)
 	require.NoError(t, err)
 	require.Equal(t, 3, len(instances))
 	for _, i := range instances {
@@ -241,7 +241,7 @@ func TestRollAndAdjustScale(t *testing.T) {
 
 	awaitGroupConvergence(t, grp)
 
-	instances, err := plugin.DescribeInstances(memberTags(updated.ID))
+	instances, err := plugin.DescribeInstances(memberTags(updated.ID), false)
 	require.NoError(t, err)
 	// TODO(wfarner): The updater currently exits as soon as the scaler is adjusted, before action has been
 	// taken.  This means the number of instances cannot be precisely checked here as the scaler has not necessarily
@@ -274,7 +274,7 @@ func TestScaleIncrease(t *testing.T) {
 	_, err = grp.CommitGroup(updated, false)
 	require.NoError(t, err)
 
-	instances, err := plugin.DescribeInstances(memberTags(updated.ID))
+	instances, err := plugin.DescribeInstances(memberTags(updated.ID), false)
 	require.NoError(t, err)
 	// TODO(wfarner): The updater currently exits as soon as the scaler is adjusted, before action has been
 	// taken.  This means the number of instances cannot be precisely checked here as the scaler has not necessarily
@@ -307,7 +307,7 @@ func TestScaleDecrease(t *testing.T) {
 	_, err = grp.CommitGroup(updated, false)
 	require.NoError(t, err)
 
-	instances, err := plugin.DescribeInstances(memberTags(updated.ID))
+	instances, err := plugin.DescribeInstances(memberTags(updated.ID), false)
 	require.NoError(t, err)
 	// TODO(wfarner): The updater currently exits as soon as the scaler is adjusted, before action has been
 	// taken.  This means the number of instances cannot be precisely checked here as the scaler has not necessarily
@@ -347,7 +347,7 @@ func TestDestroyGroup(t *testing.T) {
 
 	require.NoError(t, grp.DestroyGroup(minions.ID))
 
-	instances, err := plugin.DescribeInstances(memberTags(minions.ID))
+	instances, err := plugin.DescribeInstances(memberTags(minions.ID), false)
 	require.NoError(t, err)
 	require.Equal(t, 0, len(instances))
 }
@@ -376,7 +376,7 @@ func TestSuperviseQuorum(t *testing.T) {
 
 	awaitGroupConvergence(t, grp)
 
-	instances, err := plugin.DescribeInstances(memberTags(updated.ID))
+	instances, err := plugin.DescribeInstances(memberTags(updated.ID), false)
 	require.NoError(t, err)
 	require.Equal(t, 3, len(instances))
 	for _, i := range instances {

--- a/pkg/plugin/group/scaled.go
+++ b/pkg/plugin/group/scaled.go
@@ -131,13 +131,13 @@ func (s *scaledGroup) Destroy(inst instance.Description) {
 func (s *scaledGroup) List() ([]instance.Description, error) {
 	settings := s.latestSettings()
 
-	return settings.instancePlugin.DescribeInstances(s.memberTags)
+	return settings.instancePlugin.DescribeInstances(s.memberTags, false)
 }
 
 func (s *scaledGroup) Label() error {
 	settings := s.latestSettings()
 
-	instances, err := settings.instancePlugin.DescribeInstances(s.memberTags)
+	instances, err := settings.instancePlugin.DescribeInstances(s.memberTags, false)
 	if err != nil {
 		return err
 	}

--- a/pkg/plugin/group/scaled_test.go
+++ b/pkg/plugin/group/scaled_test.go
@@ -28,7 +28,7 @@ func TestLabelEmpty(t *testing.T) {
 	}
 
 	gomock.InOrder(
-		instancePlugin.EXPECT().DescribeInstances(tags).Return([]instance.Description{}, nil),
+		instancePlugin.EXPECT().DescribeInstances(tags, false).Return([]instance.Description{}, nil),
 	)
 
 	err := scaled.Label()
@@ -53,7 +53,7 @@ func TestLabelError(t *testing.T) {
 	}
 
 	gomock.InOrder(
-		instancePlugin.EXPECT().DescribeInstances(tags).Return(nil, errors.New("BUG")),
+		instancePlugin.EXPECT().DescribeInstances(tags, false).Return(nil, errors.New("BUG")),
 	)
 
 	err := scaled.Label()
@@ -78,7 +78,7 @@ func TestLabelAllLabelled(t *testing.T) {
 	}
 
 	gomock.InOrder(
-		instancePlugin.EXPECT().DescribeInstances(tags).Return([]instance.Description{
+		instancePlugin.EXPECT().DescribeInstances(tags, false).Return([]instance.Description{
 			{
 				ID: instance.ID("labbeled1"),
 				Tags: map[string]string{
@@ -120,7 +120,7 @@ func TestLabelOneUnlabelled(t *testing.T) {
 	}
 
 	gomock.InOrder(
-		instancePlugin.EXPECT().DescribeInstances(tags).Return([]instance.Description{
+		instancePlugin.EXPECT().DescribeInstances(tags, false).Return([]instance.Description{
 			{
 				ID: instance.ID("labbeled"),
 				Tags: map[string]string{
@@ -166,7 +166,7 @@ func TestUnableToLabel(t *testing.T) {
 	}
 
 	gomock.InOrder(
-		instancePlugin.EXPECT().DescribeInstances(tags).Return([]instance.Description{
+		instancePlugin.EXPECT().DescribeInstances(tags, false).Return([]instance.Description{
 			{
 				ID: instance.ID("labbeled"),
 				Tags: map[string]string{

--- a/pkg/plugin/group/testplugin.go
+++ b/pkg/plugin/group/testplugin.go
@@ -77,7 +77,7 @@ func (d *testplugin) Destroy(id instance.ID) error {
 	return nil
 }
 
-func (d *testplugin) DescribeInstances(tags map[string]string) ([]instance.Description, error) {
+func (d *testplugin) DescribeInstances(tags map[string]string, properties bool) ([]instance.Description, error) {
 	d.lock.Lock()
 	defer d.lock.Unlock()
 

--- a/pkg/plugin/resource/plugin.go
+++ b/pkg/plugin/resource/plugin.go
@@ -186,7 +186,7 @@ func describe(id resource.ID, resourceConfigs map[string]resourceConfig) (map[st
 		descriptions, err := resourceConfig.plugin.DescribeInstances(map[string]string{
 			resourcesTag:   string(id),
 			resourcesIDTag: name,
-		})
+		}, false)
 		if err != nil {
 			return nil, fmt.Errorf("Failed to describe resource '%s': %s", name, err)
 		}

--- a/pkg/plugin/resource/plugin_test.go
+++ b/pkg/plugin/resource/plugin_test.go
@@ -39,7 +39,7 @@ func newTestInstancePlugin() *testing_instance.Plugin {
 			delete(instances, id)
 			return nil
 		},
-		DoDescribeInstances: func(tags map[string]string) ([]instance.Description, error) {
+		DoDescribeInstances: func(tags map[string]string, properties bool) ([]instance.Description, error) {
 			descriptions := []instance.Description{}
 		Loop:
 			for id, inst := range instances {
@@ -91,11 +91,11 @@ func TestCommitAndDestroy(t *testing.T) {
 	_, err := p.Commit(spec, true)
 	require.NoError(t, err)
 
-	descriptions, err := instancePluginA.DescribeInstances(nil)
+	descriptions, err := instancePluginA.DescribeInstances(nil, false)
 	require.NoError(t, err)
 	require.Len(t, descriptions, 0)
 
-	descriptions, err = instancePluginB.DescribeInstances(nil)
+	descriptions, err = instancePluginB.DescribeInstances(nil, false)
 	require.NoError(t, err)
 	require.Len(t, descriptions, 0)
 
@@ -103,7 +103,7 @@ func TestCommitAndDestroy(t *testing.T) {
 	_, err = p.Commit(spec, false)
 	require.NoError(t, err)
 
-	descriptions, err = instancePluginA.DescribeInstances(nil)
+	descriptions, err = instancePluginA.DescribeInstances(nil, false)
 	require.NoError(t, err)
 	require.Len(t, descriptions, 1)
 
@@ -111,7 +111,7 @@ func TestCommitAndDestroy(t *testing.T) {
 	require.Nil(t, descriptions[0].LogicalID)
 	require.Equal(t, map[string]string{resourcesTag: configID, resourcesIDTag: "a"}, descriptions[0].Tags)
 
-	descriptions, err = instancePluginB.DescribeInstances(nil)
+	descriptions, err = instancePluginB.DescribeInstances(nil, false)
 	require.NoError(t, err)
 	require.Len(t, descriptions, 1)
 
@@ -123,11 +123,11 @@ func TestCommitAndDestroy(t *testing.T) {
 	_, err = p.Commit(spec, false)
 	require.NoError(t, err)
 
-	descriptions, err = instancePluginA.DescribeInstances(nil)
+	descriptions, err = instancePluginA.DescribeInstances(nil, false)
 	require.NoError(t, err)
 	require.Len(t, descriptions, 1)
 
-	descriptions, err = instancePluginB.DescribeInstances(nil)
+	descriptions, err = instancePluginB.DescribeInstances(nil, false)
 	require.NoError(t, err)
 	require.Len(t, descriptions, 1)
 
@@ -135,11 +135,11 @@ func TestCommitAndDestroy(t *testing.T) {
 	_, err = p.Destroy(spec, true)
 	require.NoError(t, err)
 
-	descriptions, err = instancePluginA.DescribeInstances(nil)
+	descriptions, err = instancePluginA.DescribeInstances(nil, false)
 	require.NoError(t, err)
 	require.Len(t, descriptions, 1)
 
-	descriptions, err = instancePluginB.DescribeInstances(nil)
+	descriptions, err = instancePluginB.DescribeInstances(nil, false)
 	require.NoError(t, err)
 	require.Len(t, descriptions, 1)
 
@@ -147,11 +147,11 @@ func TestCommitAndDestroy(t *testing.T) {
 	_, err = p.Destroy(spec, false)
 	require.NoError(t, err)
 
-	descriptions, err = instancePluginA.DescribeInstances(nil)
+	descriptions, err = instancePluginA.DescribeInstances(nil, false)
 	require.NoError(t, err)
 	require.Len(t, descriptions, 0)
 
-	descriptions, err = instancePluginB.DescribeInstances(nil)
+	descriptions, err = instancePluginB.DescribeInstances(nil, false)
 	require.NoError(t, err)
 	require.Len(t, descriptions, 0)
 
@@ -214,7 +214,7 @@ func TestDescribe(t *testing.T) {
 
 	// Error from instance.Plugin.DescribeInstances.
 	errorPlugin := &testing_instance.Plugin{
-		DoDescribeInstances: func(tags map[string]string) ([]instance.Description, error) {
+		DoDescribeInstances: func(tags map[string]string, properties bool) ([]instance.Description, error) {
 			return nil, errors.New("kaboom")
 		},
 	}

--- a/pkg/rpc/instance/client.go
+++ b/pkg/rpc/instance/client.go
@@ -62,9 +62,9 @@ func (c client) Destroy(instance instance.ID) error {
 }
 
 // DescribeInstances returns descriptions of all instances matching all of the provided tags.
-func (c client) DescribeInstances(tags map[string]string) ([]instance.Description, error) {
+func (c client) DescribeInstances(tags map[string]string, properties bool) ([]instance.Description, error) {
 	_, instanceType := c.name.GetLookupAndType()
-	req := DescribeInstancesRequest{Tags: tags, Type: instanceType}
+	req := DescribeInstancesRequest{Tags: tags, Type: instanceType, Properties: properties}
 	resp := DescribeInstancesResponse{}
 
 	err := c.client.Call("Instance.DescribeInstances", req, &resp)

--- a/pkg/rpc/instance/rpc_test.go
+++ b/pkg/rpc/instance/rpc_test.go
@@ -273,13 +273,13 @@ func TestInstancePluginDescribeInstancesNiInput(t *testing.T) {
 		{ID: instance.ID("boo")}, {ID: instance.ID("boop")},
 	}
 	server, err := rpc_server.StartPluginAtPath(socketPath, PluginServer(&testing_instance.Plugin{
-		DoDescribeInstances: func(req map[string]string) ([]instance.Description, error) {
+		DoDescribeInstances: func(req map[string]string, properties bool) ([]instance.Description, error) {
 			tagsActual <- req
 			return list, nil
 		},
 	}))
 
-	l, err := must(NewClient(name, socketPath)).DescribeInstances(tags)
+	l, err := must(NewClient(name, socketPath)).DescribeInstances(tags, false)
 	require.NoError(t, err)
 	require.Equal(t, list, l)
 
@@ -299,14 +299,14 @@ func TestInstancePluginDescribeInstances(t *testing.T) {
 		{ID: instance.ID("boo")}, {ID: instance.ID("boop")},
 	}
 	server, err := rpc_server.StartPluginAtPath(socketPath, PluginServer(&testing_instance.Plugin{
-		DoDescribeInstances: func(req map[string]string) ([]instance.Description, error) {
+		DoDescribeInstances: func(req map[string]string, properties bool) ([]instance.Description, error) {
 			tagsActual <- req
 			return list, nil
 		},
 	}))
 	require.NoError(t, err)
 
-	l, err := must(NewClient(name, socketPath)).DescribeInstances(tags)
+	l, err := must(NewClient(name, socketPath)).DescribeInstances(tags, false)
 	require.NoError(t, err)
 	require.Equal(t, list, l)
 
@@ -326,14 +326,14 @@ func TestInstancePluginDescribeInstancesError(t *testing.T) {
 		{ID: instance.ID("boo")}, {ID: instance.ID("boop")},
 	}
 	server, err := rpc_server.StartPluginAtPath(socketPath, PluginServer(&testing_instance.Plugin{
-		DoDescribeInstances: func(req map[string]string) ([]instance.Description, error) {
+		DoDescribeInstances: func(req map[string]string, properties bool) ([]instance.Description, error) {
 			tagsActual <- req
 			return list, errors.New("bad")
 		},
 	}))
 	require.NoError(t, err)
 
-	_, err = must(NewClient(name, socketPath)).DescribeInstances(tags)
+	_, err = must(NewClient(name, socketPath)).DescribeInstances(tags, false)
 	require.Error(t, err)
 	require.Equal(t, "bad", err.Error())
 

--- a/pkg/rpc/instance/service.go
+++ b/pkg/rpc/instance/service.go
@@ -145,7 +145,7 @@ func (p *Instance) DescribeInstances(_ *http.Request, req *DescribeInstancesRequ
 	if c == nil {
 		return fmt.Errorf("no-plugin:%s", req.Type)
 	}
-	desc, err := c.DescribeInstances(req.Tags)
+	desc, err := c.DescribeInstances(req.Tags, req.Properties)
 	if err != nil {
 		return err
 	}

--- a/pkg/rpc/instance/types.go
+++ b/pkg/rpc/instance/types.go
@@ -56,8 +56,9 @@ type DestroyResponse struct {
 
 // DescribeInstancesRequest is the rpc wrapper for DescribeInstances request
 type DescribeInstancesRequest struct {
-	Type string
-	Tags map[string]string
+	Type       string
+	Tags       map[string]string
+	Properties bool
 }
 
 // DescribeInstancesResponse is the rpc wrapper for the DescribeInstances response

--- a/pkg/spi/instance/spi.go
+++ b/pkg/spi/instance/spi.go
@@ -8,7 +8,7 @@ import (
 // InterfaceSpec is the current name and version of the Instance API.
 var InterfaceSpec = spi.InterfaceSpec{
 	Name:    "Instance",
-	Version: "0.3.0",
+	Version: "0.5.0",
 }
 
 // Plugin is a vendor-agnostic API used to create and manage resources with an infrastructure provider.
@@ -26,5 +26,6 @@ type Plugin interface {
 	Destroy(instance ID) error
 
 	// DescribeInstances returns descriptions of all instances matching all of the provided tags.
-	DescribeInstances(labels map[string]string) ([]Description, error)
+	// The properties flag indicates the client is interested in receiving details about each instance.
+	DescribeInstances(labels map[string]string, properties bool) ([]Description, error)
 }

--- a/pkg/spi/instance/types.go
+++ b/pkg/spi/instance/types.go
@@ -12,6 +12,10 @@ type Description struct {
 	ID        ID
 	LogicalID *LogicalID
 	Tags      map[string]string
+
+	// Properties carry the opaque, platform specific blob about the resource.
+	// It can represent the current state of the resource.
+	Properties *types.Any `json:",omitempty" yaml:",omitempty"`
 }
 
 // LogicalID is the logical identifier to associate with an instance.

--- a/pkg/testing/instance/plugin.go
+++ b/pkg/testing/instance/plugin.go
@@ -20,7 +20,7 @@ type Plugin struct {
 	DoDestroy func(instance instance.ID) error
 
 	// DoDescribeInstances returns descriptions of all instances matching all of the provided tags.
-	DoDescribeInstances func(tags map[string]string) ([]instance.Description, error)
+	DoDescribeInstances func(tags map[string]string, details bool) ([]instance.Description, error)
 }
 
 // Validate performs local validation on a provision request.
@@ -44,6 +44,6 @@ func (t *Plugin) Destroy(instance instance.ID) error {
 }
 
 // DescribeInstances returns descriptions of all instances matching all of the provided tags.
-func (t *Plugin) DescribeInstances(tags map[string]string) ([]instance.Description, error) {
-	return t.DoDescribeInstances(tags)
+func (t *Plugin) DescribeInstances(tags map[string]string, details bool) ([]instance.Description, error) {
+	return t.DoDescribeInstances(tags, details)
 }


### PR DESCRIPTION
This PR adds a new boolean to the Instance plugin's `DescribeInstances` method.  This boolean parameter can be set true by the client to request platform-specific details that represent the current state of the resource.  This extra data is carried in the opaque `Description.Properties`.

The CLI for instance plugin has been updated (the `describe` verb) to support retrieval of the instance properties and display it in tabular or raw form.  When displaying in raw form, either JSON or YAML can be the output format.