### PR TITLE
Support README in playbooks

### DIFF
--- a/pkg/rpc/mux/reverse_proxy_test.go
+++ b/pkg/rpc/mux/reverse_proxy_test.go
@@ -143,11 +143,11 @@ func TestMuxPlugins(t *testing.T) {
 	})
 	require.NotNil(t, rp)
 
-	proxy, err := startProxy(t, ":8080", rp)
+	proxy, err := startProxy(t, ":24864", rp)
 	require.NoError(t, err)
 	defer proxy.Stop(10 * time.Second)
 
-	get := "http://localhost:8080/" + pluginName + rpc.URLAPI
+	get := "http://localhost:24864/" + pluginName + rpc.URLAPI
 
 	T(100).Infoln("Basic info client:", get)
 	resp, err := http.Get(get)


### PR DESCRIPTION
If a README.md file is included in a directory of a playbook, automatically add it in the help text of the corresponding command.

Signed-off-by: David Chung <david.chung@docker.com>