### PR TITLE
Simplify template variables with a single 'var' function

### DIFF
--- a/cmd/cli/base/template.go
+++ b/cmd/cli/base/template.go
@@ -55,7 +55,7 @@ func TemplateProcessor(plugins func() discovery.Plugins) (*pflag.FlagSet, ToJSON
 
 	fs := pflag.NewFlagSet("template", pflag.ExitOnError)
 
-	globals := fs.StringSliceP("global", "g", []string{}, "key=value pairs of 'global' values in template")
+	globals := fs.StringSliceP("var", "v", []string{}, "key=value pairs of globally scoped variagbles")
 	yamlDoc := fs.BoolP("yaml", "y", false, "True if input is in yaml format; json is the default")
 	dump := fs.BoolP("dump", "x", false, "True to dump to output instead of executing")
 

--- a/cmd/cli/info/info.go
+++ b/cmd/cli/info/info.go
@@ -67,7 +67,7 @@ func Command(plugins func() discovery.Plugins) *cobra.Command {
 			return err
 		}
 
-		view, err := renderer.Def("plugin", *name, "Plugin name").Render(info)
+		view, err := renderer.Global("plugin", *name).Render(info)
 		if err != nil {
 			return err
 		}
@@ -103,7 +103,7 @@ func Command(plugins func() discovery.Plugins) *cobra.Command {
 			return err
 		}
 
-		view, err := renderer.Def("plugin", *name, "Plugin name").Render(info)
+		view, err := renderer.Global("plugin", *name).Render(info)
 		if err != nil {
 			return err
 		}
@@ -117,7 +117,7 @@ func Command(plugins func() discovery.Plugins) *cobra.Command {
 
 const (
 	apiViewTemplate = `
-Plugin:     {{ref "plugin"}}
+Plugin:     {{var "plugin"}}
 Implements: {{range $spi := .Implements}}{{$spi.Name}}/{{$spi.Version}} {{end}}
 Interfaces: {{range $iface := .Interfaces}}
   SPI:      {{$iface.Name}}/{{$iface.Version}}
@@ -136,7 +136,7 @@ Interfaces: {{range $iface := .Interfaces}}
 
 	funcsViewTemplate = `
 {{range $category, $functions := .}}
-{{ref "plugin"}}/{{$category}} _________________________________________________________________________________________
+{{var "plugin"}}/{{$category}} _________________________________________________________________________________________
   {{range $f := $functions}}
     Name:        {{$f.Name}}
     Description: {{join "\n                 " $f.Description}}

--- a/examples/flavor/swarm/templates.go
+++ b/examples/flavor/swarm/templates.go
@@ -12,7 +12,7 @@ set -o xtrace
 mkdir -p /etc/docker
 cat << EOF > /etc/docker/daemon.json
 {
-  "labels": {{ INFRAKIT_LABELS | to_json }}
+  "labels": {{ INFRAKIT_LABELS | jsonEncode }}
 }
 EOF
 
@@ -50,7 +50,7 @@ set -o xtrace
 mkdir -p /etc/docker
 cat << EOF > /etc/docker/daemon.json
 {
-  "labels": {{ INFRAKIT_LABELS | to_json }}
+  "labels": {{ INFRAKIT_LABELS | jsonEncode }}
 }
 EOF
 

--- a/pkg/template/funcs.go
+++ b/pkg/template/funcs.go
@@ -316,32 +316,6 @@ func (t *Template) DefaultFuncs() []Function {
 				return make([]struct{}, c)
 			},
 		},
-		// {
-		// 	Name: "global",
-		// 	Description: []string{
-		// 		"Sets a global variable named after the first argument, with the value as",
-		// 		"the second argument. This is similar to def (which sets the default value).",
-		// 		"Global variables are propagated to all templates that are rendered via the 'include' function.",
-		// 		"DEPRECATED - use var",
-		// 	},
-		// 	Func: func(n string, v interface{}) Void {
-		// 		log.Warn("deprecated -- use var instead")
-		// 		t.Global(n, v)
-		// 		return voidValue
-		// 	},
-		// },
-		// {
-		// 	Name: "ref",
-		// 	Description: []string{
-		// 		"References / gets the variable named after the first argument.",
-		// 		"The values must be set first by either def or global.",
-		// 		"DEPRECATED - use var",
-		// 	},
-		// 	Func: func(n string) interface{} {
-		// 		log.Warn("deprecated -- use var instead")
-		// 		return t.Ref(n)
-		// 	},
-		// },
 		{
 			Name: "var",
 			Description: []string{
@@ -473,33 +447,6 @@ func (t *Template) DefaultFuncs() []Function {
 				}
 				return ""
 			},
-		},
-
-		// Deprecated
-		{
-			Name: "to_json",
-			Description: []string{
-				"Encodes the input as a JSON string",
-				"This is useful for taking an object (interface{}) and render it inline as proper JSON.",
-				"Example: {{ include \"https://httpbin.org/get\" | from_json | to_json }}",
-			},
-			Func: ToJSON,
-		},
-		{
-			Name: "to_json_format",
-			Description: []string{
-				"Encodes the input as a JSON string with first arg as prefix, second arg the indentation, then the object",
-			},
-			Func: ToJSONFormat,
-		},
-		{
-			Name: "from_json",
-			Description: []string{
-				"Decodes the input (first arg) into a structure (a map[string]interface{} or []interface{}).",
-				"This is useful for parsing arbitrary resources in JSON format as object.  The object is the queryable via 'q'",
-				"For example: {{ include \"https://httpbin.org/get\" | from_json | q \"origin\" }} returns the origin of request.",
-			},
-			Func: FromJSON,
 		},
 	}
 }

--- a/pkg/template/integration_test.go
+++ b/pkg/template/integration_test.go
@@ -85,11 +85,11 @@ echo "this is common/setup.sh"
    "test" : "test1",
    "description" : "simple template to test the various template functions",
    {{/* Load from from ./ using relative path notation. Then split into lines and json encode */}}
-   "userData" : {{ include "script.tpl" . | lines | to_json }},
+   "userData" : {{ include "script.tpl" . | lines | jsonEncode }},
    {{/* Load from an URL */}}
    "sample" : {{ include "https://httpbin.org/get" }},
    {{/* Load from URL and then parse as JSON then select an attribute */}}
-   "originIp" : "{{ include "https://httpbin.org/get" | from_json | q "origin" }}"
+   "originIp" : "{{ include "https://httpbin.org/get" | jsonDecode | q "origin" }}"
 }`,
 
 		"plugin/script.tpl": `

--- a/pkg/template/template.go
+++ b/pkg/template/template.go
@@ -11,8 +11,10 @@ import (
 	"text/template"
 
 	"github.com/Masterminds/sprig"
-	log "github.com/Sirupsen/logrus"
+	logutil "github.com/docker/infrakit/pkg/log"
 )
+
+var log = logutil.New("module", "core/template")
 
 // Function contains the description of an exported template function
 type Function struct {
@@ -65,12 +67,6 @@ type Options struct {
 	Stderr func() io.Writer
 }
 
-type defaultValue struct {
-	Name  string
-	Value interface{}
-	Doc   string
-}
-
 // Template is the templating engine
 type Template struct {
 	options Options
@@ -81,8 +77,8 @@ type Template struct {
 	functions []func() []Function
 	funcs     map[string]interface{}
 	globals   map[string]interface{}
-	defaults  map[string]defaultValue
-	context   interface{}
+	//	defaults  map[string]defaultValue
+	context interface{}
 
 	registered []Function
 	lock       sync.Mutex
@@ -119,7 +115,7 @@ func NewTemplate(s string, opt Options) (*Template, error) {
 // path of any 'included' templates e.g. {{ include "./another.tpl" . }}
 func NewTemplateFromBytes(buff []byte, contextURL string, opt Options) (*Template, error) {
 	if contextURL == "" {
-		log.Warningln("Context is not known.  Included templates may not work properly.")
+		log.Warn("Context is not known; include/source may not work properly")
 	}
 
 	return &Template{
@@ -128,7 +124,6 @@ func NewTemplateFromBytes(buff []byte, contextURL string, opt Options) (*Templat
 		body:      buff,
 		funcs:     map[string]interface{}{},
 		globals:   map[string]interface{}{},
-		defaults:  map[string]defaultValue{},
 		functions: []func() []Function{},
 	}, nil
 }
@@ -161,8 +156,6 @@ func (t *Template) AddFunc(name string, f interface{}) *Template {
 func (t *Template) Ref(name string) interface{} {
 	if found, has := t.globals[name]; has {
 		return found
-	} else if v, has := t.defaults[name]; has {
-		return v.Value
 	}
 	return nil
 }
@@ -179,10 +172,6 @@ func (t *Template) forkFrom(parent *Template) (dotCopy interface{}, err error) {
 	// copy the globals in the parent scope into the child
 	for k, v := range parent.globals {
 		t.globals[k] = v
-	}
-	// copy the defaults in the parent scope into the child
-	for k, v := range parent.defaults {
-		t.defaults[k] = v
 	}
 	// inherit the functions defined for this template
 	for k, v := range parent.funcs {
@@ -211,26 +200,6 @@ func (t *Template) updateGlobal(name string, value interface{}) {
 	t.lock.Lock()
 	defer t.lock.Unlock()
 	t.globals[name] = value
-}
-
-// Def is equivalent to a {{ def "key" value "description" }} in defining a variable with a default value.
-// The value is accessible via a {{ ref "key" }} in the template.
-func (t *Template) Def(name string, value interface{}, doc string) *Template {
-	for here := t; here != nil; here = here.parent {
-		here.updateDef(name, value, doc)
-	}
-	return t
-}
-
-func (t *Template) updateDef(name string, val interface{}, doc ...string) *Template {
-	t.lock.Lock()
-	defer t.lock.Unlock()
-	t.defaults[name] = defaultValue{
-		Name:  name,
-		Value: val,
-		Doc:   strings.Join(doc, " "),
-	}
-	return t
 }
 
 // Validate parses the template and checks for validity.

--- a/pkg/template/template_test.go
+++ b/pkg/template/template_test.go
@@ -31,18 +31,18 @@ func TestRunTemplateWithJMESPath(t *testing.T) {
 }
 
 func TestVarAndGlobal(t *testing.T) {
-	str := `{{ q "locations[?state == 'WA'].name | sort(@) | {WashingtonCities: join(', ', @)}" . | global "washington-cities"}}
+	str := `{{ q "locations[?state == 'WA'].name | sort(@) | {WashingtonCities: join(', ', @)}" . | var "washington-cities"}}
 
 {{/* The query above is exported and referenced somewhere else */}}
-{{ from_json "[\"SF\",\"LA\"]" | def "california-cities" "Default value for California cities" }}
-{{ from_json "{\"SF\":\"94109\",\"LA\":\"90210\"}" | def "zip-codes" "Default value for zip codes" }}
+{{ from_json "[\"SF\",\"LA\"]" | var "california-cities" "Default value for California cities" }}
+{{ from_json "{\"SF\":\"94109\",\"LA\":\"90210\"}" | var "zip-codes" "Default value for zip codes" }}
 
 {
   "test" : "hello",
   "val"  : true,
-  "result" : {{ref "washington-cities" | to_json}},
-  "california" : {{ ref "california-cities" | to_json}},
-  "sf_zip" : {{ ref "zip-codes" | q "SF" | to_json }}
+  "result" : {{ var "washington-cities" | to_json}},
+  "california" : {{ var "california-cities" | to_json}},
+  "sf_zip" : {{ var "zip-codes" | q "SF" | to_json }}
 }
 `
 

--- a/pkg/template/template_test.go
+++ b/pkg/template/template_test.go
@@ -9,7 +9,7 @@ import (
 func TestRunTemplateWithJMESPath(t *testing.T) {
 
 	// Example from http://jmespath.org/
-	str := `{{ q "locations[?state == 'WA'].name | sort(@) | {WashingtonCities: join(', ', @)}" . | to_json}}`
+	str := `{{ q "locations[?state == 'WA'].name | sort(@) | {WashingtonCities: join(', ', @)}" . | jsonEncode}}`
 
 	tpl, err := NewTemplate("str://"+str, Options{})
 	require.NoError(t, err)
@@ -34,15 +34,15 @@ func TestVarAndGlobal(t *testing.T) {
 	str := `{{ q "locations[?state == 'WA'].name | sort(@) | {WashingtonCities: join(', ', @)}" . | var "washington-cities"}}
 
 {{/* The query above is exported and referenced somewhere else */}}
-{{ from_json "[\"SF\",\"LA\"]" | var "california-cities" "Default value for California cities" }}
-{{ from_json "{\"SF\":\"94109\",\"LA\":\"90210\"}" | var "zip-codes" "Default value for zip codes" }}
+{{ jsonDecode "[\"SF\",\"LA\"]" | var "california-cities" "Default value for California cities" }}
+{{ jsonDecode "{\"SF\":\"94109\",\"LA\":\"90210\"}" | var "zip-codes" "Default value for zip codes" }}
 
 {
   "test" : "hello",
   "val"  : true,
-  "result" : {{ var "washington-cities" | to_json}},
-  "california" : {{ var "california-cities" | to_json}},
-  "sf_zip" : {{ var "zip-codes" | q "SF" | to_json }}
+  "result" : {{ var "washington-cities" | jsonEncode}},
+  "california" : {{ var "california-cities" | jsonEncode}},
+  "sf_zip" : {{ var "zip-codes" | q "SF" | jsonEncode }}
 }
 `
 


### PR DESCRIPTION
Currently there are 3 functions that deal with setting and getting of global variables for a template -- it's too complex.  In this PR, a single `var` function is introduced and the other 3 are removed / deprecated in an effort to simplify the template functions. 

The `var` function serves a single purpose of getting / setting global variables and is pipeline-friendly.  The var function takes variable arguments, but if only a single string is passed, it is a `get`.  If more than one values are passed after the key (arg 1), then the *last* value is the varargs is taken as the value to `set`.  So

```
{{ var "my-variable" 20 }} /* sets my-variable to 20 */
{{ var "my-variable" }}  /* gets my-variable, returns 20 */
{{ var "my-variable" | var "a-copy" }} /* gets from my-variable and sets a-copy to 20 */
```
Because the last element of the var args is taken if and only if var args have more than 0 elements, it's possible to add doc string like so:
```
{{ var "my-variable" | var "a-copy" "note: copies a value" }} /* gets from my-variable and sets a-copy to 20 */
```

Also in this PR
  + Remove the `to_json` and `from_json` functions.  Instead `jsonEncode` and `jsonDecode` are the function names that are more consistent with the conventions adopted by Sprig
  + Renamed command-line flag `global` to `var`, with a short flag of `-v`.

Signed-off-by: David Chung <david.chung@docker.com>