### PR TITLE
Drop github.com/gorilla/handlers from vendor.conf

### DIFF
--- a/vendor.conf
+++ b/vendor.conf
@@ -30,7 +30,6 @@ github.com/golang/glog                                  23def4e
 github.com/golang/mock                                  bd3c8e8
 github.com/golang/protobuf/jsonpb                       4bd1920723d7b7c925de087aa32e2187708897f7
 github.com/golang/protobuf/proto                        4bd1920723d7b7c925de087aa32e2187708897f7
-github.com/gorilla/handlers                             v1.1-12-ge1b2144
 github.com/gorilla/mux                                  757bef9
 github.com/gorilla/rpc                                  22c016f
 github.com/grpc-ecosystem/go-grpc-prometheus            v1.1


### PR DESCRIPTION
Trash says:

   Package 'github.com/gorilla/handlers' has been completely removed: it's probably useless (in vendor.conf)

Looks like the last usage was removed in a6d51a597746.

Signed-off-by: Ian Campbell <ian.campbell@docker.com>