### PR TITLE
Support plugins that listen on network port

### DIFF
--- a/pkg/cli/serverutil.go
+++ b/pkg/cli/serverutil.go
@@ -19,20 +19,47 @@ func EnsureDirExists(dir string) {
 // RunPlugin runs a plugin server, advertising with the provided name for discovery.
 // The plugin should conform to the rpc call convention as implemented in the rpc package.
 func RunPlugin(name string, plugin server.VersionedInterface, more ...server.VersionedInterface) {
-
 	dir := local.Dir()
 	EnsureDirExists(dir)
 
 	socketPath := path.Join(dir, name)
 	pidPath := path.Join(dir, name+".pid")
+	run("", socketPath, pidPath, plugin, more...)
+}
 
-	stoppable, err := server.StartPluginAtPath(socketPath, plugin, more...)
-	if err != nil {
-		logrus.Error(err)
+// RunListener runs a plugin server, listening at listen address, and
+// advertising with the provided name for discovery.
+// The plugin should conform to the rpc call convention as implemented in the rpc package.
+func RunListener(listen, name string, plugin server.VersionedInterface, more ...server.VersionedInterface) {
+	dir := local.Dir()
+	EnsureDirExists(dir)
+
+	discoverPath := path.Join(dir, name+".listen")
+	pidPath := path.Join(dir, name+".pid")
+	run(listen, discoverPath, pidPath, plugin, more...)
+}
+
+func run(listen, discoverPath, pidPath string,
+	plugin server.VersionedInterface, more ...server.VersionedInterface) {
+
+	var stoppable server.Stoppable
+
+	if listen != "" {
+		s, err := server.StartListenerAtPath(listen, discoverPath, plugin, more...)
+		if err != nil {
+			logrus.Error(err)
+		}
+		stoppable = s
+	} else {
+		s, err := server.StartPluginAtPath(discoverPath, plugin, more...)
+		if err != nil {
+			logrus.Error(err)
+		}
+		stoppable = s
 	}
 
 	// write PID file
-	err = ioutil.WriteFile(pidPath, []byte(fmt.Sprintf("%v", os.Getpid())), 0644)
+	err := ioutil.WriteFile(pidPath, []byte(fmt.Sprintf("%v", os.Getpid())), 0644)
 	if err != nil {
 		logrus.Error(err)
 	}
@@ -44,4 +71,7 @@ func RunPlugin(name string, plugin server.VersionedInterface, more ...server.Ver
 	// clean up
 	os.Remove(pidPath)
 	logrus.Infoln("Removed PID file at", pidPath)
+
+	os.Remove(discoverPath)
+	logrus.Infoln("Removed discover file at", discoverPath)
 }

--- a/pkg/discovery/discovery.go
+++ b/pkg/discovery/discovery.go
@@ -18,16 +18,16 @@ const (
 	PluginDirEnvVar = "INFRAKIT_PLUGINS_DIR"
 )
 
-// ErrNotUnixSocket is the error raised when the file is not a unix socket
-type ErrNotUnixSocket string
+// ErrNotUnixSocketOrListener is the error raised when the file is not a unix socket
+type ErrNotUnixSocketOrListener string
 
-func (e ErrNotUnixSocket) Error() string {
-	return fmt.Sprintf("not a unix socket:%s", string(e))
+func (e ErrNotUnixSocketOrListener) Error() string {
+	return fmt.Sprintf("not a unix socket or listener:%s", string(e))
 }
 
-// IsErrNotUnixSocket returns true if the error is due to the file not being a valid unix socket.
-func IsErrNotUnixSocket(e error) bool {
-	_, is := e.(ErrNotUnixSocket)
+// IsErrNotUnixSocketOrListener returns true if the error is due to the file not being a valid unix socket.
+func IsErrNotUnixSocketOrListener(e error) bool {
+	_, is := e.(ErrNotUnixSocketOrListener)
 	return is
 }
 

--- a/pkg/discovery/discovery_test.go
+++ b/pkg/discovery/discovery_test.go
@@ -6,8 +6,8 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestErrNotUnixSocket(t *testing.T) {
-	err := ErrNotUnixSocket("no socket!")
+func TestErrNotUnixSocketOrListener(t *testing.T) {
+	err := ErrNotUnixSocketOrListener("no socket!")
 	require.Error(t, err)
-	require.True(t, IsErrNotUnixSocket(err))
+	require.True(t, IsErrNotUnixSocketOrListener(err))
 }

--- a/pkg/discovery/local/dir_test.go
+++ b/pkg/discovery/local/dir_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/docker/infrakit/pkg/plugin"
 	rpc "github.com/docker/infrakit/pkg/rpc/instance"
 	"github.com/docker/infrakit/pkg/rpc/server"
+	. "github.com/docker/infrakit/pkg/testing"
 	"github.com/stretchr/testify/require"
 )
 
@@ -30,15 +31,17 @@ func TestDirDiscovery(t *testing.T) {
 	dir, err := ioutil.TempDir("", "infrakit_dir_test")
 	require.NoError(t, err)
 
+	T(100).Infoln("Starting server1")
 	name1 := "server1"
 	path1 := filepath.Join(dir, name1)
 	server1, err := server.StartPluginAtPath(path1, rpc.PluginServer(nil))
 	require.NoError(t, err)
 	require.NotNil(t, server1)
 
+	T(100).Infoln("Starting server2")
 	name2 := "server2"
-	path2 := filepath.Join(dir, name2)
-	server2, err := server.StartPluginAtPath(path2, rpc.PluginServer(nil))
+	path2 := filepath.Join(dir, name2+".listen")
+	server2, err := server.StartListenerAtPath("localhost:7777", path2, rpc.PluginServer(nil))
 	require.NoError(t, err)
 	require.NotNil(t, server2)
 

--- a/pkg/rpc/client/client_test.go
+++ b/pkg/rpc/client/client_test.go
@@ -21,7 +21,7 @@ func TestParseAddress(t *testing.T) {
 	u, c, err = parseAddress("tcp://host:9090/foo/bar/baz")
 	require.NoError(t, err)
 	require.Nil(t, c.Transport)
-	require.Equal(t, "tcp://host:9090/foo/bar/baz", u.String())
+	require.Equal(t, "http://host:9090/foo/bar/baz", u.String())
 
 	u, c, err = parseAddress("https://host:9090")
 	require.NoError(t, err)


### PR DESCRIPTION
Closes #248 

Specifically, it's now possible to have a plugin listening on a network port, while writing a file at the discovery directory with the name of `plugin_name.listen`.  The content of the file is the url at which the service listens on.  During discovery, the plugin discovery will scan for socket files as well as `.listen` files.  For socket files, a client based on unix socket will be created for each matching plugin; for `.listen` files, a client based on tcp connection will be created for each matching plugin.

This has been a long feature request, as well as, for supporting an upcoming PR where the Infrakit / HyperKit instance plugin will listen on a network port acting as a Type-2 hypervisor to manage local guest vm instances on the host.

Signed-off-by: David Chung <david.chung@docker.com>