### PR TITLE
instance tracker

### DIFF
--- a/cmd/cli/util/fileserver.go
+++ b/cmd/cli/util/fileserver.go
@@ -1,0 +1,34 @@
+package util
+
+import (
+	"net/http"
+	"os"
+
+	"github.com/docker/infrakit/pkg/discovery"
+	"github.com/spf13/cobra"
+)
+
+func fileServerCommand(plugins func() discovery.Plugins) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "fileserver <path>",
+		Short: "Fileserver over http",
+	}
+
+	listen := cmd.Flags().StringP("listen", "l", ":8080", "Listening port")
+
+	cmd.RunE = func(c *cobra.Command, args []string) error {
+
+		if len(args) != 1 {
+			c.Usage()
+			os.Exit(-1)
+		}
+
+		logger.Info("Starting file server", "listen", *listen)
+
+		rootFS := args[0]
+		handler := http.FileServer(http.Dir(rootFS))
+		return http.ListenAndServe(*listen, handler)
+	}
+
+	return cmd
+}

--- a/cmd/cli/util/mux.go
+++ b/cmd/cli/util/mux.go
@@ -1,0 +1,60 @@
+package util
+
+import (
+	"time"
+
+	"github.com/docker/infrakit/pkg/discovery"
+	"github.com/docker/infrakit/pkg/rpc/mux"
+	"github.com/spf13/cobra"
+)
+
+func muxCommand(plugins func() discovery.Plugins) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "mux",
+		Short: "API mux service",
+	}
+
+	// http://www.speedguide.net/port.php?port=24864 - unassigned by IANA
+	listen := cmd.Flags().StringP("listen", "l", ":24864", "Listening port")
+	autoStop := cmd.Flags().BoolP("auto-stop", "a", false, "True to stop when no plugins are running")
+	interval := cmd.Flags().DurationP("scan", "s", 1*time.Minute, "Scan interval to check for plugins")
+
+	cmd.RunE = func(c *cobra.Command, args []string) error {
+		logger.Info("Starting mux server", "listen", *listen)
+		server, err := mux.NewServer(*listen, plugins)
+		if err != nil {
+			return err
+		}
+		defer server.Stop()
+
+		block := make(chan struct{})
+		// If the sockets are gone, then we can safely exit.
+		go func() {
+			checkNow := time.Tick(*interval)
+			for {
+				select {
+				case <-server.Wait():
+					logger.Info("server stopped")
+					close(block)
+					return
+
+				case <-checkNow:
+					if m, err := plugins().List(); err == nil {
+						if len(m) == 0 && *autoStop {
+							logger.Info("scan found no plugins.")
+							close(block)
+							return
+						}
+					}
+
+				}
+			}
+		}()
+
+		<-block
+
+		return nil
+	}
+
+	return cmd
+}

--- a/cmd/cli/util/track.go
+++ b/cmd/cli/util/track.go
@@ -1,0 +1,75 @@
+package util
+
+import (
+	"os"
+	"strings"
+	"time"
+
+	"github.com/docker/infrakit/pkg/cli"
+	"github.com/docker/infrakit/pkg/discovery"
+	"github.com/docker/infrakit/pkg/plugin"
+	"github.com/docker/infrakit/pkg/plugin/event/instance"
+	event_rpc "github.com/docker/infrakit/pkg/rpc/event"
+	instance_rpc "github.com/docker/infrakit/pkg/rpc/instance"
+	"github.com/docker/infrakit/pkg/spi/event"
+	"github.com/spf13/cobra"
+)
+
+func trackCommand(plugins func() discovery.Plugins) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "track",
+		Short: "Track instances",
+	}
+
+	name := cmd.Flags().String("name", "", "Name to use as name of this plugin")
+	targets := cmd.Flags().StringSliceP("instance", "n", []string{}, "Instance plugins to track")
+	poll := cmd.Flags().DurationP("poll", "i", 3*time.Second, "Polling interval")
+	flagTags := cmd.Flags().StringSliceP("tag", "t", []string{}, "Tags to filter instance by")
+
+	cmd.RunE = func(c *cobra.Command, args []string) error {
+
+		if len(args) != 0 {
+			cmd.Usage()
+			os.Exit(-1)
+		}
+
+		tags := map[string]string{}
+
+		for _, tag := range *flagTags {
+			kv := strings.SplitN(tag, "=", 2)
+			if len(kv) != 2 {
+				logger.Warn("bad format tag", "input", tag)
+				continue
+			}
+			key := strings.TrimSpace(kv[0])
+			val := strings.TrimSpace(kv[1])
+			if key != "" && val != "" {
+				tags[key] = val
+			}
+		}
+
+		trackers := map[string]event.Plugin{}
+
+		for _, target := range *targets {
+
+			endpoint, err := plugins().Find(plugin.Name(target))
+			if err != nil {
+				return err
+			}
+
+			if p, err := instance_rpc.NewClient(plugin.Name(target), endpoint.Address); err == nil {
+				trackers[target] = instance.NewTracker(target, p, time.Tick(*poll), tags)
+			} else {
+				return err
+			}
+		}
+
+		cli.RunPlugin(*name,
+			// As event plugin
+			event_rpc.PluginServerWithTypes(trackers),
+		)
+		return nil
+	}
+
+	return cmd
+}

--- a/cmd/cli/util/util.go
+++ b/cmd/cli/util/util.go
@@ -1,14 +1,9 @@
 package util
 
 import (
-	"net/http"
-	"os"
-	"time"
-
 	"github.com/docker/infrakit/cmd/cli/base"
 	"github.com/docker/infrakit/pkg/discovery"
 	"github.com/docker/infrakit/pkg/log"
-	"github.com/docker/infrakit/pkg/rpc/mux"
 	"github.com/spf13/cobra"
 )
 
@@ -16,82 +11,6 @@ var logger = log.New("module", "cli/util")
 
 func init() {
 	base.Register(Command)
-}
-
-func fileServerCommand(plugins func() discovery.Plugins) *cobra.Command {
-	cmd := &cobra.Command{
-		Use:   "fileserver <path>",
-		Short: "Fileserver over http",
-	}
-
-	listen := cmd.Flags().StringP("listen", "l", ":8080", "Listening port")
-
-	cmd.RunE = func(c *cobra.Command, args []string) error {
-
-		if len(args) != 1 {
-			c.Usage()
-			os.Exit(-1)
-		}
-
-		logger.Info("Starting file server", "listen", *listen)
-
-		rootFS := args[0]
-		handler := http.FileServer(http.Dir(rootFS))
-		return http.ListenAndServe(*listen, handler)
-	}
-
-	return cmd
-}
-
-func muxCommand(plugins func() discovery.Plugins) *cobra.Command {
-	cmd := &cobra.Command{
-		Use:   "mux",
-		Short: "API mux service",
-	}
-
-	// http://www.speedguide.net/port.php?port=24864 - unassigned by IANA
-	listen := cmd.Flags().StringP("listen", "l", ":24864", "Listening port")
-	autoStop := cmd.Flags().BoolP("auto-stop", "a", false, "True to stop when no plugins are running")
-	interval := cmd.Flags().DurationP("scan", "s", 1*time.Minute, "Scan interval to check for plugins")
-
-	cmd.RunE = func(c *cobra.Command, args []string) error {
-		logger.Info("Starting mux server", "listen", *listen)
-		server, err := mux.NewServer(*listen, plugins)
-		if err != nil {
-			return err
-		}
-		defer server.Stop()
-
-		block := make(chan struct{})
-		// If the sockets are gone, then we can safely exit.
-		go func() {
-			checkNow := time.Tick(*interval)
-			for {
-				select {
-				case <-server.Wait():
-					logger.Info("server stopped")
-					close(block)
-					return
-
-				case <-checkNow:
-					if m, err := plugins().List(); err == nil {
-						if len(m) == 0 && *autoStop {
-							logger.Info("scan found no plugins.")
-							close(block)
-							return
-						}
-					}
-
-				}
-			}
-		}()
-
-		<-block
-
-		return nil
-	}
-
-	return cmd
 }
 
 // Command is the head of this module
@@ -102,7 +21,7 @@ func Command(plugins func() discovery.Plugins) *cobra.Command {
 		Short: "Utilties",
 	}
 
-	util.AddCommand(muxCommand(plugins), fileServerCommand(plugins))
+	util.AddCommand(muxCommand(plugins), fileServerCommand(plugins), trackCommand(plugins))
 
 	return util
 }

--- a/pkg/plugin/event/instance/track.go
+++ b/pkg/plugin/event/instance/track.go
@@ -1,0 +1,160 @@
+package instance
+
+import (
+	"time"
+
+	"github.com/deckarep/golang-set"
+	logutil "github.com/docker/infrakit/pkg/log"
+	"github.com/docker/infrakit/pkg/spi/event"
+	"github.com/docker/infrakit/pkg/spi/instance"
+	"github.com/docker/infrakit/pkg/types"
+)
+
+var log = logutil.New("module", "util/event/instance")
+
+const (
+	eventType = event.Type("tracker")
+)
+
+// NewTracker returns an event plugin implementation that can generate events based on resources it trackers
+func NewTracker(name string, plugin instance.Plugin, tick <-chan time.Time, tags map[string]string) *Tracker {
+	m := &Tracker{
+		poll:   tick,
+		Plugin: plugin,
+		Name:   name,
+		tags:   tags,
+	}
+	return m.init()
+}
+
+// Tracker implements the event spi -- just just calls the Describe to get a
+// list of known instances, and report anything it hasn't seen before, or
+// if anything that disappeared.
+type Tracker struct {
+	stop   chan struct{}
+	topics map[string]interface{}
+
+	tags map[string]string
+
+	// poll is the ticker for polling
+	poll <-chan time.Time
+
+	// Plugin is the instance plugin to use
+	Plugin instance.Plugin
+
+	// Name is the name of the plugin
+	Name string
+}
+
+func (m *Tracker) getEndpoint() interface{} {
+	return "redirect to endpoint (not implemented)"
+}
+
+// Init initializes the event plugin and starts working
+func (m *Tracker) init() *Tracker {
+	m.topics = map[string]interface{}{}
+	m.stop = make(chan struct{})
+
+	if m.poll == nil {
+		m.poll = time.Tick(3 * time.Second)
+	}
+
+	for _, topic := range types.PathFromStrings(
+		"found",
+		"lost",
+		"error",
+	) {
+		types.Put(topic, m.getEndpoint, m.topics)
+	}
+	return m
+}
+
+// Stop stops the Tracker
+func (m *Tracker) Stop() {
+	if m.stop != nil {
+		close(m.stop)
+	}
+}
+
+// List returns the nodes under the given topic
+func (m *Tracker) List(topic types.Path) ([]string, error) {
+	return types.List(topic, m.topics), nil
+}
+
+// PublishOn sets the channel to publish on
+func (m *Tracker) PublishOn(events chan<- *event.Event) {
+	go func() {
+
+		c := events
+
+		defer func() {
+			if c != nil {
+				close(c)
+			}
+		}()
+
+		log.Info("Start trackering instances", "name", m.Name)
+
+		instances := map[instance.ID]instance.Description{}
+		last := mapset.NewSet()
+
+	poll:
+		for {
+			select {
+			case <-m.stop:
+				m.stop = nil
+				return
+
+			case <-m.poll:
+
+				described, err := m.Plugin.DescribeInstances(m.tags, false)
+				if err != nil {
+					log.Warn("Error describing instances", "name", m.Name, "err", err)
+					c <- event.Event{
+						Type: eventType,
+						ID:   "error",
+					}.Init().Now().WithTopic("error").WithDataMust(err)
+
+					// Done here. skip to the next poll
+					continue poll
+				}
+
+				current := mapset.NewSet()
+				for _, f := range described {
+					current.Add(f.ID)
+					instances[f.ID] = f
+				}
+
+				lost := last.Difference(current)
+				found := current.Difference(last)
+
+				log.Debug("found", "list", found)
+				log.Debug("lost", "list", lost)
+
+				for v := range lost.Iter() {
+					id := v.(instance.ID)
+					c <- event.Event{
+						Type: eventType,
+						ID:   string(id),
+					}.Init().Now().WithTopic("lost").WithDataMust(instances[id])
+
+					log.Debug("sent lost", "id", id)
+				}
+				for v := range found.Iter() {
+					id := v.(instance.ID)
+					c <- event.Event{
+						Type: eventType,
+						ID:   string(id),
+					}.Init().Now().WithTopic("found").WithDataMust(instances[id])
+
+					log.Debug("sent found", "id", id)
+				}
+
+				log.Debug("current", "list", current)
+
+				last = current
+
+			}
+		}
+	}()
+}

--- a/pkg/plugin/event/instance/track_test.go
+++ b/pkg/plugin/event/instance/track_test.go
@@ -53,6 +53,15 @@ func TestTracker(t *testing.T) {
 
 	// Send different responses each step
 
+	// initial state - found = 1
+	steps <- 0
+	describes <- []instance.Description{
+		{
+			ID: instance.ID("a"),
+		},
+	}
+	tick <- time.Now()
+
 	// initial state - found = 2
 	steps <- 0
 	describes <- []instance.Description{

--- a/pkg/plugin/event/instance/track_test.go
+++ b/pkg/plugin/event/instance/track_test.go
@@ -1,0 +1,147 @@
+package instance
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/docker/infrakit/pkg/spi/event"
+	"github.com/docker/infrakit/pkg/spi/instance"
+	. "github.com/docker/infrakit/pkg/testing"
+	testing_instance "github.com/docker/infrakit/pkg/testing/instance"
+	"github.com/docker/infrakit/pkg/types"
+	"github.com/stretchr/testify/require"
+)
+
+func TestTracker(t *testing.T) {
+
+	steps := make(chan int, 1)
+	describes := make(chan []instance.Description, 1)
+
+	inst1 := &testing_instance.Plugin{
+
+		DoDescribeInstances: func(tags map[string]string, details bool) ([]instance.Description, error) {
+
+			for step := range steps {
+
+				switch step {
+				case 0:
+					return <-describes, nil
+				case 1:
+					return <-describes, nil
+				case 2:
+					return <-describes, nil
+				case 3:
+					return nil, fmt.Errorf("error")
+				case 4:
+					return <-describes, nil
+				case 5:
+					return <-describes, nil
+				}
+			}
+			return nil, nil
+		},
+	}
+
+	tick := make(chan time.Time)
+
+	m := NewTracker("inst1", inst1, tick, nil)
+
+	chanEvents := make(chan *event.Event, 100)
+
+	m.PublishOn(chanEvents)
+
+	// Send different responses each step
+
+	// initial state - found = 2
+	steps <- 0
+	describes <- []instance.Description{
+		{
+			ID: instance.ID("a"),
+		},
+		{
+			ID: instance.ID("b"),
+		},
+	}
+	tick <- time.Now()
+
+	// lost 1, gain 1 = found = 1; lost = 1
+	steps <- 1
+	describes <- []instance.Description{
+		{
+			ID: instance.ID("b"),
+		},
+		{
+			ID: instance.ID("c"),
+		},
+	}
+	tick <- time.Now()
+
+	// steady state
+	steps <- 2
+	describes <- []instance.Description{
+		{
+			ID: instance.ID("b"),
+		},
+		{
+			ID: instance.ID("c"),
+		},
+	}
+	tick <- time.Now()
+
+	// error error = 1
+	steps <- 3
+	tick <- time.Now()
+
+	// another - now recovered
+	steps <- 4
+	describes <- []instance.Description{
+		{
+			ID: instance.ID("b"),
+		},
+		{
+			ID: instance.ID("c"),
+		},
+	}
+	tick <- time.Now()
+
+	// found 1 more
+	steps <- 5
+	describes <- []instance.Description{
+		{
+			ID: instance.ID("b"),
+		},
+		{
+			ID: instance.ID("c"),
+		},
+		{
+			ID: instance.ID("d"),
+		},
+	}
+	tick <- time.Now()
+
+	// shutdown after a wait
+	<-time.After(100 * time.Millisecond)
+	m.Stop()
+
+	T(100).Infoln("checking events")
+	events := []*event.Event{}
+	for event := range chanEvents {
+		events = append(events, event)
+	}
+
+	require.Equal(t, 6, len(events))
+
+	checkEvent(t, "a", "found", events[0])
+	checkEvent(t, "b", "found", events[1])
+	checkEvent(t, "a", "lost", events[2])
+	checkEvent(t, "c", "found", events[3])
+	checkEvent(t, "error", "error", events[4])
+	checkEvent(t, "d", "found", events[5])
+
+}
+
+func checkEvent(t *testing.T, id string, topic string, event *event.Event) {
+	require.Equal(t, id, event.ID)
+	require.Equal(t, types.PathFromString(topic), event.Topic)
+}


### PR DESCRIPTION
Adding a utility for tracking / monitoring instances as they come and go.  This is the AWS instance tracker demo'd at DockerCon / Moby Summit in Austin, generalized.  This serves to show a simple implementation of event source that continuously check for presence/absence of instances.  

For each instance plugin it tracks, event topics are created: lost, found, error.  Periodically the tracker will call the instance plugins to check for presence of instances.  New instances unknown will be reported as found, lost as lost, and errors are reported as well.

For example, we can track the instances created / destroyed from the `instance-file` plugin like so:

```shell
infrakit util track --name tracker -n instance-file 
INFO[0000] Listening at: /Users/davidchung/.infrakit/plugins/tracker 
INFO[0000] PID file at /Users/davidchung/.infrakit/plugins/tracker.pid 
INFO[04-27|19:36:21] Start trackering instances               module=util/event/instance name=instance-file fn=github.com/docker/infrakit/pkg/plugin/event/instance.(*Tracker).PublishOn.func1

```
This starts an event plugin with the name `tracker`:
```shell
$ infrakit plugin ls
NAME                	LISTEN
group2              	/Users/davidchung/.infrakit/plugins/group2
instance-file       	/Users/davidchung/.infrakit/plugins/instance-file
tracker             	/Users/davidchung/.infrakit/plugins/tracker
flavor-vanilla      	/Users/davidchung/.infrakit/plugins/flavor-vanilla
group               	/Users/davidchung/.infrakit/plugins/group
group-stateless     	/Users/davidchung/.infrakit/plugins/group-stateless
group1              	/Users/davidchung/.infrakit/plugins/group1
```

And we see new event topics:
```shell
$ infrakit event ls
tracker
$ infrakit event ls -al tracker
total 3:
tracker/instance-file/error
tracker/instance-file/found
tracker/instance-file/lost
```

To tail / watch events:
```shell
$ infrakit event tail tracker/instance-file/
INFO[04-27|19:38:49] rendering view                           module=cli/event template==str://{{.}} fn=github.com/docker/infrakit/cmd/cli/event.Command.func2
INFO[04-27|19:38:49] Subscribing                              module=cli/event topic=instance-file/ fn=github.com/docker/infrakit/cmd/cli/event.Command.func2
INFO[0000] Connecting to broker url= unix://tracker topic= instance-file/ opts= {/Users/davidchung/.infrakit/plugins /events}
```

And when the user changes the size of the cluster, for instance, like so:
```shell
infrakit manager change -v Groups/cattle/Properties/Properties/Allocation/Size=2  -c
```
We should see events coming through as instances are created or destroyed.  Obviously this also applies to when the instances themselves terminate or disappear, since the tracker continuously monitor the infrastructure and operates independently of the group plugin.

```shell
$ infrakit event tail tracker/instance-file/
INFO[04-27|19:38:49] rendering view                           module=cli/event template==str://{{.}} fn=github.com/docker/infrakit/cmd/cli/event.Command.func2
INFO[04-27|19:38:49] Subscribing                              module=cli/event topic=instance-file/ fn=github.com/docker/infrakit/cmd/cli/event.Command.func2
INFO[0000] Connecting to broker url= unix://tracker topic= instance-file/ opts= {/Users/davidchung/.infrakit/plugins /events}
{tracker/instance-file/found tracker instance-2420576373405968023 2017-04-27 19:41:42.218135145 -0700 PDT 2017-04-27 19:41:42.220306586 -0700 PDT {"ID": "instance-2420576373405968023","LogicalID": null,"Tags": {"infrakit.config_sha": "jpfedp4sefvncwye5b6yre5qoz2odtnd","infrakit.group": "cattle","project": "infrakit","tier": "web"}} <nil>}
{tracker/instance-file/found tracker instance-4616022332507437567 2017-04-27 19:41:42.218163777 -0700 PDT 2017-04-27 19:41:42.220327122 -0700 PDT {"ID": "instance-4616022332507437567","LogicalID": null,"Tags": {"infrakit.config_sha": "jpfedp4sefvncwye5b6yre5qoz2odtnd","infrakit.group": "cattle","project": "infrakit","tier": "web"}} <nil>}
{tracker/instance-file/found tracker instance-6162719026775606111 2017-04-27 19:41:42.218194233 -0700 PDT 2017-04-27 19:41:42.220359075 -0700 PDT {"ID": "instance-6162719026775606111","LogicalID": null,"Tags": {"infrakit.config_sha": "jpfedp4sefvncwye5b6yre5qoz2odtnd","infrakit.group": "cattle","project": "infrakit","tier": "web"}} <nil>}
```

Signed-off-by: David Chung <david.chung@docker.com>