### PR TITLE
Terraform plugin fails to describe instance by tag

### DIFF
--- a/examples/instance/terraform/plugin.go
+++ b/examples/instance/terraform/plugin.go
@@ -538,9 +538,8 @@ func (p *plugin) DescribeInstances(tags map[string]string, properties bool) ([]i
 	re := regexp.MustCompile("(.*)(instance-[0-9]+)")
 	result := []instance.Description{}
 	// now we scan for <instance_type.instance-<timestamp> as keys
-scan:
 	for t, vm := range localSpecs {
-
+	scan:
 		for k, v := range vm {
 			matches := re.FindStringSubmatch(string(k))
 			if len(matches) == 3 {


### PR DESCRIPTION
The terraform instance plugin's `DescribeInstances` function may fail if there are multiple groups. The resources types are parsed from the .tf.json files and stored in a map key'd by the resource type. During the tag match filtering, if a tag does not match then (currently) no other resources of the same type are processed.

This is exposed when there are multiple groups since the group name is included in a tag.

Closes #493

Signed-off-by: Steven Kaufer <kaufer@us.ibm.com>