### PR TITLE
Fix exec stderr redirection

### DIFF
--- a/pkg/util/exec/exec.go
+++ b/pkg/util/exec/exec.go
@@ -56,7 +56,7 @@ func (b *Builder) WithStdout(w io.Writer) *Builder {
 
 // WithStderr sets the stderr writer
 func (b *Builder) WithStderr(w io.Writer) *Builder {
-	b.stdout = w
+	b.stderr = w
 	return b
 }
 


### PR DESCRIPTION
The `WithStderr` function in `pkg/util/exec/exec.go` is incorrectly assigning the given `Writer` to stdout instead of stderr; this causes the log messages from stderr to not be captured.

Closes #504

Signed-off-by: Steven Kaufer <kaufer@us.ibm.com>