### PR TITLE
Added missing trailing slash for older Docker version

### DIFF
--- a/dockerfiles/Dockerfile.bundle
+++ b/dockerfiles/Dockerfile.bundle
@@ -26,4 +26,4 @@ ENV INFRAKIT_INSTANCE_TERRAFORM_DIR /infrakit/instance/terraform
 
 
 ADD build/* /usr/local/bin/
-ADD dockerfiles/build-infrakit /usr/local/bin
+ADD dockerfiles/build-infrakit /usr/local/bin/


### PR DESCRIPTION
Dockerfile is missing the trailing slash, which ends up not adding the file specified in older Docker versions. 