### PR TITLE
Use COPY instead of ADD in dockerfile

### DIFF
--- a/dockerfiles/Dockerfile.bundle
+++ b/dockerfiles/Dockerfile.bundle
@@ -26,4 +26,4 @@ ENV INFRAKIT_INSTANCE_TERRAFORM_DIR /infrakit/instance/terraform
 
 
 ADD build/* /usr/local/bin/
-ADD dockerfiles/build-infrakit /usr/local/bin/
+COPY dockerfiles/build-infrakit /usr/local/bin/


### PR DESCRIPTION
Some weirdness with older version of Docker engine running on CircleCI...  use COPY for single file instead of ADD.

Signed-off-by: David Chung <david.chung@docker.com>