### PR TITLE
Support go 1.8

### DIFF
--- a/pkg/rpc/mux/reverse_proxy_test.go
+++ b/pkg/rpc/mux/reverse_proxy_test.go
@@ -150,6 +150,7 @@ func TestMuxPlugins(t *testing.T) {
 
 	T(100).Infoln("Basic info client:", get)
 	resp, err := http.Get(get)
+	require.NoError(t, err)
 	defer resp.Body.Close()
 	T(100).Infoln("resp=", resp, "err=", err)
 

--- a/pkg/rpc/mux/server_test.go
+++ b/pkg/rpc/mux/server_test.go
@@ -53,6 +53,7 @@ func TestMuxServer(t *testing.T) {
 
 	T(100).Infoln("Basic info client:", get)
 	resp, err := http.Get(get)
+	require.NoError(t, err)
 	defer resp.Body.Close()
 	T(100).Infoln("resp=", resp, "err=", err)
 


### PR DESCRIPTION
When using go 1.8, I got error below

```
$ make ci
+ fmt
+ vet
pkg/rpc/mux/reverse_proxy_test.go:153: using resp before checking for errors
pkg/rpc/mux/server_test.go:56: using resp before checking for errors
exit status 1
Makefile:93: recipe for target 'vet' failed
make: *** [vet] Error 1
```
After merging this, I will update circleCI go version as each major Go release obsoletes and ends support for the previous one.

Signed-off-by: Ubuntu <ubuntu@ip-172-31-19-41.ap-northeast-1.compute.internal>