### PR TITLE
Fix docs; make CLI not break when included files are missing

### DIFF
--- a/docs/playbooks/README.md
+++ b/docs/playbooks/README.md
@@ -6,6 +6,7 @@ If you don't have infrakit or go compiler installed locally, just
 ```shell
 
 docker run --rm -e GOARCH=amd64 -e GOOS=darwin -v `pwd`:/build infrakit/installer build-infrakit
+cp ./infrakit /usr/local/bin
 ```
 
 This will cross-compile the `infrakit` cli for Mac OSX.  For Linux, there's no need to set the `GOOS` and `GOARCH`
@@ -46,12 +47,19 @@ Usage:
 Available Commands:
   aws            aws
   darwin         darwin
-  do             do
+  digitalocean   do
   events         events
   gcp            gcp
   start-infrakit start-infrakit
   stop-infrakit  stop-infrakit
 ```
+
+## Prerequisites:
+
+This tutorial uses Digitial Ocean.  Be sure you have the API token; you will be prompted to provide it
+if you don't provide it in the command line flag.  You can also authenticate via the `doctl` tool and thus
+have a `~/.config/doctl/config.yaml` file which has the access token.
+
 
 ## Start up Infrakit controller daemons and plugins
 
@@ -87,10 +95,10 @@ Now you can connect to Infrakit at localhost:24864 via the `-H` option:
 
 ## Provision an Instance
 
-There's a `do` sub-command, for Digital Ocean.  It has the following command available:
+There's a `digitalocean` sub-command, for Digital Ocean.  It has the following command available:
 
 ```shell
-$ infrakit -H localhost:24864 playbook intro do -h
+$ infrakit -H localhost:24864 playbook intro digitialocean -h
 
 
 ___  ________   ________ ________  ________  ___  __    ___  _________
@@ -105,7 +113,7 @@ ___  ________   ________ ________  ________  ___  __    ___  _________
 do
 
 Usage:
-  infrakit playbook intro do [command]
+  infrakit playbook intro digitalocean [command]
 
 Available Commands:
   provision-instance provision-instance
@@ -118,7 +126,7 @@ Now provision.  Use flags or follow the prompts:
 
 ```shell
 
-$ infrakit -H localhost:24864 playbook intro do provision-instance
+$ infrakit -H localhost:24864 playbook intro digitialocean provision-instance
 Owner? [davidchung]:
 Region? [sfo1]:
 Image to boot? [ubuntu-16-10-x64]:
@@ -243,16 +251,16 @@ destroyed 47604302
 
 ## Manage a Scale Group
 
-The Digital Ocean playbook `do` also has a function to create a scale group of nodes:
+The Digital Ocean playbook `digitalocean` also has a function to create a scale group of nodes:
 
 ```shell
 
-$ infrakit -H localhost:24864 playbook intro do scale-group -h
+$ infrakit -H localhost:24864 playbook intro digitialocean scale-group -h
 
 scale-group
 
 Usage:
-  infrakit playbook intro do scale-group [flags]
+  infrakit playbook intro digitialocean scale-group [flags]
 
 Flags:
       --group-name string      Name of group
@@ -269,7 +277,7 @@ You can use flags or follow along:
 
 ```shell
 
-$ infrakit -H localhost:24864 playbook intro do scale-group
+$ infrakit -H localhost:24864 playbook intro digitialocean scale-group
 How many nodes? [2]: 3
 Name of the group? [mygroup]:
 Region? [sfo1]:

--- a/docs/playbooks/intro/do/provision-instance.ikt
+++ b/docs/playbooks/intro/do/provision-instance.ikt
@@ -5,10 +5,8 @@
 {{ $region := flag "region" "string" "DO region" | prompt "Region?" "string" "sfo1" }}
 {{ $image := flag "image-id" "string" "Image  ID" | prompt "Image to boot?" "string" "ubuntu-16-10-x64" }}
 {{ $instanceSize := flag "instance-size" "string" "Instance size" | prompt "Instance size?" "string" "1gb"}}
-{{ $privateIP := flag "private-ip" "string" "Private IP" | prompt "Private IP address (IPv4)?" "string" "" }}
 {{ $sshKey := flag "ssh-key" "string" "SSH key to use" | prompt "SSH key to use?" "string" "" }}
 
-LogicalID : {{ $privateIP }}
 Tags:
   infrakit.created: {{ now | htmlDate }}
   infrakit.user: {{ $user }}

--- a/docs/playbooks/intro/do/start-plugin.ikt
+++ b/docs/playbooks/intro/do/start-plugin.ikt
@@ -5,7 +5,7 @@
 {{ $do := flag "start-do" "bool" "Start Digital Ocean plugin" | prompt "Start Digital Ocean plugin?" "bool" "no" }}
 
 {{ $defaultConfig := cat "file://" (env "HOME") "/.config/doctl/config.yaml" | nospace }}
-{{ $defaultAccessToken := source $defaultConfig | yamlDecode | k "access-token" }}
+{{ $defaultAccessToken := include $defaultConfig | yamlDecode | k "access-token" }}
 
 {{ $accessToken := flag "access-token" "string" "Access token" | prompt "Access token?" "string" $defaultAccessToken }}
 {{ $project := var "/project" }} {{/*flag "project" "string" "Project name" | prompt "What's the name of the project?" "string" "mytest" */}}

--- a/docs/playbooks/intro/index.ikb
+++ b/docs/playbooks/intro/index.ikb
@@ -13,4 +13,4 @@ events         : events/index.ikb
 aws : aws/index.ikb
 gcp : gcp/index.ikb
 darwin : darwin/index.ikb
-do : do/index.ikb
+digitalocean : do/index.ikb

--- a/pkg/cli/context.go
+++ b/pkg/cli/context.go
@@ -255,7 +255,9 @@ func (c *Context) Funcs() []template.Function {
 			Name: "include",
 			Func: func(p string, opt ...interface{}) (string, error) {
 				if c.exec {
-					return c.template.Include(p, opt...)
+					if content, err := c.template.Include(p, opt...); err == nil {
+						return content, nil
+					}
 				}
 				return "{}", nil
 			},

--- a/pkg/template/template.go
+++ b/pkg/template/template.go
@@ -64,7 +64,13 @@ type Options struct {
 	// CustomizeFetch allows setting of http request header, etc. during fetch
 	CustomizeFetch func(*http.Request)
 
+	// Stderr is a function that returns stream to use for stderr
 	Stderr func() io.Writer
+
+	// MultiPass can affect the behavior of some functions like `var` where
+	// evaluation of the function return different results based on whether the
+	// template is meant to be evaluated in multiple passes.
+	MultiPass bool
 }
 
 // Template is the templating engine
@@ -77,8 +83,7 @@ type Template struct {
 	functions []func() []Function
 	funcs     map[string]interface{}
 	globals   map[string]interface{}
-	//	defaults  map[string]defaultValue
-	context interface{}
+	context   interface{}
 
 	registered []Function
 	lock       sync.Mutex
@@ -197,7 +202,39 @@ func (t *Template) Global(name string, value interface{}) *Template {
 }
 
 // Var implements the var function. It's a combination of global and ref
+// Note that the behavior of the var function depends on whether the template is used
+// in multiple passes where some var cannot be resolved to values in the first pass.
+// In this case, if the MultiplePass flag is set, the var function will just echo back
+// the same template expression in case of no value.
 func (t *Template) Var(name string, optional ...interface{}) interface{} {
+	base := t.doVar(name, optional...)
+
+	if !t.options.MultiPass {
+		return base
+	}
+
+	if base != nil {
+		return base
+	}
+
+	dl := t.options.DelimLeft
+	dr := t.options.DelimRight
+	if dl == "" {
+		dl = "{{"
+	}
+	if dr == "" {
+		dr = "}}"
+	}
+	// Handling of optional parameter isn't possible here because by now the
+	// template engine has already done the variable expansions and we have full values.
+	// Cases like {{ var "my-var" $defaultValue }} will render to {{ var "my-var" }}.
+	// Also this will not work in the case of pipeline - like {{ $x | var "my-var" }} --
+	// which will just render to {{ var "my-var }}
+	return fmt.Sprintf("%s var \"%s\" %s", dl, name, dr)
+}
+
+// var implements the var function. It's a combination of global and ref
+func (t *Template) doVar(name string, optional ...interface{}) interface{} {
 	if len(optional) == 0 {
 		return t.Ref(name)
 	}


### PR DESCRIPTION
This PR fixes a few bugs related to the docs to make it easier to follow in the Digital Ocean case.
Other changes
  + template function support for multi-pass evaluation

Signed-off-by: David Chung <david.chung@docker.com>