### PR TITLE
Fix template multipass for group commit

### DIFF
--- a/cmd/infrakit/base/template.go
+++ b/cmd/infrakit/base/template.go
@@ -116,7 +116,7 @@ func TemplateProcessor(plugins func() discovery.Plugins) (*pflag.FlagSet, ToJSON
 			}
 
 			log.Debug("reading template", "url", url)
-			engine, err := template.NewTemplate(url, template.Options{})
+			engine, err := template.NewTemplate(url, template.Options{MultiPass: true})
 			if err != nil {
 				return
 			}

--- a/pkg/template/template.go
+++ b/pkg/template/template.go
@@ -227,10 +227,10 @@ func (t *Template) Var(name string, optional ...interface{}) interface{} {
 	}
 	// Handling of optional parameter isn't possible here because by now the
 	// template engine has already done the variable expansions and we have full values.
-	// Cases like {{ var "my-var" $defaultValue }} will render to {{ var "my-var" }}.
+	// Cases like {{ var "my-var" $defaultValue }} will render to {{ var `my-var` }}.
 	// Also this will not work in the case of pipeline - like {{ $x | var "my-var" }} --
-	// which will just render to {{ var "my-var }}
-	return fmt.Sprintf("%s var \"%s\" %s", dl, name, dr)
+	// which will just render to {{ var `my-var` }}
+	return fmt.Sprintf("%s var `%s` %s", dl, name, dr)
 }
 
 // var implements the var function. It's a combination of global and ref

--- a/pkg/template/template_test.go
+++ b/pkg/template/template_test.go
@@ -133,7 +133,7 @@ func TestVarAndGlobalMultiPass(t *testing.T) {
   "LA"
 ],
   "sf_zip" : "94109",
-  "second_stage" : {{ var "second-stage" }}
+  "second_stage" : {{ var ` + "`second-stage`" + ` }}
 }
 `
 	require.Equal(t, expected, view)


### PR DESCRIPTION
The json passed to the group commit goes through the templating flow when it is first loaded. This first pass needs to have the "multipass" support so that additional templating can be completed downstream by other plugins when additional data is available.

Also, when multipass is enabled, the escape sequence to render the original var is incorrect. It needs to be a back-tic vs. an escaped quote.

Closes #515

Signed-off-by: Steven Kaufer <kaufer@us.ibm.com>