### PR TITLE
Fix user data base64 merging in the terraform plugin

### DIFF
--- a/examples/instance/terraform/plugin.go
+++ b/examples/instance/terraform/plugin.go
@@ -407,7 +407,8 @@ func (p *plugin) Provision(spec instance.Spec) (*instance.ID, error) {
 	// merge the inits
 	switch vmType {
 	case VMAmazon, VMDigitalOcean:
-		addUserData(properties, "user_data", base64.StdEncoding.EncodeToString([]byte(spec.Init)))
+		addUserData(properties, "user_data", spec.Init)
+		properties["user_data"] = base64.StdEncoding.EncodeToString([]byte(properties["user_data"].(string)))
 	case VMSoftLayer:
 		addUserData(properties, "user_metadata", spec.Init)
 	case VMAzure:

--- a/examples/instance/terraform/plugin_test.go
+++ b/examples/instance/terraform/plugin_test.go
@@ -19,129 +19,129 @@ func TestUsage(t *testing.T) {
 	// Test a softlayer_virtual_guest with an @hostname_prefix
 	run(t, "softlayer_virtual_guest", `
 {
-  "resource" : {
-    "softlayer_virtual_guest": {
-      "host" : {
-          "@hostname_prefix": "softlayer-hostname",
-          "cores": 2,
-          "memory": 2048,
-          "tags": [
-            "terraform_demo_swarm_mgr_sl"
-          ],
-          "connection": {
-            "user": "root",
-            "private_key": "${file(\"~/.ssh/id_rsa_de\")}"
-          },
-          "hourly_billing": true,
-          "local_disk": true,
-          "network_speed": 100,
-          "datacenter": "dal10",
-          "os_reference_code": "UBUNTU_14_64",
-          "domain": "softlayer.com",
-          "ssh_key_ids": [
-            "${data.softlayer_ssh_key.public_key.id}"
-          ]
-        }
-    }
-  }
+	"resource" : {
+		"softlayer_virtual_guest": {
+			"host" : {
+				"@hostname_prefix": "softlayer-hostname",
+				"cores": 2,
+				"memory": 2048,
+				"tags": [
+					"terraform_demo_swarm_mgr_sl"
+				],
+				"connection": {
+					"user": "root",
+					"private_key": "${file(\"~/.ssh/id_rsa_de\")}"
+				},
+				"hourly_billing": true,
+				"local_disk": true,
+				"network_speed": 100,
+				"datacenter": "dal10",
+				"os_reference_code": "UBUNTU_14_64",
+				"domain": "softlayer.com",
+				"ssh_key_ids": [
+					"${data.softlayer_ssh_key.public_key.id}"
+				]
+			}
+		}
+	}
 }
 `)
 
 	// Test a softlayer_virtual_guest without an @hostname_prefix
 	run(t, "softlayer_virtual_guest", `
 {
-  "resource" : {
-    "ibmcloud_infra_file_storage": {
-      "csy_test_file_storage1": {
-        "iops" : 0.25,
-        "type" : "Endurance",
-        "datacenter" : "dal10",
-        "capacity" : 20
-      }
-    },
-    "softlayer_virtual_guest" : {
-       "host" : {
-	  "cores": 2,
-	  "memory": 2048,
-	  "tags": [ "terraform_demo_swarm_mgr_sl" ],
-	  "connection": {
-	     "user": "root",
-	     "private_key": "${file(\"~/.ssh/id_rsa_de\")}"
-	     },
-	  "hourly_billing": true,
-	  "local_disk": true,
-	  "network_speed": 100,
-	  "datacenter": "dal10",
-	  "os_reference_code": "UBUNTU_14_64",
-	  "domain": "softlayer.com",
-	  "ssh_key_ids": [ "${data.softlayer_ssh_key.public_key.id}" ]
-       }
-    }
-  }
+	"resource" : {
+		"ibmcloud_infra_file_storage": {
+			"csy_test_file_storage1": {
+				"iops" : 0.25,
+				"type" : "Endurance",
+				"datacenter" : "dal10",
+				"capacity" : 20
+			}
+		},
+		"softlayer_virtual_guest" : {
+			"host": {
+				"cores": 2,
+				"memory": 2048,
+				"tags": [ "terraform_demo_swarm_mgr_sl" ],
+				"connection": {
+					"user": "root",
+					"private_key": "${file(\"~/.ssh/id_rsa_de\")}"
+				},
+				"hourly_billing": true,
+				"local_disk": true,
+				"network_speed": 100,
+				"datacenter": "dal10",
+				"os_reference_code": "UBUNTU_14_64",
+				"domain": "softlayer.com",
+				"ssh_key_ids": [ "${data.softlayer_ssh_key.public_key.id}" ]
+			}
+		}
+	}
 }
 `)
 
 	// Test a softlayer_virtual_guest with an empty @hostname_prefix
 	run(t, "softlayer_virtual_guest", `
 {
-  "resource" : {
-    "softlayer_virtual_guest" : {
-      "host" : {
-			"@hostname_prefix": "   ",
-			"cores": 2,
-			"memory": 2048,
-			"tags": [
-				"terraform_demo_swarm_mgr_sl"
-			],
-			"connection": {
-				"user": "root",
-				"private_key": "${file(\"~/.ssh/id_rsa_de\")}"
-			},
-			"hourly_billing": true,
-			"local_disk": true,
-			"network_speed": 100,
-			"datacenter": "dal10",
-			"os_reference_code": "UBUNTU_14_64",
-			"domain": "softlayer.com",
-			"ssh_key_ids": [
-				"${data.softlayer_ssh_key.public_key.id}"
-			]
+	"resource" : {
+		"softlayer_virtual_guest" : {
+			"host" : {
+				"@hostname_prefix": "   ",
+				"cores": 2,
+				"memory": 2048,
+				"tags": [
+					"terraform_demo_swarm_mgr_sl"
+				],
+				"connection": {
+					"user": "root",
+					"private_key": "${file(\"~/.ssh/id_rsa_de\")}"
+				},
+				"hourly_billing": true,
+				"local_disk": true,
+				"network_speed": 100,
+				"datacenter": "dal10",
+				"os_reference_code": "UBUNTU_14_64",
+				"domain": "softlayer.com",
+				"ssh_key_ids": [
+					"${data.softlayer_ssh_key.public_key.id}"
+				]
+			}
 		}
-    }
-  }
+	}
 }
 `)
 
 	run(t, "aws_instance", `
 {
-  "resource" : {
-    "aws_instance" : {
-      "host" : {
-         "ami" : "${lookup(var.aws_amis, var.aws_region)}",
-         "instance_type" : "m1.small",
-         "key_name": "PUBKEY",
-         "vpc_security_group_ids" : ["${aws_security_group.default.id}"],
-         "subnet_id": "${aws_subnet.default.id}",
-         "private_ip": "INSTANCE_LOGICAL_ID",
-         "tags" :  {
-             "Name" : "web4",
-             "InstancePlugin" : "terraform"
-         },
-         "connection" : {
-             "user" : "ubuntu"
-         },
-         "provisioner" : {
-             "remote_exec" : {
-                 "inline" : [
-                     "sudo apt-get -y update",
-                     "sudo apt-get -y install nginx",
-                     "sudo service nginx start"
-                 ]
-             }
-         }
-      }
-    }
-  }
+	"resource" : {
+		"aws_instance" : {
+			"host" : {
+				"ami" : "${lookup(var.aws_amis, var.aws_region)}",
+				"instance_type" : "m1.small",
+				"key_name": "PUBKEY",
+				"vpc_security_group_ids" : ["${aws_security_group.default.id}"],
+				"subnet_id": "${aws_subnet.default.id}",
+				"private_ip": "INSTANCE_LOGICAL_ID",
+				"tags" :  {
+					"Name" : "web4",
+					"InstancePlugin" : "terraform"
+				},
+				"connection" : {
+					"user" : "ubuntu"
+				},
+				"provisioner" : {
+					"remote_exec" : {
+						"inline" : [
+							"sudo apt-get -y update",
+							"sudo apt-get -y install nginx",
+							"sudo service nginx start"
+						]
+					}
+				}
+			}
+		}
+	}
 }
 `)
 }


### PR DESCRIPTION
User data in the resource definition needs to be base64 encoded with the spec's init script data. Currently, the non-encoded data is merged with encoded spec init data.

Closes #518

Signed-off-by: Steven Kaufer <kaufer@us.ibm.com>