### PR TITLE
Add dynamic instance ID templating to terraform instance

### DIFF
--- a/examples/flavor/swarm/main.go
+++ b/examples/flavor/swarm/main.go
@@ -24,7 +24,7 @@ func init() {
 		})
 }
 
-var defaultTemplateOptions = template.Options{}
+var defaultTemplateOptions = template.Options{MultiPass: true}
 
 func main() {
 

--- a/examples/instance/terraform/plugin.go
+++ b/examples/instance/terraform/plugin.go
@@ -16,6 +16,7 @@ import (
 	log "github.com/Sirupsen/logrus"
 	"github.com/deckarep/golang-set"
 	"github.com/docker/infrakit/pkg/spi/instance"
+	"github.com/docker/infrakit/pkg/template"
 	"github.com/docker/infrakit/pkg/types"
 	"github.com/nightlyone/lockfile"
 	"github.com/spf13/afero"
@@ -317,14 +318,37 @@ func (p *plugin) optionalProcessHostname(vmType TResourceType, name TResourceNam
 	log.Debugln("Adding hostname to properties: hostname=", properties["hostname"])
 }
 
+// renderInstIdVar applies the "/self/instId" as a global option and renders
+// the given string
+func renderInstIDVar(data string, id instance.ID) (string, error) {
+	t, _ := template.NewTemplate("str://"+data, template.Options{})
+	return t.Global("/self/instId", id).Render(nil)
+}
+
 // Provision creates a new instance based on the spec.
 func (p *plugin) Provision(spec instance.Spec) (*instance.ID, error) {
 
 	// Because the format of the spec.Properties is simply the same tf.json
 	// we simply look for vm instance and merge in the tags, and user init, etc.
 
+	// use timestamp as instance id
+	name := p.ensureUniqueFile()
+	id := instance.ID(name)
+
+	// Template the {{ var "/self/instId" }} var in both the Properties and the Init
+	rendered, err := renderInstIDVar(spec.Properties.String(), id)
+	if err != nil {
+		return nil, err
+	}
+	spec.Properties = types.AnyBytes([]byte(rendered))
+	rendered, err = renderInstIDVar(spec.Init, id)
+	if err != nil {
+		return nil, err
+	}
+	spec.Init = rendered
+
 	tf := TFormat{}
-	err := spec.Properties.Decode(&tf)
+	err = spec.Properties.Decode(&tf)
 	if err != nil {
 		return nil, err
 	}
@@ -337,11 +361,6 @@ func (p *plugin) Provision(spec instance.Spec) (*instance.ID, error) {
 	if properties == nil {
 		return nil, fmt.Errorf("no-vm-instance-in-spec")
 	}
-
-	// use timestamp as instance id
-	name := p.ensureUniqueFile()
-
-	id := instance.ID(name)
 
 	// set the tags.
 	// add a name

--- a/examples/instance/terraform/plugin_test.go
+++ b/examples/instance/terraform/plugin_test.go
@@ -41,7 +41,7 @@ func TestUsage(t *testing.T) {
 				"ssh_key_ids": [
 					"${data.softlayer_ssh_key.public_key.id}"
 				],
-				"user_metadata": "ls"
+				"user_metadata": "echo {{ var `+"`/self/instId`"+` }}"
 			}
 		}
 	}
@@ -76,7 +76,7 @@ func TestUsage(t *testing.T) {
 				"os_reference_code": "UBUNTU_14_64",
 				"domain": "softlayer.com",
 				"ssh_key_ids": [ "${data.softlayer_ssh_key.public_key.id}" ],
-				"user_metadata": "ls"
+				"user_metadata": "echo {{ var `+"`/self/instId`"+` }}"
 			}
 		}
 	}
@@ -108,7 +108,7 @@ func TestUsage(t *testing.T) {
 				"ssh_key_ids": [
 					"${data.softlayer_ssh_key.public_key.id}"
 				],
-				"user_metadata": "ls"
+				"user_metadata": "echo {{ var `+"`/self/instId`"+` }}"
 			}
 		}
 	}
@@ -133,7 +133,7 @@ func TestUsage(t *testing.T) {
 				"connection" : {
 					"user" : "ubuntu"
 				},
-				"user_data": "ls",
+				"user_data": "echo {{ var `+"`/self/instId`"+` }}",
 				"provisioner" : {
 					"remote_exec" : {
 						"inline" : [
@@ -228,9 +228,9 @@ func run(t *testing.T, resourceType, properties string) {
 	_, v := firstInMap(vms.(map[string]interface{}))
 	value, _ := v.(map[string]interface{})
 
-	// Userdata should have the resource defined data (ie, "ls") with
+	// Userdata should have the resource defined data (ie, echo <instId>) with
 	// the spec init data appended
-	expectedUserData2 := "ls\n" + instanceSpec2.Init
+	expectedUserData2 := "echo " + string(*id2) + "\n" + instanceSpec2.Init
 
 	switch vmType {
 	case VMSoftLayer:


### PR DESCRIPTION
Adds support to make the dynamic terraform instance ID template-able in the groups.json file. For example, if the instance was named instance-1493145652 then the `{{ var "/self/instId" }}` should resolve to 1493145652 in the groups definition. This allows us to reference the dynamic instance ID in the group definition.

Additionally, the same variable reference can be used in the swarm flavor's `InitScriptTemplateURL` boot scripts.

Signed-off-by: Steven Kaufer <kaufer@us.ibm.com>