### PR TITLE
Change terminology; change class-> kind

### DIFF
--- a/pkg/core/depend.go
+++ b/pkg/core/depend.go
@@ -129,8 +129,8 @@ func nested(s *types.Spec) []*types.Spec {
 }
 
 type key struct {
-	class string
-	name  string
+	kind string
+	name string
 }
 
 func indexSpecs(specs []*types.Spec, g *graph.Graph) map[key]*graph.Node {
@@ -140,13 +140,13 @@ func indexSpecs(specs []*types.Spec, g *graph.Graph) map[key]*graph.Node {
 		node := g.MakeNode()
 		*(node.Value) = spec
 
-		index[key{class: spec.Class, name: spec.Metadata.Name}] = &node
+		index[key{kind: spec.Kind, name: spec.Metadata.Name}] = &node
 	}
 	return index
 }
 
-func indexGet(index map[key]*graph.Node, class, name string) *graph.Node {
-	if v, has := index[key{class: class, name: name}]; has {
+func indexGet(index map[key]*graph.Node, kind, name string) *graph.Node {
+	if v, has := index[key{kind: kind, name: name}]; has {
 		return v
 	}
 	return nil
@@ -175,14 +175,14 @@ func OrderByDependency(specs []*types.Spec) ([]*types.Spec, error) {
 
 	for _, spec := range specs {
 
-		from := indexGet(index, spec.Class, spec.Metadata.Name)
+		from := indexGet(index, spec.Kind, spec.Metadata.Name)
 		if from == nil {
-			return nil, errNotFound{class: spec.Class, name: spec.Metadata.Name}
+			return nil, errNotFound{kind: spec.Kind, name: spec.Metadata.Name}
 		}
 
 		for _, depend := range spec.Depends {
 
-			to := indexGet(index, depend.Class, depend.Name)
+			to := indexGet(index, depend.Kind, depend.Name)
 			if to == nil {
 				return nil, errBadDependency(depend)
 			}

--- a/pkg/core/depend_test.go
+++ b/pkg/core/depend_test.go
@@ -14,7 +14,7 @@ import (
 func TestFindSpecs0(t *testing.T) {
 
 	spec := `
-class:        top
+kind:        top
 spiVersion:   top-version
 metadata:
   name: top
@@ -26,7 +26,7 @@ properties:
 
 	found := []string{}
 	for _, f := range findSpecs(s) {
-		found = append(found, f.Class)
+		found = append(found, f.Kind)
 	}
 
 	T(100).Infoln("list=", found)
@@ -37,17 +37,17 @@ properties:
 func TestFindSpecs1(t *testing.T) {
 
 	spec := `
-class:        top
+kind:        top
 spiVersion:   top-version
 metadata:
   name: top
 properties:
-  class: nest1
+  kind: nest1
   spiVersion: nest1-version
   metadata:
     name: nest1
   properties:
-    class: nest2
+    kind: nest2
     spiVersion: nest2-version
     metadata:
       name: nest2
@@ -57,7 +57,7 @@ properties:
 
 	found := []string{}
 	for _, f := range findSpecs(s) {
-		found = append(found, f.Class)
+		found = append(found, f.Kind)
 	}
 
 	T(100).Infoln("list=", found)
@@ -68,28 +68,28 @@ properties:
 func TestFindSpecs2(t *testing.T) {
 
 	spec := `
-class:        top
+kind:        top
 spiVersion:   top-version
 metadata:
   name: top
 properties:
   instance:
-    class: nest1
+    kind: nest1
     spiVersion: nest1-version
     metadata:
       name: nest1
     properties:
-      class: nest2
+      kind: nest2
       spiVersion: nest2-version
       metadata:
         name: nest2
   flavor:
-    class: nest3
+    kind: nest3
     spiVersion: nest3-version
     metadata:
       name: nest3
     properties:
-      class: nest4
+      kind: nest4
       spiVersion: nest4-version
       metadata:
         name: nest4
@@ -99,7 +99,7 @@ properties:
 
 	found := []string{}
 	for _, f := range findSpecs(s) {
-		found = append(found, f.Class)
+		found = append(found, f.Kind)
 	}
 
 	T(100).Infoln("list=", found)
@@ -110,41 +110,41 @@ properties:
 func TestFindSpecs3(t *testing.T) {
 
 	spec := `
-class:        top
+kind:        top
 spiVersion:   top-version
 metadata:
   name: top
 properties:
   instance:
-    class: nest1
+    kind: nest1
     spiVersion: nest1-version
     metadata:
       name: nest1
     properties:
-      class: nest2
+      kind: nest2
       spiVersion: nest2-version
       metadata:
         name: nest2
       properties:
-        - class: nest5
+        - kind: nest5
           spiVersion: nest5-version
           metadata:
             name: nest5
-        - class: nest6
+        - kind: nest6
           spiVersion: nest6-version
           metadata:
             name: nest6
-        - class: nest7
+        - kind: nest7
           spiVersion: nest7-version
           metadata:
             name: nest7
   flavor:
-    class: nest3
+    kind: nest3
     spiVersion: nest3-version
     metadata:
       name: nest3
     properties:
-      class: nest4
+      kind: nest4
       spiVersion: nest4-version
       metadata:
         name: nest4
@@ -154,7 +154,7 @@ properties:
 
 	found := []string{}
 	for _, f := range findSpecs(s) {
-		found = append(found, f.Class)
+		found = append(found, f.Kind)
 	}
 
 	T(100).Infoln("list=", found)
@@ -190,18 +190,18 @@ func testDependency(t *testing.T, input string, expFound, expOrdered []string) {
 func TestDepedencyOrder1(t *testing.T) {
 
 	testDependency(t, `
-- class:        top1C
+- kind:        top1C
   spiVersion:   top1-version
   metadata:
     name: top1N
   properties:
     instance:
-      class: nest1C
+      kind: nest1C
       spiVersion: nest1-version
       metadata:
         name: nest1N
       properties:
-        class: nest2C
+        kind: nest2C
         spiVersion: nest2-version
         metadata:
           name: nest2N
@@ -209,30 +209,30 @@ func TestDepedencyOrder1(t *testing.T) {
           nest2Prop1: nest2Val1
           nest2Prop2: nest2Val2
     flavor:
-      class: nest3C
+      kind: nest3C
       spiVersion: nest3-version
       metadata:
         name: nest3N
-- class:        top2C
+- kind:        top2C
   spiVersion:   top2-version
   metadata:
     name: top2N
   depends:
-    - class: top1C
+    - kind: top1C
       name: top1N
-- class:        top3C
+- kind:        top3C
   spiVersion:   top3-version
   metadata:
     name: top3N
   depends:
-    - class: top2C
+    - kind: top2C
       name: top2N
-- class:        top4C
+- kind:        top4C
   spiVersion:   top4-version
   metadata:
     name: top4N
   depends:
-    - class: top3C
+    - kind: top3C
       name: top3N
 `,
 		[]string{"nest1N", "nest2N", "nest3N", "top1N", "top2N", "top3N", "top4N"},
@@ -240,26 +240,26 @@ func TestDepedencyOrder1(t *testing.T) {
 	)
 
 	testDependency(t, `
-- class:        top1C
+- kind:        top1C
   spiVersion:   top1-version
   metadata:
     name: top1N
   properties:
-- class:        top2C
+- kind:        top2C
   spiVersion:   top2-version
   metadata:
     name: top2N
   depends:
-    - class: top3C
+    - kind: top3C
       name: top3N
-- class:        top3C
+- kind:        top3C
   spiVersion:   top3-version
   metadata:
     name: top3N
   depends:
-    - class: top4C
+    - kind: top4C
       name: top4N
-- class:        top4C
+- kind:        top4C
   spiVersion:   top4-version
   metadata:
     name: top4N
@@ -269,31 +269,31 @@ func TestDepedencyOrder1(t *testing.T) {
 	)
 
 	testDependency(t, `
-- class:        top1C
+- kind:        top1C
   spiVersion:   top1-version
   metadata:
     name: top1N
   properties:
-- class:        top2C
+- kind:        top2C
   spiVersion:   top2-version
   metadata:
     name: top2N
   depends:
-    - class: top1C
+    - kind: top1C
       name: top1N
-- class:        top3C
+- kind:        top3C
   spiVersion:   top3-version
   metadata:
     name: top3N
   depends:
-    - class: top1C
+    - kind: top1C
       name: top1N
-- class:        top4C
+- kind:        top4C
   spiVersion:   top4-version
   metadata:
     name: top4N
   depends:
-    - class: top1C
+    - kind: top1C
       name: top1N
 `,
 		[]string{"top1N", "top2N", "top3N", "top4N"},
@@ -301,64 +301,64 @@ func TestDepedencyOrder1(t *testing.T) {
 	)
 
 	testDependency(t, `
-- class:        pool
+- kind:        pool
   spiVersion:   poolVersion
   metadata:
     name: pool1
   properties:
     instance:
-      class: ebs
+      kind: ebs
       spiVersion: ebsVersion
       metadata:
         name: ebs1
 
-- class:        pool
+- kind:        pool
   spiVersion:   poolVersion
   metadata:
     name: pool2
   properties:
     instance:
-      class: ebs
+      kind: ebs
       spiVersion: ebsVersion
       metadata:
         name: ebs2
 
-- class:        group
+- kind:        group
   spiVersion:   groupVersion
   metadata:
     name: managers
   properties:
     instance:
-       class : instance
+       kind : instance
        spiVersion: instanceVersion
        metadata:
           name: instance-managers
     flavor:
-       class : flavor
+       kind : flavor
        spiVersion: flavorVersion
        metadata:
           name: flavor-swarm-manager
   depends:
-    - class: pool
+    - kind: pool
       name: pool1
 
-- class:        group
+- kind:        group
   spiVersion:   groupVersion
   metadata:
     name: workers
   properties:
     instance:
-       class : instance
+       kind : instance
        spiVersion: instanceVersion
        metadata:
           name: instance-workers
     flavor:
-       class : flavor
+       kind : flavor
        spiVersion: flavorVersion
        metadata:
           name: flavor-swarm-worker
   depends:
-    - class: pool
+    - kind: pool
       name: pool2
 `,
 		[]string{
@@ -405,18 +405,18 @@ func testDependencyCycles(t *testing.T, input string, expFound []string) {
 func TestDepedencyOrder2Cycles(t *testing.T) {
 
 	testDependencyCycles(t, `
-- class:        top1C
+- kind:        top1C
   spiVersion:   top1-version
   metadata:
     name: top1N
   properties:
     instance:
-      class: nest1C
+      kind: nest1C
       spiVersion: nest1-version
       metadata:
         name: nest1N
       properties:
-        class: nest2C
+        kind: nest2C
         spiVersion: nest2-version
         metadata:
           name: nest2N
@@ -424,32 +424,32 @@ func TestDepedencyOrder2Cycles(t *testing.T) {
           nest2Prop1: nest2Val1
           nest2Prop2: nest2Val2
     flavor:
-      class: nest3C
+      kind: nest3C
       spiVersion: nest3-version
       metadata:
         name: nest3N
-- class:        top2C
+- kind:        top2C
   spiVersion:   top2-version
   metadata:
     name: top2N
   depends:
-    - class: top1C
+    - kind: top1C
       name: top1N
-- class:        top3C
+- kind:        top3C
   spiVersion:   top3-version
   metadata:
     name: top3N
   depends:
-    - class: top2C
+    - kind: top2C
       name: top2N
-    - class: top4C
+    - kind: top4C
       name: top4N
-- class:        top4C
+- kind:        top4C
   spiVersion:   top4-version
   metadata:
     name: top4N
   depends:
-    - class: top3C
+    - kind: top3C
       name: top3N
 `,
 		[]string{"nest1N", "nest2N", "nest3N", "top1N", "top2N", "top3N", "top4N"},

--- a/pkg/core/error.go
+++ b/pkg/core/error.go
@@ -9,25 +9,25 @@ import (
 type errBadDependency types.Dependency
 
 func (e errBadDependency) Error() string {
-	return fmt.Sprintf("unresolved dependency: class=%s name=%s", types.Dependency(e).Class, types.Dependency(e).Name)
+	return fmt.Sprintf("unresolved dependency: kind=%s name=%s", types.Dependency(e).Kind, types.Dependency(e).Name)
 }
 
 type errCircularDependency []*types.Spec
 
 func (e errCircularDependency) Error() string {
 	deps := []*types.Spec(e)
-	list := fmt.Sprintf("%s/%s", deps[0].Class, deps[0].Metadata.Name)
+	list := fmt.Sprintf("%s/%s", deps[0].Kind, deps[0].Metadata.Name)
 	for _, dep := range deps[1:] {
-		list = list + fmt.Sprintf("=> %s/%s", dep.Class, dep.Metadata.Name)
+		list = list + fmt.Sprintf("=> %s/%s", dep.Kind, dep.Metadata.Name)
 	}
 	return fmt.Sprintf("circular dependency: %s", list)
 }
 
 type errNotFound struct {
-	class string
-	name  string
+	kind string
+	name string
 }
 
 func (e errNotFound) Error() string {
-	return fmt.Sprintf("not found %s/%s", e.class, e.name)
+	return fmt.Sprintf("not found %s/%s", e.kind, e.name)
 }

--- a/pkg/core/object.go
+++ b/pkg/core/object.go
@@ -77,7 +77,7 @@ func resolveDepends(o *types.Object, objects Objects) (depends map[string]interf
 
 	for _, dep := range o.Depends {
 
-		otherObject := objects.FindBy(dep.Class, dep.Name)
+		otherObject := objects.FindBy(dep.Kind, dep.Name)
 		if otherObject == nil {
 			err = fmt.Errorf("unresolved dependency: %v", dep)
 			return

--- a/pkg/core/object_test.go
+++ b/pkg/core/object_test.go
@@ -14,7 +14,7 @@ import (
 func TestObject(t *testing.T) {
 
 	text := `
-- class:        instance-aws/ec2-instance
+- kind:        instance-aws/ec2-instance
   spiVersion:   instance/v0.1.0
   metadata:
     name: host1
@@ -30,13 +30,13 @@ func TestObject(t *testing.T) {
     region: us-west-1
     stack:  test
   depends:
-    - class: instance-aws/ec2-volume
+    - kind: instance-aws/ec2-volume
       name: disk1
       bind:
          volume/id : metadata/uid
          volume/size: properties/sizeGb
 
-- class:        instance-aws/ec2-volume
+- kind:        instance-aws/ec2-volume
   spiVersion:   instance/v0.1.0
   metadata:
     name: disk1
@@ -60,7 +60,7 @@ func TestObject(t *testing.T) {
 	require.Equal(t, 2, len(specs))
 
 	objects := NewObjects(func(o *types.Object) []interface{} {
-		return []interface{}{o.Spec.Class, o.Spec.Metadata.Name}
+		return []interface{}{o.Spec.Kind, o.Spec.Metadata.Name}
 	})
 
 	objects.Add(&types.Object{
@@ -77,7 +77,7 @@ func TestObject(t *testing.T) {
 	disk.Metadata.Identity = &types.Identity{UID: "disk-11234"}
 
 	host := objects.FindBy("instance-aws/ec2-volume", "host1")
-	require.Nil(t, host) // wrong class
+	require.Nil(t, host) // wrong kind
 
 	host = objects.FindBy("instance-aws/ec2-instance", "host1")
 	require.NotNil(t, host)
@@ -99,7 +99,7 @@ func TestObject(t *testing.T) {
 func TestObjectNested(t *testing.T) {
 
 	text := `
-- class:        group
+- kind:        group
   spiVersion:   group/v0.1.0
   metadata:
     name: managers
@@ -108,7 +108,7 @@ func TestObjectNested(t *testing.T) {
       project: test
   properties:
     instance:
-      class:        instance-aws/ec2-instance
+      kind:        instance-aws/ec2-instance
       spiVersion:   instance/v0.1.0
       metadata:
         name: manager-node
@@ -124,21 +124,21 @@ func TestObjectNested(t *testing.T) {
         region: us-west-1
         stack:  test
       depends:
-        - class: instance-aws/ec2-volume
+        - kind: instance-aws/ec2-volume
           name: disk1
           bind:
             disk1VolumeId : metadata/uid
-        - class: instance-aws/ec2-volume
+        - kind: instance-aws/ec2-volume
           name: disk2
           bind:
             disk2VolumeId : metadata/uid
-        - class: instance-aws/ec2-volume
+        - kind: instance-aws/ec2-volume
           name: disk3
           bind:
             disk3VolumeId : metadata/uid
 
     flavor:
-      class:        flavor-swarm/manager
+      kind:        flavor-swarm/manager
       spiVersion:   flavor/v0.1.0
       metadata:
         name: swarm-manager
@@ -149,7 +149,7 @@ func TestObjectNested(t *testing.T) {
       options:
           region: us-west-1
           stack:  test
-- class:        instance-aws/ec2-volume
+- kind:        instance-aws/ec2-volume
   spiVersion:   instance/v0.1.0
   metadata:
     name: disk1
@@ -163,7 +163,7 @@ func TestObjectNested(t *testing.T) {
   options:
     region: us-west-1
     stack:  test
-- class:        instance-aws/ec2-volume
+- kind:        instance-aws/ec2-volume
   spiVersion:   instance/v0.1.0
   metadata:
     name: disk2
@@ -177,7 +177,7 @@ func TestObjectNested(t *testing.T) {
   options:
     region: us-west-1
     stack:  test
-- class:        instance-aws/ec2-volume
+- kind:        instance-aws/ec2-volume
   spiVersion:   instance/v0.1.0
   metadata:
     name: disk3
@@ -201,7 +201,7 @@ func TestObjectNested(t *testing.T) {
 	require.Equal(t, 4, len(specs)) // nested
 
 	objects := NewObjects(func(o *types.Object) []interface{} {
-		return []interface{}{o.Spec.Class, o.Spec.Metadata.Name}
+		return []interface{}{o.Spec.Kind, o.Spec.Metadata.Name}
 	})
 
 	all := AllSpecs(specs) // all including nested

--- a/pkg/core/process.go
+++ b/pkg/core/process.go
@@ -76,7 +76,7 @@ func NewProcess(model ModelDefinition,
 
 	proc.Constructor = func(instance fsm.Instance) error {
 		if proc.ProcessDefinition.Constructor == nil {
-			return fmt.Errorf("no constructor %s %s", input.Spec.Class, input.Spec.Metadata.Name)
+			return fmt.Errorf("no constructor %s %s", input.Spec.Kind, input.Spec.Metadata.Name)
 		}
 
 		// create an instace and resolve dependencies to compute a full spec

--- a/pkg/core/process_test.go
+++ b/pkg/core/process_test.go
@@ -108,7 +108,7 @@ func TestRenderProperties(t *testing.T) {
 
 	// Case - no template, just properties. Note the escapes here.
 	testRenderProperties(t, `
-- class:        instance-aws/ec2-instance
+- kind:        instance-aws/ec2-instance
   spiVersion:   instance/v0.1.0
   metadata:
     name: host1
@@ -158,7 +158,7 @@ func TestRenderProperties(t *testing.T) {
 		})
 	// Case - has template.  No properties
 	testRenderProperties(t, `
-- class:        instance-aws/ec2-instance
+- kind:        instance-aws/ec2-instance
   spiVersion:   instance/v0.1.0
   metadata:
     name: host1
@@ -189,7 +189,7 @@ func TestRenderProperties(t *testing.T) {
 
 	// Case - has template, with properties override
 	testRenderProperties(t, `
-- class:        instance-aws/ec2-instance
+- kind:        instance-aws/ec2-instance
   spiVersion:   instance/v0.1.0
   metadata:
     name: host1
@@ -232,7 +232,7 @@ func query(t *testing.T, exp string, v interface{}) interface{} {
 func TestProcess(t *testing.T) {
 
 	text := `
-- class:        instance-aws/ec2-instance
+- kind:        instance-aws/ec2-instance
   spiVersion:   instance/v0.1.0
   metadata:
     name: workers
@@ -337,7 +337,7 @@ func TestProcess(t *testing.T) {
 	require.Equal(t, "m2-xlarge", types.Get(types.PathFromString("RunInstancesInput/InstanceType"), properties))
 
 	T(100).Infoln(spec)
-	require.Equal(t, "instance-aws/ec2-instance", types.Get(types.PathFromString("Class"), spec))
+	require.Equal(t, "instance-aws/ec2-instance", types.Get(types.PathFromString("Kind"), spec))
 
 	// we should have 1 instance in the available state
 	require.Equal(t, 1, proc.Instances().CountByState(available))

--- a/pkg/core/testdata/simple.yml
+++ b/pkg/core/testdata/simple.yml
@@ -1,4 +1,4 @@
-- class:        instance-aws/ec2-instance
+- kind:        instance-aws/ec2-instance
   spiVersion:   instance/v0.1.0
   metadata:
     name: host1
@@ -14,12 +14,12 @@
     region: us-west-1
     stack:  test
   depends:
-    - class: instance-aws/ec2-volume
+    - kind: instance-aws/ec2-volume
       name: disk1
       bind:
          volumeId : metadata/UID
 
-- class:        instance-aws/ec2-volume
+- kind:        instance-aws/ec2-volume
   spiVersion:   instance/v0.1.0
   metadata:
     name: disk1

--- a/pkg/types/object_test.go
+++ b/pkg/types/object_test.go
@@ -9,7 +9,7 @@ import (
 func TestObject(t *testing.T) {
 
 	text := `
-- class:        instance-aws/ec2-instance
+- kind:        instance-aws/ec2-instance
   spiVersion:   instance/v0.1.0
   metadata:
     name: host1
@@ -25,13 +25,13 @@ func TestObject(t *testing.T) {
     region: us-west-1
     stack:  test
   depends:
-    - class: instance-aws/ec2-volume
+    - kind: instance-aws/ec2-volume
       name: disk1
       bind:
          volume/id : metadata/UID
          volume/size: properties/sizeGb
 
-- class:        instance-aws/ec2-volume
+- kind:        instance-aws/ec2-volume
   spiVersion:   instance/v0.1.0
   metadata:
     uid: disk1-1234

--- a/pkg/types/spec.go
+++ b/pkg/types/spec.go
@@ -9,8 +9,8 @@ import (
 // Spec is the specification of the resource / object
 type Spec struct {
 
-	// Class is the kind/type of the resource -- e.g. instance-aws/ec2-instance
-	Class string `json:"class"`
+	// Kind is the category of the resources and kind can have types  -- e.g. instance-aws/ec2-instance
+	Kind string `json:"kind"`
 
 	// SpiVersion is the name of the interface and version - instance/v0.1.0
 	SpiVersion string `json:"spiVersion"`
@@ -36,7 +36,7 @@ type Spec struct {
 
 // Validate checks the spec for validity
 func (s Spec) Validate() error {
-	if s.Class == "" {
+	if s.Kind == "" {
 		return errMissingAttribute("class")
 	}
 	if s.SpiVersion == "" {
@@ -48,12 +48,12 @@ func (s Spec) Validate() error {
 	return nil
 }
 
-// Dependency models the reference and usage of another spec, by spec's Class and Name, and a way
+// Dependency models the reference and usage of another spec, by spec's Kind and Name, and a way
 // to extract its properties, and how it's referenced via the alias in the Properties section of the dependent Spec.
 type Dependency struct {
 
-	// Class is the Class of the spec this spec depends on
-	Class string `json:"class"`
+	// Kind is the Kind of the spec this spec depends on
+	Kind string `json:"kind"`
 
 	// Name is the Name of the spec this spec dependes on
 	Name string `json:"name"`

--- a/pkg/types/spec_test.go
+++ b/pkg/types/spec_test.go
@@ -10,7 +10,7 @@ import (
 func TestEncodeDecodeSpec(t *testing.T) {
 
 	spec := `
-class:        instance-aws/ec2-instance
+kind:        instance-aws/ec2-instance
 spiVersion:   instance/v0.1.0
 metadata:
   name: host1
@@ -29,7 +29,7 @@ options:
 	require.NoError(t, yaml.Unmarshal([]byte(spec), &s))
 
 	expected := Spec{
-		Class:      "instance-aws/ec2-instance",
+		Kind:       "instance-aws/ec2-instance",
 		SpiVersion: "instance/v0.1.0",
 		Metadata: Metadata{
 			Name: "host1",
@@ -51,7 +51,7 @@ options:
 	require.Equal(t, AnyValueMust(expected), AnyValueMust(s))
 	require.NoError(t, s.Validate())
 
-	s.Class = ""
+	s.Kind = ""
 	require.Error(t, s.Validate())
 
 	s.SpiVersion = ""
@@ -61,7 +61,7 @@ options:
 func TestEncodeDecodeObject(t *testing.T) {
 
 	object := `
-class:        instance-aws/ec2-instance
+kind:        instance-aws/ec2-instance
 spiVersion:   instance/v0.1.0
 metadata:
   uid : u-12134
@@ -78,7 +78,7 @@ options:
     region: us-west-1
     stack:  test
 depends:
-    - class: instance-aws/ebs-volume
+    - kind: instance-aws/ebs-volume
       name: /var/lib/docker
       bind:
          volume/id : Spec/Metadata/Identity/UID
@@ -95,7 +95,7 @@ state:
 
 	expected := Object{
 		Spec: Spec{
-			Class:      "instance-aws/ec2-instance",
+			Kind:       "instance-aws/ec2-instance",
 			SpiVersion: "instance/v0.1.0",
 			Metadata: Metadata{
 				Identity: &Identity{
@@ -119,8 +119,8 @@ state:
 			}),
 			Depends: []Dependency{
 				{
-					Class: "instance-aws/ebs-volume",
-					Name:  "/var/lib/docker",
+					Kind: "instance-aws/ebs-volume",
+					Name: "/var/lib/docker",
 					Bind: map[string]*Pointer{
 						"volume/id": PointerFromString("Spec/Metadata/Identity/UID"),
 					},


### PR DESCRIPTION
`Class` isn't really appropriate, since infrakit isn't offering an OO type system; `Kind` or `Category` is a better term for naming of plugins (e.g. aws/ec2-instance).

Signed-off-by: David Chung <david.chung@docker.com>