### PR TITLE
CLI should not exit if hosts file is missing

### DIFF
--- a/cmd/infrakit/main.go
+++ b/cmd/infrakit/main.go
@@ -82,11 +82,12 @@ func main() {
 				return nil // do nothing -- local mode
 			}
 
+			// If the env is set but we don't have any hosts file locally, don't exit.  Print a warning and proceed.
 			// Now look up the host lists in the file
 			hostsFile := filepath.Join(os.Getenv("INFRAKIT_HOME"), "hosts")
 			buff, err := ioutil.ReadFile(hostsFile)
 			if err != nil {
-				return fmt.Errorf("cannot read hosts file at %s for INFRAKIT_HOST=%s, err=%v", hostsFile, host, err)
+				return nil // do nothing -- local mode
 			}
 			m := map[string]string{}
 			yaml, err := types.AnyYAML(buff)


### PR DESCRIPTION
This PR fixes a bug where if the local hosts file is missing the CLI does not run at all.  Instead, the correct behavior should be to continue in local mode (ie using local sockets).

Signed-off-by: David Chung <david.chung@docker.com>