### PR TITLE
Add flag -f to allow final pass in template evaluation

### DIFF
--- a/cmd/infrakit/base/template.go
+++ b/cmd/infrakit/base/template.go
@@ -58,6 +58,7 @@ func TemplateProcessor(plugins func() discovery.Plugins) (*pflag.FlagSet, ToJSON
 	globals := fs.StringSliceP("var", "v", []string{}, "key=value pairs of globally scoped variagbles")
 	yamlDoc := fs.BoolP("yaml", "y", false, "True if input is in yaml format; json is the default")
 	dump := fs.BoolP("dump", "x", false, "True to dump to output instead of executing")
+	singlePass := fs.BoolP("final", "f", false, "True to render template as the final pass")
 
 	return fs,
 		// ToJSONFunc
@@ -116,7 +117,7 @@ func TemplateProcessor(plugins func() discovery.Plugins) (*pflag.FlagSet, ToJSON
 			}
 
 			log.Debug("reading template", "url", url)
-			engine, err := template.NewTemplate(url, template.Options{MultiPass: true})
+			engine, err := template.NewTemplate(url, template.Options{MultiPass: !*singlePass})
 			if err != nil {
 				return
 			}


### PR DESCRIPTION
This PR adds a flag to allow user to indicate the evaluation of the template is final and not meant to be input to another pass of template evaluation.  

Signed-off-by: David Chung <david.chung@docker.com>