### PR TITLE
support adding a single command file

### DIFF
--- a/cmd/infrakit/playbook/playbook.go
+++ b/cmd/infrakit/playbook/playbook.go
@@ -95,14 +95,12 @@ func Command(plugins func() discovery.Plugins) *cobra.Command {
 			if err != nil {
 				return err
 			}
-
-			// try fetch
-			test, err := template.NewTemplate(url, template.Options{})
-			if err != nil {
-				return err
+			if modules == nil {
+				modules = map[remote.Op]remote.SourceURL{}
 			}
 
-			_, err = test.Render(nil)
+			// try fetch
+			_, err = template.Fetch(url, template.Options{})
 			if err != nil {
 				return err
 			}

--- a/pkg/cli/remote/remote.go
+++ b/pkg/cli/remote/remote.go
@@ -84,6 +84,10 @@ func dir(url SourceURL) (Modules, error) {
 
 	m := Modules{}
 	err = Decode([]byte(view), &m)
+	if err == nil {
+		return m, nil
+	}
+	m[Op(".")] = url
 	return m, err
 }
 


### PR DESCRIPTION
This PR makes it possible to add a single command (one that declares flags, prompts, etc.) as a command / playbook.

Signed-off-by: David Chung <david.chung@docker.com>