### PR TITLE
Support int and bool types as template CLI vars

### DIFF
--- a/pkg/cli/services.go
+++ b/pkg/cli/services.go
@@ -5,6 +5,7 @@ import (
 	"io/ioutil"
 	"os"
 	"path"
+	"strconv"
 	"strings"
 
 	"github.com/docker/infrakit/pkg/discovery"
@@ -171,7 +172,15 @@ func templateProcessor(plugins func() discovery.Plugins) (*pflag.FlagSet, ToJSON
 				key := strings.TrimSpace(kv[0])
 				val := strings.TrimSpace(kv[1])
 				if key != "" && val != "" {
-					engine.Global(key, val)
+					// Attempt to convert to int and bool types so that template operations
+					// are not only against strings.
+					if intVal, err := strconv.Atoi(val); err == nil {
+						engine.Global(key, intVal)
+					} else if boolVar, err := strconv.ParseBool(val); err == nil {
+						engine.Global(key, boolVar)
+					} else {
+						engine.Global(key, val)
+					}
 				}
 			}
 


### PR DESCRIPTION
Commit ce00509140f0bb010ec230412317dc5c85571566 overrode the changes in commit 8f9f5332b63e5e38c524676b596b87e85ecedd83.

Signed-off-by: Steven Kaufer <kaufer@us.ibm.com>