### PR TITLE
make check timestamp when per-binary build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,6 +11,9 @@ DOCKER_CLIENT_VERSION?=1.24
 # True to run e2e test
 E2E_TESTS?=true
 
+#Source file target
+SRCS  := $(shell find . -type f -name '*.go')
+
 # Allow turning off function inlining and variable registerization
 ifeq (${DISABLE_OPTIMIZATION},true)
 	GO_GCFLAGS=-gcflags "-N -l"
@@ -128,7 +131,7 @@ clean:
 	mkdir -p build
 
 define binary_target_template
-build/$(1):
+build/$(1): $(SRCS)
 	go build -o build/$(1) \
 		-ldflags "-X github.com/docker/infrakit/pkg/cli.Version=$(VERSION) -X github.com/docker/infrakit/pkg/cli.Revision=$(REVISION) -X github.com/docker/infrakit/pkg/util/docker.ClientVersion=$(DOCKER_CLIENT_VERSION)" $(2)
 endef


### PR DESCRIPTION
When build per-binary, it doesn't check timestamp.
If there is a binary always `make` says below even the binary is old.
 
```
make build/infrakit-*
make: 'build/infrakit-*' is up to date.
```

This PR make it check *.go file time stamp.

Signed-off-by: YujiOshima <yuji.oshima0x3fd@gmail.com>