### PR TITLE
Fix debug message when unable to get the terraform lock

### DIFF
--- a/examples/instance/terraform/apply.go
+++ b/examples/instance/terraform/apply.go
@@ -26,8 +26,9 @@ func (p *plugin) terraformApply() error {
 			if err := p.lock.TryLock(); err == nil {
 				defer p.lock.Unlock()
 				doTerraformApply(p.Dir)
+			} else {
+				log.Debugln("Can't acquire lock, waiting")
 			}
-			log.Debugln("Can't acquire lock, waiting")
 			time.Sleep(time.Duration(int64(rand.NormFloat64())%1000) * time.Millisecond)
 		}
 	}()


### PR DESCRIPTION
Message should have been in an `else` block.

Signed-off-by: Steven Kaufer <kaufer@us.ibm.com>