### PR TITLE
Append LogicalID to Softlayer instance hostname

### DIFF
--- a/examples/instance/terraform/plugin_test.go
+++ b/examples/instance/terraform/plugin_test.go
@@ -259,14 +259,13 @@ func run(t *testing.T, resourceType, properties string) {
 			}), conv(props["tags"].([]interface{})))
 			require.Equal(t, expectedUserData2, props["user_metadata"])
 
-			// If a hostname was specified, the expectation is that the hostname is appended with the timestamp from the ID
+			// If a hostname was specified, the expectation is that the hostname is appended with the logical ID
 			if value["@hostname_prefix"] != nil && strings.Trim(value["@hostname_prefix"].(string), " ") != "" {
-				newID := strings.Replace(string(*id2), "instance-", "", -1)
-				expectedHostname := "softlayer-hostname-" + newID
+				expectedHostname := "softlayer-hostname-logical:id-2"
 				require.Equal(t, expectedHostname, props["hostname"])
 			} else {
-				// If no hostname was specified, the hostname should equal the ID
-				require.Equal(t, string(*id2), props["hostname"])
+				// If no hostname was specified, the hostname should equal the logical ID
+				require.Equal(t, "logical:id-2", props["hostname"])
 			}
 			// Verify the hostname prefix key/value is no longer in the props
 			require.Nil(t, props["@hostname_prefix"])


### PR DESCRIPTION
Currently, the hostname for the Softlayer terraform resource is either the instance name (ie, "instance-12345") if the `@hostname_prefix` property is not set; else it's formatted as `<@hostname_prefix>-<timestamp>` (ie, "given-prefix-12345).

This approach makes sense for workers but having a more predictable naming scheme for managers would be more usable. This commit updates the naming scheme to use the `LogicalID` (if set) instead of the timestamp when generating the hostname.

See issue #555.

Note that the instance name remains unchanged; it's only the `hostname` property that is being updated.

Signed-off-by: Steven Kaufer <kaufer@us.ibm.com>