### PR TITLE
Check for quorom group instance changes during PlanUpdate

### DIFF
--- a/pkg/plugin/group/quorum.go
+++ b/pkg/plugin/group/quorum.go
@@ -3,12 +3,13 @@ package group
 import (
 	"errors"
 	"fmt"
-	log "github.com/Sirupsen/logrus"
-	"github.com/docker/infrakit/pkg/spi/group"
-	"github.com/docker/infrakit/pkg/spi/instance"
 	"reflect"
 	"sync"
 	"time"
+
+	log "github.com/Sirupsen/logrus"
+	"github.com/docker/infrakit/pkg/spi/group"
+	"github.com/docker/infrakit/pkg/spi/instance"
 )
 
 // TODO(wfarner): Converge this implementation with scaler.go, they share a lot of behavior.
@@ -36,6 +37,11 @@ func (q *quorum) PlanUpdate(scaled Scaled, settings groupSettings, newSettings g
 
 	if !reflect.DeepEqual(settings.config.Allocation.LogicalIDs, newSettings.config.Allocation.LogicalIDs) {
 		return nil, errors.New("Logical ID changes to a quorum is not currently supported")
+	}
+
+	if settings.config.InstanceHash() == newSettings.config.InstanceHash() {
+		// This is a no-op update because the instance configuration is unchanged
+		return &noopUpdate{}, nil
 	}
 
 	return &rollingupdate{

--- a/pkg/plugin/group/scaler.go
+++ b/pkg/plugin/group/scaler.go
@@ -89,7 +89,7 @@ func (s *scaler) PlanUpdate(scaled Scaled, settings groupSettings, newSettings g
 				newSettings.config.Allocation.Size)
 		} else {
 			plan.desc = fmt.Sprintf(
-				"Terminating %d instances to reduce the group size to %d, "+
+				"Terminating %d instances to reduce the group size to %d,"+
 					" then performing a rolling update on %d instances",
 				int(sizeChange)*-1,
 				newSettings.config.Allocation.Size,


### PR DESCRIPTION
When doing a `PlanUpdate` on a quorum group, a rolling update is **always** executed if the `LogicalIDs` have not changed; this causes an undesired rolling update on a group of managers.

However, on a scaler group, the hash of the instance definition is also checked to determine if a rolling update needs to be performed. Therefore, on a scaler group, no updates are done if the size and instance definition has not changed.

The fix is to add a similar hash check in the quorum function so that a rolling update is only done if the instance definition changes.

This commit also adds the missing UT to verify the quorum and scaler groups.

Closes #563

Signed-off-by: Steven Kaufer <kaufer@us.ibm.com>