### PR TITLE
Lifecycle mgmt for dependent resources via "@scope" tf prop

### DIFF
--- a/examples/instance/terraform/plugin.go
+++ b/examples/instance/terraform/plugin.go
@@ -59,73 +59,73 @@ TFormat models the on disk representation of a terraform resource JSON.
 An example of this looks like:
 
 {
-    "resource" : {
-	"aws_instance" : {
-	    "web4" : {
-		"ami" : "${lookup(var.aws_amis, var.aws_region)}",
-		"instance_type" : "m1.small",
-		"key_name": "PUBKEY",
-		"vpc_security_group_ids" : ["${aws_security_group.default.id}"],
-		"subnet_id": "${aws_subnet.default.id}",
-		"tags" :  {
-		    "Name" : "web4",
-		    "InstancePlugin" : "terraform"
+	"resource": {
+		"aws_instance": {
+			"web4": {
+				"ami": "${lookup(var.aws_amis, var.aws_region)}",
+				"instance_type": "m1.small",
+				"key_name": "PUBKEY",
+				"vpc_security_group_ids": ["${aws_security_group.default.id}"],
+				"subnet_id": "${aws_subnet.default.id}",
+				"tags":  {
+					"Name": "web4",
+					"InstancePlugin": "terraform"
+				},
+				"connection": {
+					"user": "ubuntu"
+				},
+				"provisioner": {
+					"remote_exec": {
+						"inline": [
+							"sudo apt-get -y update",
+							"sudo apt-get -y install nginx",
+							"sudo service nginx start"
+						]
+					}
+				}
+			}
 		}
-		"connection" : {
-		    "user" : "ubuntu"
-		},
-		"provisioner" : {
-		    "remote_exec" : {
-			"inline" : [
-			    "sudo apt-get -y update",
-			    "sudo apt-get -y install nginx",
-			    "sudo service nginx start"
-			]
-		    }
-		}
-	    }
 	}
-    }
 }
 
 The block above is essentially embedded inside the `Properties` field of the instance Spec:
 
 {
-    "Properties" : {
-      "resource" : {
-    	 "aws_instance" : {
-	    "web4" : {
-		"ami" : "${lookup(var.aws_amis, var.aws_region)}",
-		"instance_type" : "m1.small",
-		"key_name": "PUBKEY",
-		"vpc_security_group_ids" : ["${aws_security_group.default.id}"],
-		"subnet_id": "${aws_subnet.default.id}",
-		"tags" :  {
-		    "Name" : "web4",
-		    "InstancePlugin" : "terraform"
+	"Properties": {
+		"resource": {
+			"aws_instance": {
+				"web4": {
+					"ami": "${lookup(var.aws_amis, var.aws_region)}",
+					"instance_type": "m1.small",
+					"key_name": "PUBKEY",
+					"vpc_security_group_ids": ["${aws_security_group.default.id}"],
+					"subnet_id": "${aws_subnet.default.id}",
+					"tags":  {
+						"Name": "web4",
+						"InstancePlugin": "terraform"
+					},
+					"connection": {
+						"user": "ubuntu"
+					},
+					"provisioner": {
+						"remote_exec": {
+							"inline": [
+								"sudo apt-get -y update",
+								"sudo apt-get -y install nginx",
+								"sudo service nginx start"
+							]
+						}
+					}
+				}
+			}
 		}
-		"connection" : {
-		    "user" : "ubuntu"
-		},
-		"provisioner" : {
-		    "remote_exec" : {
-			"inline" : [
-			    "sudo apt-get -y update",
-			    "sudo apt-get -y install nginx",
-			    "sudo service nginx start"
-			]
-		    }
-		}
-	    }
-	 }
-      }
-    },
-    "Tags" : {
-        "other" : "values",
-        "to" : "merge",
-        "with" : "tags"
-    },
-    "Init" : "init string"
+	},
+	"Tags": {
+		"other": "values",
+		"to": "merge",
+		"with": "tags"
+	},
+	"Init": "init string"
 }
 
 */


### PR DESCRIPTION
This PR adds support for a new `@scope` terraform property. This value of this property dictates the specific `.tf.json` file that the resource is placed in:

- `@default`: resources in same "instance-xxxx.tf.json" file as VM
- `@dedicated`: resources in different file as VM using the same ID (`instance-xxxx-dedicated.tf.json`)
- `<other>`: resource defined in different file with a scope identifier (`scope-<other>.tf.json`)

The related resource IDs (which are the names of the related `.tf.json` files) are persisted in a new `infrakit.attach` tag whose value is a comma-separated `string`.

During the `Destroy` phase all related resources that **are not** referenced by other resources are removed.  There is a parallel work being done to update the SPI to pass the context for a `Destroy` so that we can differentiate between a rolling update (where related resources should not removed) and a scale down (where related resources should be removed); once this is completed then the `Destroy` flow will need to be updated accordingly.

Signed-off-by: Steven Kaufer <kaufer@us.ibm.com>