### PR TITLE
Fix broken links from moving terraform instance

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ Here is a list of plugins:
 | [zookeeper](./examples/flavor/zookeeper)            | flavor   | run an Apache ZooKeeper ensemble        |
 | [infrakit/file](./examples/instance/file)           | instance | useful for development and testing      |
 | [infrakit/docker](./examples/instance/docker)       | instance | provisions container via Docker         |
-| [infrakit/terraform](./examples/instance/terraform) | instance | creates resources using Terraform       |
+| [infrakit/terraform](./pkg/provider/terraform/instance) | instance | creates resources using Terraform       |
 | [infrakit/maas](./examples/instance/maas)           | instance | bare-metal provisioning using Ubuntu MAAS  |
 | [infrakit/vagrant](./examples/instance/vagrant)     | instance | creates Vagrant VMs                     |
 | [infrakit/hyperkit](./pkg/plugin/instance/hyperkit)   | instance | creates [HyperKit](https://github.com/moby/hyperkit) VMs on Mac OSX |
@@ -77,7 +77,7 @@ Here is a list of plugins:
 |:--------------------------------------------------------|:---------|:----------------------------------------|
 | [HewlettPackard/infrakit-instance-oneview](https://github.com/HewlettPackard/infrakit-instance-oneview)      | instance    | bare-metal server provisioning via HP-OneView |
 | [codedellemc/infrakit.rackhd](https://github.com/codedellemc/infrakit.rackhd)      | instance    | bare-metal server provisioning via RackHD |
-| [IBM Bluemix / SoftLayer](./examples/instance/terraform) | instance    | SoftLayer via terraform             |
+| [IBM Bluemix / SoftLayer](./pkg/provider/terraform/instance) | instance    | SoftLayer via terraform             |
 | [AliyunContainerService/infrakit.aliyun](https://github.com/AliyunContainerService/infrakit.aliyun) | instance    | Provisions instances on Alibaba Cloud |
 | [1and1/infrakit-instance-oneandone](https://github.com/1and1/infrakit-instance-oneandone) | instance    | Provisions instances on 1&1 Cloud Server |
 | [sacloud/infrakit-instance-sakuracloud](https://github.com/sacloud/infrakit.sakuracloud) | instance    | Provisions instances on Sakura Cloud |
@@ -128,7 +128,7 @@ This will produce binaries for tools and several reference Plugin implementation
   + [`infrakit`](cmd/cli/README.md): a command line interface to interact with plugins
   + [`infrakit-group-default`](cmd/group/README.md): the default [Group plugin](./pkg/spi/group)
   + [`infrakit-instance-file`](examples/instance/file): an Instance plugin using dummy files to represent instances
-  + [`infrakit-instance-terraform`](examples/instance/terraform):
+  + [`infrakit-instance-terraform`](pkg/provider/terraform/instance):
     an Instance plugin integrating [Terraform](https://www.terraform.io)
   + [`infrakit-instance-vagrant`](examples/instance/vagrant):
     an Instance plugin using [Vagrant](https://www.vagrantup.com/)

--- a/examples/cli/build/infrakit/make
+++ b/examples/cli/build/infrakit/make
@@ -30,7 +30,7 @@ build-binaries:
 	$(call build_binary,infrakit-flavor-vanilla,github.com/docker/infrakit/examples/flavor/vanilla)
 	$(call build_binary,infrakit-flavor-zookeeper,github.com/docker/infrakit/examples/flavor/zookeeper)
 	$(call build_binary,infrakit-instance-file,github.com/docker/infrakit/examples/instance/file)
-	$(call build_binary,infrakit-instance-terraform,github.com/docker/infrakit/examples/instance/terraform)
+	$(call build_binary,infrakit-instance-terraform,github.com/docker/infrakit/pkg/provider/terraform/instance)
 	$(call build_binary,infrakit-instance-vagrant,github.com/docker/infrakit/examples/instance/vagrant)
 	$(call build_binary,infrakit-instance-maas,github.com/docker/infrakit/examples/instance/maas)
 	$(call build_binary,infrakit-event-time,github.com/docker/infrakit/examples/event/time)

--- a/pkg/provider/terraform/instance/README.md
+++ b/pkg/provider/terraform/instance/README.md
@@ -104,7 +104,7 @@ is run continuously in the background so as soon as new files are deposited, Ter
 and update its state.  When an instance is removed, Terraform will do the same by destroying the instance
 and update its state.
 
- 
+
 ## Running
 
 Begin by building plugin [binaries](/README.md#binaries).
@@ -118,7 +118,7 @@ See the [CLI Doc](/cmd/cli/README.md) for details on accessing the instance plug
 Start the plugin:
 
 ```shell
-$ build/infrakit-instance-terraform --dir=./examples/instance/terraform/aws-two-tier/
+$ build/infrakit-instance-terraform --dir=./pkg/provider/terraform/instance/aws-two-tier/
 INFO[0000] Listening at: ~/.infrakit/plugins/instance-terraform
 ```
 
@@ -128,7 +128,7 @@ Now lets try to validate something.  Instead of reading from stdin we are loadin
 to avoid problems with bad bash substitution beacuse Terrafrom configs use `$` to indicate variables.
 
 ```shell
-$ cat examples/instance/terraform/aws-two-tier/instance-plugin-properties.json
+$ cat pkg/provider/terraform/instance/aws-two-tier/instance-plugin-properties.json
 {
     "type" : "aws_instance",
     "value" : {
@@ -146,14 +146,14 @@ $ cat examples/instance/terraform/aws-two-tier/instance-plugin-properties.json
         }
     }
 }
-$ build/infrakit instance --name instance-terraform validate examples/instance/terraform/aws-two-tier/instance-plugin-properties.json
+$ build/infrakit instance --name instance-terraform validate pkg/provider/terraform/instance/aws-two-tier/instance-plugin-properties.json
 validate:ok
 ```
 
 Now we can provision:
 
 ```shell
-$ cat examples/instance/terraform/aws-two-tier/instance-plugin-spec.json
+$ cat pkg/provider/terraform/instance/aws-two-tier/instance-plugin-spec.json
 {
     "Properties" : {
         "type" : "aws_instance",
@@ -177,7 +177,7 @@ $ cat examples/instance/terraform/aws-two-tier/instance-plugin-spec.json
     },
     "Init" : "#!/bin/sh; sudo apt-get -y update; sudo apt-get -y install nginx; sudo service nginx start"
 }
-$ build/infrakit instance --name instance-terraform provision examples/instance/terraform/aws-two-tier/instance-plugin-spec.json
+$ build/infrakit instance --name instance-terraform provision pkg/provider/terraform/instance/aws-two-tier/instance-plugin-spec.json
 instance-1475004829
 ```
 


### PR DESCRIPTION
The files at `examples/instance/terraform` were moved to `pkg/provider/terraform/instance` and a few files were referencing the old location.

Signed-off-by: Steven Kaufer <kaufer@us.ibm.com>