### PR TITLE
Terraform apply polling updates

### DIFF
--- a/pkg/provider/terraform/instance/apply.go
+++ b/pkg/provider/terraform/instance/apply.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"math/rand"
 	"os"
 	"time"
 
@@ -9,6 +8,9 @@ import (
 	"github.com/docker/infrakit/pkg/util/exec"
 )
 
+// terraformApply starts a goroutine that executes "terraform apply" at the
+// configured freqency; if the goroutine is already running then the sleeping
+// is interrupted
 func (p *plugin) terraformApply() error {
 	if p.pretend {
 		return nil
@@ -18,30 +20,60 @@ func (p *plugin) terraformApply() error {
 	defer p.applyLock.Unlock()
 
 	if p.applying {
+		select {
+		case p.pollChannel <- true:
+			log.Infoln("Successfully interrupted terraform apply goroutine")
+		default:
+			log.Infoln("Polling channel is full, not interrupting")
+		}
 		return nil
 	}
 
+	p.pollChannel = make(chan bool, 1)
 	go func() {
+		initial := true
 		for {
-			if err := p.lock.TryLock(); err == nil {
-				defer p.lock.Unlock()
-				doTerraformApply(p.Dir)
-			} else {
-				log.Debugln("Can't acquire lock, waiting")
+			attempted, err := p.doTerraformApply(initial)
+			initial = false
+			if err != nil {
+				log.Errorf("Executing 'terraform apply' failed: %v", err)
 			}
-			time.Sleep(time.Duration(int64(rand.NormFloat64())%1000) * time.Millisecond)
+			if !attempted {
+				log.Infof("Can't acquire apply lock, waiting %v seconds", p.pollInterval)
+			}
+			select {
+			case <-p.pollChannel:
+				// Interrupted, use same initial delay so that more than a single delta
+				// can be processed
+				initial = true
+				break
+			case <-time.After(p.pollInterval):
+				break
+			}
 		}
 	}()
+
 	p.applying = true
 	return nil
 }
 
-func doTerraformApply(dir string) error {
-	log.Infoln(time.Now().Format(time.RFC850) + " Applying plan")
-	command := exec.Command(`terraform apply`).InheritEnvs(true).WithDir(dir)
-	err := command.WithStdout(os.Stdout).WithStderr(os.Stdout).Start()
-	if err != nil {
-		return err
+// doTerraformApply executes "terraform apply" if it can aquire the lock. Returns
+// true/false if the command was executed and an error
+func (p *plugin) doTerraformApply(initial bool) (bool, error) {
+	if err := p.lock.TryLock(); err == nil {
+		defer p.lock.Unlock()
+		// The trigger for the initial apply is typically from a group commit, sleep
+		// for a few seconds so that multiple .tf.json files have time to be created
+		if initial {
+			time.Sleep(time.Second * 5)
+		}
+		log.Infoln("Applying plan")
+		command := exec.Command(`terraform apply`).InheritEnvs(true).WithDir(p.Dir)
+		err := command.WithStdout(os.Stdout).WithStderr(os.Stdout).Start()
+		if err != nil {
+			return true, err
+		}
+		return true, command.Wait()
 	}
-	return command.Wait()
+	return false, nil
 }

--- a/pkg/provider/terraform/instance/apply_test.go
+++ b/pkg/provider/terraform/instance/apply_test.go
@@ -4,6 +4,7 @@ import (
 	"os"
 	"path"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
 
@@ -20,7 +21,9 @@ func TestRunTerraformApply(t *testing.T) {
 	dir, err := os.Getwd()
 	require.NoError(t, err)
 	dir = path.Join(dir, "aws-two-tier")
-
-	err = doTerraformApply(dir)
+	terraform := NewTerraformInstancePlugin(dir, 1*time.Second)
+	p, _ := terraform.(*plugin)
+	attempted, err := p.doTerraformApply(false)
 	require.NoError(t, err)
+	require.True(t, attempted)
 }

--- a/pkg/provider/terraform/instance/apply_test.go
+++ b/pkg/provider/terraform/instance/apply_test.go
@@ -33,14 +33,7 @@ func TestContinuePollingStandalone(t *testing.T) {
 	defer os.RemoveAll(dir)
 	terraform := NewTerraformInstancePlugin(dir, 1*time.Second, true)
 	p, _ := terraform.(*plugin)
-	require.True(t, p.continuePolling())
-}
-
-func TestContinuePollingNotStandaloneNoManager(t *testing.T) {
-	dir, err := ioutil.TempDir("", "infrakit-instance-terraform")
+	execute, err := p.continuePolling()
 	require.NoError(t, err)
-	defer os.RemoveAll(dir)
-	terraform := NewTerraformInstancePlugin(dir, 1*time.Second, false)
-	p, _ := terraform.(*plugin)
-	require.False(t, p.continuePolling())
+	require.True(t, execute)
 }

--- a/pkg/provider/terraform/instance/main.go
+++ b/pkg/provider/terraform/instance/main.go
@@ -3,6 +3,7 @@ package main
 import (
 	"os"
 	"os/exec"
+	"time"
 
 	log "github.com/Sirupsen/logrus"
 	"github.com/docker/infrakit/pkg/cli"
@@ -35,11 +36,12 @@ func main() {
 	name := cmd.Flags().String("name", "instance-terraform", "Plugin name to advertise for discovery")
 	logLevel := cmd.Flags().Int("log", cli.DefaultLogLevel, "Logging level. 0 is least verbose. Max is 5")
 	dir := cmd.Flags().String("dir", getDir(), "Dir for storing plan files")
+	pollInterval := cmd.Flags().Duration("poll-interval", 30*time.Second, "Terraform polling interval")
 	cmd.Run = func(c *cobra.Command, args []string) {
 		mustHaveTerraform()
 
 		cli.SetLogLevel(*logLevel)
-		cli.RunPlugin(*name, instance_plugin.PluginServer(NewTerraformInstancePlugin(*dir)))
+		cli.RunPlugin(*name, instance_plugin.PluginServer(NewTerraformInstancePlugin(*dir, *pollInterval)))
 	}
 
 	cmd.AddCommand(cli.VersionCommand())

--- a/pkg/provider/terraform/instance/main.go
+++ b/pkg/provider/terraform/instance/main.go
@@ -37,11 +37,12 @@ func main() {
 	logLevel := cmd.Flags().Int("log", cli.DefaultLogLevel, "Logging level. 0 is least verbose. Max is 5")
 	dir := cmd.Flags().String("dir", getDir(), "Dir for storing plan files")
 	pollInterval := cmd.Flags().Duration("poll-interval", 30*time.Second, "Terraform polling interval")
+	standalone := cmd.Flags().Bool("standalone", false, "Set if running standalone, disables manager leadership verification")
 	cmd.Run = func(c *cobra.Command, args []string) {
 		mustHaveTerraform()
 
 		cli.SetLogLevel(*logLevel)
-		cli.RunPlugin(*name, instance_plugin.PluginServer(NewTerraformInstancePlugin(*dir, *pollInterval)))
+		cli.RunPlugin(*name, instance_plugin.PluginServer(NewTerraformInstancePlugin(*dir, *pollInterval, *standalone)))
 	}
 
 	cmd.AddCommand(cli.VersionCommand())

--- a/pkg/provider/terraform/instance/plugin.go
+++ b/pkg/provider/terraform/instance/plugin.go
@@ -45,10 +45,11 @@ type plugin struct {
 	pretend      bool // true to actually do terraform apply
 	pollInterval time.Duration
 	pollChannel  chan bool
+	standalone   bool
 }
 
 // NewTerraformInstancePlugin returns an instance plugin backed by disk files.
-func NewTerraformInstancePlugin(dir string, pollInterval time.Duration) instance.Plugin {
+func NewTerraformInstancePlugin(dir string, pollInterval time.Duration, standalone bool) instance.Plugin {
 	log.Debugln("terraform instance plugin. dir=", dir)
 	lock, err := lockfile.New(filepath.Join(dir, "tf-apply.lck"))
 	if err != nil {
@@ -60,6 +61,7 @@ func NewTerraformInstancePlugin(dir string, pollInterval time.Duration) instance
 		fs:           afero.NewOsFs(),
 		lock:         lock,
 		pollInterval: pollInterval,
+		standalone:   standalone,
 	}
 }
 

--- a/pkg/provider/terraform/instance/plugin_test.go
+++ b/pkg/provider/terraform/instance/plugin_test.go
@@ -23,7 +23,7 @@ import (
 func getPlugin(t *testing.T) (*plugin, string) {
 	dir, err := ioutil.TempDir("", "infrakit-instance-terraform")
 	require.NoError(t, err)
-	tf := NewTerraformInstancePlugin(dir, 1*time.Second)
+	tf := NewTerraformInstancePlugin(dir, 1*time.Second, false)
 	tf.(*plugin).pretend = true
 	p, is := tf.(*plugin)
 	require.True(t, is)

--- a/pkg/provider/terraform/instance/plugin_test.go
+++ b/pkg/provider/terraform/instance/plugin_test.go
@@ -10,6 +10,7 @@ import (
 	"sort"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/docker/infrakit/pkg/spi/instance"
 	"github.com/docker/infrakit/pkg/types"
@@ -22,7 +23,7 @@ import (
 func getPlugin(t *testing.T) (*plugin, string) {
 	dir, err := ioutil.TempDir("", "infrakit-instance-terraform")
 	require.NoError(t, err)
-	tf := NewTerraformInstancePlugin(dir)
+	tf := NewTerraformInstancePlugin(dir, 1*time.Second)
 	tf.(*plugin).pretend = true
 	p, is := tf.(*plugin)
 	require.True(t, is)


### PR DESCRIPTION
- Adds a new `--poll-interval` that specifies the `terraform apply` frequency.
- Sleep for 5 seconds on the first apply, allowing the initial commit (which typically has more then a single member) time to get multiple `tf.json` files created
- Adds interrupt support to force an apply on-demand (vs. waiting for the next poll iteration)
- Stops polling goroutine if the manager plugin exists and it is not a leader; this checking can be disabled by specifying a new `--standalone` CLI arg

Closes #594

Signed-off-by: Steven Kaufer <kaufer@us.ibm.com>