### PR TITLE
HTTP Client Timeout

### DIFF
--- a/cmd/infrakit/main.go
+++ b/cmd/infrakit/main.go
@@ -53,8 +53,8 @@ func (e emptyPlugins) List() (map[string]*plugin.Endpoint, error) {
 }
 
 var (
-	empty      = emptyPlugins{}
-	emptyError = errors.New("no plugins")
+	empty    = emptyPlugins{}
+	errEmpty = errors.New("no plugins")
 )
 
 // A generic client for infrakit
@@ -129,7 +129,7 @@ func main() {
 	if os.Getenv("INFRAKIT_DYNAMIC_CLI") != "false" {
 		// Load dynamic plugin commands based on discovery
 		pluginCommands, err := cli.LoadAll(cli.NewServices(f))
-		if err != nil && err != emptyError {
+		if err != nil && err != errEmpty {
 			log.Debug("error loading", "cmd", cmd.Use, "err", err)
 			fmt.Println(err.Error())
 			os.Exit(1)

--- a/cmd/infrakit/main.go
+++ b/cmd/infrakit/main.go
@@ -45,11 +45,11 @@ func init() {
 type emptyPlugins struct{}
 
 func (e emptyPlugins) Find(name plugin.Name) (*plugin.Endpoint, error) {
-	return nil, emptyError
+	return nil, errEmpty
 }
 
 func (e emptyPlugins) List() (map[string]*plugin.Endpoint, error) {
-	return nil, emptyError
+	return nil, errEmpty
 }
 
 var (

--- a/cmd/infrakit/main.go
+++ b/cmd/infrakit/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"errors"
 	"flag"
 	"fmt"
 	"os"
@@ -13,6 +14,7 @@ import (
 	discovery_local "github.com/docker/infrakit/pkg/discovery/local"
 	"github.com/docker/infrakit/pkg/discovery/remote"
 	logutil "github.com/docker/infrakit/pkg/log"
+	"github.com/docker/infrakit/pkg/plugin"
 	"github.com/docker/infrakit/pkg/template"
 	"github.com/spf13/cobra"
 
@@ -39,6 +41,21 @@ import (
 func init() {
 	logutil.Configure(&logutil.ProdDefaults)
 }
+
+type emptyPlugins struct{}
+
+func (e emptyPlugins) Find(name plugin.Name) (*plugin.Endpoint, error) {
+	return nil, emptyError
+}
+
+func (e emptyPlugins) List() (map[string]*plugin.Endpoint, error) {
+	return nil, emptyError
+}
+
+var (
+	empty      = emptyPlugins{}
+	emptyError = errors.New("no plugins")
+)
 
 // A generic client for infrakit
 func main() {
@@ -81,23 +98,23 @@ func main() {
 
 		ulist, err := cli.Remotes()
 		if err != nil {
-			log.Crit("Cannot lookup plugins", "err", err)
-			os.Exit(1)
+			log.Debug("Cannot lookup plugins", "err", err)
+			return empty
 		}
 
 		if len(ulist) == 0 {
 			d, err := discovery_local.NewPluginDiscovery()
 			if err != nil {
-				log.Crit("Failed to initialize plugin discovery", "err", err)
-				os.Exit(1)
+				log.Debug("Failed to initialize plugin discovery", "err", err)
+				return empty
 			}
 			return d
 		}
 
 		d, err := remote.NewPluginDiscovery(ulist)
 		if err != nil {
-			log.Crit("Failed to initialize remote plugin discovery", "err", err)
-			os.Exit(1)
+			log.Debug("Failed to initialize remote plugin discovery", "err", err)
+			return empty
 		}
 		return d
 	}
@@ -112,8 +129,8 @@ func main() {
 	if os.Getenv("INFRAKIT_DYNAMIC_CLI") != "false" {
 		// Load dynamic plugin commands based on discovery
 		pluginCommands, err := cli.LoadAll(cli.NewServices(f))
-		if err != nil {
-			log.Crit("error loading", "cmd", cmd.Use, "err", err)
+		if err != nil && err != emptyError {
+			log.Debug("error loading", "cmd", cmd.Use, "err", err)
 			fmt.Println(err.Error())
 			os.Exit(1)
 		}

--- a/pkg/rpc/client/client_test.go
+++ b/pkg/rpc/client/client_test.go
@@ -20,12 +20,12 @@ func TestParseAddress(t *testing.T) {
 
 	u, c, err = parseAddress("tcp://host:9090/foo/bar/baz")
 	require.NoError(t, err)
-	require.Nil(t, c.Transport)
+	require.NotNil(t, c.Transport)
 	require.Equal(t, "http://host:9090/foo/bar/baz", u.String())
 
 	u, c, err = parseAddress("https://host:9090")
 	require.NoError(t, err)
-	require.Nil(t, c.Transport)
+	require.NotNil(t, c.Transport)
 	require.Equal(t, "https://host:9090", u.String())
 
 }


### PR DESCRIPTION
This PR adds timeout to HTTP client so that on unreachable hosts, the client does not hang.

To adjust the timeout, use environment variable `INFRAKIT_CLIENT_TIMEOUT`, the value is a string Golang `time.Duration`.  So acceptable values are `1s` or `500msec`

Signed-off-by: David Chung <david.chung@docker.com>