### PR TITLE
fix(pkg/cli/services): Pass an absolute path to command

### DIFF
--- a/pkg/cli/services.go
+++ b/pkg/cli/services.go
@@ -154,6 +154,9 @@ func templateProcessor(plugins func() discovery.Plugins) (*pflag.FlagSet, ToJSON
 				if dir, err := os.Getwd(); err == nil {
 					p = path.Join(dir, url)
 				}
+				if _, err := os.Stat(p); os.IsNotExist(err) {
+					p = url
+				}
 				url = "file://" + p
 			}
 


### PR DESCRIPTION
The command infrakit group commit path give an error when the path is absolute