### PR TITLE
Fix broken `cmd/cli` and `pkg/plugin/flavor` links in documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,7 +125,7 @@ $ make binaries
 ```
 Executables will be placed in the `./build` directory.
 This will produce binaries for tools and several reference Plugin implementations:
-  + [`infrakit`](cmd/cli/README.md): a command line interface to interact with plugins
+  + [`infrakit`](cmd/infrakit/README.md): a command line interface to interact with plugins
   + [`infrakit-group-default`](cmd/group/README.md): the default [Group plugin](./pkg/spi/group)
   + [`infrakit-instance-file`](examples/instance/file): an Instance plugin using dummy files to represent instances
   + [`infrakit-instance-terraform`](pkg/provider/terraform/instance):
@@ -171,7 +171,7 @@ A common pattern for a JSON object looks like this:
 
 There is only one `Properties` field in this JSON and its value is a JSON object. The opaque
 JSON value for `Properties` is decoded via the Go `Spec` struct defined within the package of the plugin --
-for example -- [`vanilla.Spec`](pkg/plugin/flavor/vanilla/flavor.go).
+for example -- [`vanilla.Spec`](examples/flavor/vanilla/flavor.go).
 
 The JSON above is a _value_, but the type of the value belongs outside the structure.  For example, the
 default Group [Spec](pkg/plugin/group/types/types.go) is composed of an Instance plugin, a Flavor plugin, and an

--- a/dockerfiles/Dockerfile.bundle
+++ b/dockerfiles/Dockerfile.bundle
@@ -12,7 +12,7 @@ ENV INFRAKIT_PLUGINS_DIR /infrakit/plugins
 # Defined in pkg/cli
 ENV INFRAKIT_CLI_DIR /infrakit/cli
 
-# Defined in cmd/cli/playbook
+# Defined in cmd/infrakit/playbook
 ENV INFRAKIT_PLAYBOOKS_FILE /infrakit/playbooks
 
 # When using the manager 'os' option

--- a/docs/plugins/README.md
+++ b/docs/plugins/README.md
@@ -17,7 +17,7 @@ to the name the plugin is referenced throughout the system.  For example, a
 Note that multiple instances of a plugin may run, provided they have different names for discovery.  This may be useful,
 for example, if a plugin can be configured to behave differently. For example:
 
-The CLI shows which plugins are [discoverable](../../cmd/cli/README.md#list-plugins).
+The CLI shows which plugins are [discoverable](../../cmd/infrakit/README.md#list-plugins).
 
 ## Plugin types
 ### Group

--- a/examples/cli/build/infrakit/make
+++ b/examples/cli/build/infrakit/make
@@ -21,7 +21,7 @@ endef
 binaries: clean build-binaries
 build-binaries:
 	@echo "+ $@"
-	$(call build_binary,infrakit,github.com/docker/infrakit/cmd/cli/main)
+	$(call build_binary,infrakit,github.com/docker/infrakit/cmd/infrakit/main)
 	$(call build_binary,infrakit-manager,github.com/docker/infrakit/cmd/manager)
 	$(call build_binary,infrakit-group-default,github.com/docker/infrakit/cmd/group)
 	$(call build_binary,infrakit-resource,github.com/docker/infrakit/cmd/resource)
@@ -38,4 +38,4 @@ build-binaries:
 cli: build-cli
 build-cli:
 	@echo "+ $@"
-	$(call build_binary,infrakit,github.com/docker/infrakit/cmd/cli/main)
+	$(call build_binary,infrakit,github.com/docker/infrakit/cmd/infrakit/main)

--- a/examples/flavor/zookeeper/README.md
+++ b/examples/flavor/zookeeper/README.md
@@ -31,7 +31,7 @@ $ build/infrakit-flavor-zookeeper
 INFO[0000] Listening at: ~/.infrakit/plugins/flavor-zookeeper
 ```
 
-Be sure to verify that the plugin is [discoverable](/cmd/cli/README.md#list-plugins).
+Be sure to verify that the plugin is [discoverable](/cmd/infrakit/README.md#list-plugins).
 
 Here's a JSON for the group we'd like to see [vagrant-zk.json](./vagrant-zk.json):
 

--- a/examples/instance/file/README.md
+++ b/examples/instance/file/README.md
@@ -26,9 +26,9 @@ $ build/infrakit-instance-file --name=another-file --dir=./test
 INFO[0000] Listening at: ~/.infrakit/plugins/another-file
 ```
 
-Be sure to verify that the plugin is [discoverable](/cmd/cli/README.md#list-plugins).
+Be sure to verify that the plugin is [discoverable](/cmd/infrakit/README.md#list-plugins).
 
 Note that there should be two file instance plugins running now with different names
 (`instance-file`, and `another-file`).
 
-See the [CLI Doc](/cmd/cli/README.md) for details on accessing the instance plugin via CLI.
+See the [CLI Doc](/cmd/infrakit/README.md) for details on accessing the instance plugin via CLI.

--- a/pkg/provider/terraform/instance/README.md
+++ b/pkg/provider/terraform/instance/README.md
@@ -113,7 +113,7 @@ The plugin requires a directory (`--dir`) that will be used to contain the `tfst
 files.  It also checks to make sure it can call `terraform`.
 Install Terraform [here](https://www.terraform.io/downloads.html) if you haven't done so.
 
-See the [CLI Doc](/cmd/cli/README.md) for details on accessing the instance plugin via CLI.
+See the [CLI Doc](/cmd/infrakit/README.md) for details on accessing the instance plugin via CLI.
 
 Start the plugin:
 
@@ -122,7 +122,7 @@ $ build/infrakit-instance-terraform --dir=./pkg/provider/terraform/instance/aws-
 INFO[0000] Listening at: ~/.infrakit/plugins/instance-terraform
 ```
 
-Be sure to verify that the plugin is [discoverable](/cmd/cli/README.md#list-plugins).
+Be sure to verify that the plugin is [discoverable](/cmd/infrakit/README.md#list-plugins).
 
 Now lets try to validate something.  Instead of reading from stdin we are loading from a file
 to avoid problems with bad bash substitution beacuse Terrafrom configs use `$` to indicate variables.


### PR DESCRIPTION
Resolves #611 