### PR TITLE
Fix racey maxlife "TestEnsureMaxlife" UT

### DIFF
--- a/pkg/x/maxlife/maxlife_test.go
+++ b/pkg/x/maxlife/maxlife_test.go
@@ -2,6 +2,7 @@ package maxlife
 
 import (
 	"fmt"
+	"sort"
 	"testing"
 	"time"
 
@@ -86,10 +87,17 @@ func TestEnsureMaxlife(t *testing.T) {
 	destroy := make(chan instance.ID, 2)
 	plugin := &fake.Plugin{
 		DoDescribeInstances: func(tags map[string]string, details bool) ([]instance.Description, error) {
-
 			list := []instance.Description{}
-			for _, inst := range all {
-				list = append(list, inst)
+			// Return instances in sorted order by instance ID
+			keys := make([]string, len(all))
+			i := 0
+			for key := range all {
+				keys[i] = string(key)
+				i++
+			}
+			sort.Strings(keys)
+			for _, key := range keys {
+				list = append(list, all[instance.ID(key)])
 			}
 			return list, nil
 		},


### PR DESCRIPTION
The problem is that the `DescribeInstances` function is expected to return an ordered list (based on the instance ID); the first instance with `Instance.ID` of `0` is expected to be destroyed.

The problem is order is not guaranteed in the `all` `map`. The fix to first sort the keys in the `map` and then returned on ordered list.

Closes #614

Signed-off-by: Steven Kaufer <kaufer@us.ibm.com>