### PR TITLE
Terraform plugin locking updates

### DIFF
--- a/pkg/provider/terraform/instance/apply.go
+++ b/pkg/provider/terraform/instance/apply.go
@@ -76,8 +76,8 @@ func (p *plugin) terraformApply() error {
 // doTerraformApply executes "terraform apply" if it can aquire the lock. Returns
 // true/false if the command was executed and an error
 func (p *plugin) doTerraformApply(initial bool) (bool, error) {
-	if err := p.lock.TryLock(); err == nil {
-		defer p.lock.Unlock()
+	if err := p.fsLock.TryLock(); err == nil {
+		defer p.fsLock.Unlock()
 		// The trigger for the initial apply is typically from a group commit, sleep
 		// for a few seconds so that multiple .tf.json files have time to be created
 		if initial {


### PR DESCRIPTION
Terraform uses the filesystem for everything and we need to protect access whenever we need to modify one or more files. Currently, during Provision, the lock is acquired to determine a unique filename and then immediately released; this in case the file has not yet been written so a parallel API call could run in the same second and get the same filename.

This commit protects (via a common lock) the following operations:
* Provision: Hold until the file is written out (the apply is done in a goroutine which also gets the lock -- sleep/retry if it cannot)
* Label: Just like Provision, hold until the file is written out
* Destroy: Just like Provision, hold until the file is removed
* Describe: Only hold when reading all of the files

Signed-off-by: Steven Kaufer <kaufer@us.ibm.com>