### PR TITLE
vCenter updates

### DIFF
--- a/pkg/provider/vsphere/README.md
+++ b/pkg/provider/vsphere/README.md
@@ -1,40 +1,108 @@
-InfraKit Instance Plugin - VMware vCenter/vSphere
+InfraKit Instance Plugin - VMware vCenter
 ===============================
 
-This plugin allows Docker InfraKit to automate the provisioning of Virtual Machine instances. 
+An [InfraKit](https://github.com/docker/infrakit/blob/master/README.md) plugin
+for creating and managing Virtual Machine resources inside of [VMware vCenter](https://www.vmware.com/products/vcenter-server.html). This plugin communicates directly with the VMware vCenter Web SDK through the use of the VMware [govmomi](https://github.com/vmware/govmomi) library.
 
-### Current State
-- InfraKit will provision from LinuxKit `.iso` files that can be uploaded using the `$ linuxkit push vcenter <args> file.iso` command.
+## Building and Running
+
+To build the vsphere plugin, run `make binaries`. The plugin will be located at `./build/infrakist-instance-vsphere`.
+
+The *minimum* requirement to start the plugin is the URL+Credentials of a VMware vCenter server in the form of: `https://``Username`:`Password`@`vCenterAddress/sdk`
+This can either be passed to through the environment variable `VCURL` or with the flag `--url=`.
+
+#### NOTE:
+For **Testing** purposes the plugin can also be started with `--ignoreOnDestroy=true`, when this is set InfraKit will not actually delete VMs but only "label" them as deleted.
+
+## Plugin Design
+
+The vCenter Plugin makes use of two methods to track InfraKit instances:
+
+- vCenter Folders, that follow the naming convention of the InfraKit Group
+- vSphere VM annotation notes that are applied to each new created VM, that track both the group attachement and the configuration. The configuration tracking allows InfraKit to know when a VM will need rebuilding from a new config.
+
+When the plugin needs to identify VMs that it is managing it will:
+
+1. Retrieve VMs from the folder that matches the InfraKit group name.
+2. It will then iterate through those VMs looking at the annotation to identify VMs that InfraKit manages in that folder.
+3. It will then only return to InfraKit the VMs that are both in the folder and have the InfraKit group ID attached to them, all other VMs are ignored by InfraKit.
+
+This allows end-users to drag runnning VMs from the folder for other use cases (such as debugging and VM inspection). When that VM is removed, InfraKit will notice that the Virtual Machine allocation for the folder is incorrect and rebalance the group.
+
+## Supported Features
+
+- Multiple DataCentre support (for people with multiple DCs in a vCenter cluster)
+- Use of Folders and VM annotations to track InfraKit VMs
 - Provisioning, Scaling and Destroying
-- An InfraKit Group will create a VMware vCenter folder that will hold all VM instances that are tied to that group.
-- On vSphere it will use the `annotation` field to hold the InfraKit group and config SHA.
-- Environment variables can be used with the plugin for VMware vCenter configuration:
-	- `VCURL` = URL for VMware vCenter/vSphere `https://User:Pass@X.X.X.X/sdk`
-	- `VCNETWORK` = Name of network e.g. `VM Network`
-	- `VCDATASTORE` = Default Datastore used for new VM Instances
-	- `VCHOST` = Name of the main vSphere host that will be used.
-- The following JSON parameters provide VM Instance configuration:
+- Cloning of Virtual Machine Templates, to be used as the base image for new instances
+- Building of new VM instances around LinuxKist `.iso` files that are uploades through the `$ linuxkit push vcenter <args> file.iso` command.
+- Capability to identify VM guest IP address settings throught the `infrakit group describe <groupID>`
+- Can be used with a single vSphere Host, however Folders aren't supported so all VMs will end up as part of the root structure.
+
+## Plugin Usage
+
+### Additional flags / environment variables when starting the plugin
+
+- `--datacenter` or `VCDATACENTER` = name of a Datacenter within vCenter
+- `--network` or env `VCNETWORK` = Name of network e.g. `VM Network`
+- `--datastore` or `VCDATASTORE` = Default Datastore used for new VM Instances
+- `--hostname` or `VCHOST` = Name of the main vSphere host that will be used
+
+**Note**: These may be depricated as they should be `commited` through the infrakit cli instead.
+
+### Example JSON with a Template
+```
+      "Properties": {
+         "Datastore" : "datastore1",
+         "Network" : "VM Network",
+         "Hostname" : "localhost.localdomain",
+         "Template" : "CentOS7 - NGINX",
+         "VMPrefix" : "lk", 
+         "PowerOn" : true
+      }
+```
+
+### Example JSON with LinuxKit
 
 ```
       "Properties": {
          "Datastore" : "datastore1",
          "Network" : "VM Network",
          "Hostname" : "localhost.localdomain",
-         "isoPath" : "linuxkit/linuxkit.iso",
+         "ISOPath" : "linuxkit/linuxkit.iso",
          "CPUs" : "1",
          "MEM" : "512",
-         "vmPrefix" : "lk", 
-         "powerOn" : true
+         "VMPrefix" : "lk", 
+         "PowerOn" : true
       }
-
 ```
-- Moved to `pkg/providers/vsphere`
 
 
-## To Do
-- Investigate error messages, when using vSphere instead of VMware vCenter
-- VMware Template support `.vmtx`
-- `Makefile` needs updating
+## Outstanding Issues
+
+- On initial creation of VMs, there can be a warning as the plugin can try to create the same folder in quick succession to hold the new VMs. **However**, these errors can be ignored as the plugin will safely create the new VM instances once the folder has been created.
+- The Plugin will login to vCenter when first started and will continue to remain logged in **only** whilst it is monitoring created instances. If all instances are destroyed and the plugin isn't monitoring vCenter then the login will eventually timeout and the plugin will need restarting.
+
+## Reporting security issues
+
+The maintainers take security seriously. If you discover a security issue,
+please bring it to their attention right away!
+
+Please **DO NOT** file a public issue, instead send your report privately to
+[security@docker.com](mailto:security@docker.com).
+
+Security reports are greatly appreciated and we will publicly thank you for it.
+We also like to send gifts—if you're into Docker schwag, make sure to let
+us know. We currently do not offer a paid security bounty program, but are not
+ruling it out in the future.
 
 
+## Copyright and license
+
+Copyright © 2016 Docker, Inc. All rights reserved, except as follows. Code
+is released under the Apache 2.0 license. The README.md file, and files in the
+"docs" folder are licensed under the Creative Commons Attribution 4.0
+International License under the terms and conditions set forth in the file
+"LICENSE.docs". You may obtain a duplicate copy of the same license, titled
+CC-BY-SA-4.0, at http://creativecommons.org/licenses/by/4.0/.
 

--- a/pkg/provider/vsphere/main.go
+++ b/pkg/provider/vsphere/main.go
@@ -29,9 +29,12 @@ func main() {
 	newVCenter.networkName = cmd.Flags().String("network", os.Getenv("VCNETWORK"), "The network label the VM will use")
 	newVCenter.vSphereHost = cmd.Flags().String("hostname", os.Getenv("VCHOST"), "The server that will run the VM")
 
+	// Testing flag to ensure VMs are never deleted
+	ignoreOnDestroy := cmd.Flags().Bool("ignoreOnDestroy", false, "When set to true, InfraKit will only Mark VMs as deleted")
+
 	cmd.Run = func(c *cobra.Command, args []string) {
 		cli.SetLogLevel(*logLevel)
-		cli.RunPlugin(*name, instance_plugin.PluginServer(NewVSphereInstancePlugin(&newVCenter)))
+		cli.RunPlugin(*name, instance_plugin.PluginServer(NewVSphereInstancePlugin(&newVCenter, *ignoreOnDestroy)))
 	}
 
 	cmd.AddCommand(cli.VersionCommand())

--- a/pkg/provider/vsphere/vsphere.go
+++ b/pkg/provider/vsphere/vsphere.go
@@ -34,10 +34,13 @@ type vmInstance struct {
 
 	// Used with LinuxKit ISOs
 	isoPath string
+
 	// Used with a VMware VM template
 	vmTemplate string
+	// TODO - Add in reading template from one DS and deploy to another
+	vmTemplateDatastore string
 
-	// Used by InfraKit to tack group
+	// Used by InfraKit to track group
 	groupTag string
 
 	// Folder that will store all InfraKit instances
@@ -162,9 +165,13 @@ func parseParameters(properties map[string]interface{}, p *plugin) (vmInstance, 
 	}
 
 	if properties["isoPath"] == nil {
-		log.Debugf("The property 'isoPath' hasn't been set, no networks will be attached to VM")
+		log.Debugf("The property 'isoPath' hasn't been set, bootable ISO will not be added to the VM")
 	} else {
 		newInstance.isoPath = properties["isoPath"].(string)
+	}
+
+	if properties["Template"] != nil {
+		newInstance.vmTemplate = properties["Template"].(string)
 	}
 
 	if properties["CPUs"] == nil {
@@ -186,10 +193,10 @@ func parseParameters(properties map[string]interface{}, p *plugin) (vmInstance, 
 		newInstance.persistentSz = int(properties["persistantSZ"].(float64))
 	}
 
-	if properties["powerOn"] == nil {
+	if properties["PowerOn"] == nil {
 		newInstance.poweron = false
 	} else {
-		newInstance.poweron = bool(properties["powerOn"].(bool))
+		newInstance.poweron = bool(properties["PowerOn"].(bool))
 	}
 
 	return newInstance, nil


### PR DESCRIPTION
- VMware Template Support (no longer tied to LinuxKit)
- Updated Documentation
- Better handling of InfraKit instances (ALWAYS tied to VM labels now)
- Capability to have ignored instead of deleted instances
- Removed unneeded contexts

Signed-off-by: Dan Finneran <daniel.finneran@gmail.com>