### PR TITLE
Update terraform show parsing code

### DIFF
--- a/pkg/provider/terraform/instance/show.go
+++ b/pkg/provider/terraform/instance/show.go
@@ -2,14 +2,30 @@ package main
 
 import (
 	"bufio"
+	"fmt"
 	"io"
 	"regexp"
+	"sort"
+	"strconv"
+	"strings"
 
 	"github.com/docker/infrakit/pkg/util/exec"
 )
 
+// title matches a line like: "aws_security_group.default:"
 var title = regexp.MustCompile("^(.*)\\.(.*):$")
-var properties = regexp.MustCompile("[ ]+(.*)[ ]+=[ ]+(.*)$")
+
+// properties matches a line like: "  id = igw-c5fcffac"
+var properties = regexp.MustCompile("^[ ]+(.*)[ ]+=[ ]+(.*)$")
+
+// listRegx matches a kye in a line like: "  egress.# = 1"
+var sliceRegex = regexp.MustCompile("^([^.]+)\\.#")
+
+// mapInsliceRegex matches a key in a line like: "  egress.482069346.cidr_blocks.# = 1"
+var mapInSliceRegex = regexp.MustCompile("^([^.]+)\\.([0-9]+)\\.(.*)")
+
+// mapRegex matches a key in a line like: "  tags.% = 1"
+var mapRegex = regexp.MustCompile("^([^.]+)\\.%")
 
 // TerraformShow calls terraform show and scans the result for the given resource type
 // and returns a map of properties by name.
@@ -41,11 +57,31 @@ var properties = regexp.MustCompile("[ ]+(.*)[ ]+=[ ]+(.*)$")
 //   main_route_table_id = rtb-7bf68e13
 //   tags.% = 1
 //   tags.provisioner = infrakit-terraform-demo
+// ibm_compute_vm_instance.instance-1499827079:
+//   id = 36147555
+//   cores = 1
+//   datacenter = dal10
+//   file_storage_ids.# = 0
+//   hostname = worker-1499827079
+//   memory = 2048
+//   ssh_key_ids.# = 1
+//   ssh_key_ids.0 = 123456
+//   tags.# = 5
+//   tags.1516831048 = infrakit.group:workers
+//   tags.3434794676 = infrakit.config_sha:tubmesopo6lrsfnl5otajlpvwd23v46j
+//   tags.356689043 = name:instance-1499827079
+//   tags.3639269190 = infrakit-link-context:swarm::c80s4c4kq0kgjs64ojxzvsdjz::worker
+//   tags.838324444 = swarm-id:c80s4c4kq0kgjs64ojxzvsdjz
+//   user_metadata = set -o errexit
+// set -o nounset
+// set -o xtrace
+// apt-get -y update
 func parseTerraformShowOutput(byType TResourceType, input io.Reader) (map[TResourceName]TResourceProperties, error) {
 	found := map[TResourceName]TResourceProperties{}
 
 	reader := bufio.NewReader(input)
 	var resourceName TResourceName
+	var propKey string
 	for {
 		line, _, err := reader.ReadLine()
 		if err != nil {
@@ -53,29 +89,127 @@ func parseTerraformShowOutput(byType TResourceType, input io.Reader) (map[TResou
 		}
 
 		m := title.FindAllStringSubmatch(string(line), -1)
-		if m != nil && len(m[0][1]) > 0 && len(m[0][1]) > 0 {
-
+		if m != nil && len(m[0][1]) > 0 && len(m[0][2]) > 0 {
+			// Line is for a new resource type
 			resourceType := TResourceType(m[0][1])
-			resourceName = TResourceName(m[0][2])
-
 			if resourceType != byType {
+				resourceName = ""
 				continue
 			}
+			resourceName = TResourceName(m[0][2])
 			found[resourceName] = TResourceProperties{}
-
-		} else {
-			p := properties.FindAllStringSubmatch(string(line), -1)
-			if p != nil && len(p[0][1]) > 0 && len(p[0][2]) > 0 {
-				key := p[0][1]
-				value := p[0][2]
-
-				if props, has := found[resourceName]; has {
-					props[key] = value
+		} else if resourceName != "" {
+			if props, has := found[resourceName]; has {
+				p := properties.FindAllStringSubmatch(string(line), -1)
+				if p != nil && len(p[0][1]) > 0 {
+					propKey = strings.TrimSpace(p[0][1])
+					value := strings.TrimSpace(p[0][2])
+					props[propKey] = value
+				} else {
+					// Append to previous key
+					props[propKey] = fmt.Sprintf("%s\n%s", props[propKey], line)
 				}
 			}
 		}
 	}
+	// Process the properties to convert from string to native types
+	for _, props := range found {
+		expandProps(props)
+	}
 	return found, nil
+}
+
+// expandProps converts the flattened resource definition into native JSON types
+func expandProps(props map[string]interface{}) {
+	// Sort all keys to group maps and slices
+	keys := make([]string, len(props))
+	i := 0
+	for key := range props {
+		keys[i] = key
+		i++
+	}
+	sort.Strings(keys)
+
+	for i, key := range keys {
+		// Map keys in form: <key>.%
+		if m := mapRegex.FindAllStringSubmatch(key, -1); len(m) > 0 {
+			prefix := m[0][1]
+			nestedProps := map[string]interface{}{}
+			// Get all of the keys with the same prefix
+			for (i + 1) < len(keys) {
+				if !strings.HasPrefix(keys[i+1], prefix+".") {
+					break
+				}
+				i++
+				curKey := keys[i]
+				// Remove common prefix and add to nested map
+				nestedKey := strings.Replace(curKey, prefix+".", "", 1)
+				nestedProps[nestedKey] = props[curKey]
+			}
+			// No more additional keys, process the properties in the map and associate
+			// with the common key
+			expandProps(nestedProps)
+			props[prefix] = nestedProps
+			continue
+		}
+		// List keys in form: <key>.#
+		if m := sliceRegex.FindAllStringSubmatch(key, -1); len(m) > 0 {
+			prefix := m[0][1]
+			slice := []interface{}{}
+			nestedProps := map[string]interface{}{}
+			// Get all of the keys with the same prefix
+			for (i + 1) < len(keys) {
+				if !strings.HasPrefix(keys[i+1], prefix+".") {
+					break
+				}
+				i++
+				curKey := keys[i]
+				// Map in slice in form: <prefix>.482069346.cidr_blocks.#
+				if m := mapInSliceRegex.FindAllStringSubmatch(curKey, -1); len(m) > 0 {
+					nestedPropsKey := m[0][2] // Common hash for map values, used to group
+					suffix := m[0][3]
+					if nestedMap, has := nestedProps[nestedPropsKey]; has {
+						nestedMap.(map[string]interface{})[suffix] = props[curKey]
+					} else {
+						nestedProps[nestedPropsKey] = map[string]interface{}{
+							suffix: props[curKey],
+						}
+					}
+				} else {
+					slice = append(slice, convertToType(props[curKey].(string)))
+				}
+			}
+			for _, nestedMap := range nestedProps {
+				expandProps(nestedMap.(map[string]interface{}))
+				slice = append(slice, nestedMap)
+			}
+			props[prefix] = slice
+			continue
+		}
+	}
+	for _, key := range keys {
+		// Ignore list and map key values, they have already been expanded
+		if strings.Contains(key, ".") {
+			delete(props, key)
+			continue
+		}
+		val := props[key]
+		props[key] = convertToType(val.(string))
+	}
+}
+
+// convertToType converts the string to a native int, float, or bool type
+func convertToType(val string) interface{} {
+	if intVal, err := strconv.Atoi(val); err == nil {
+		return intVal
+	}
+	if floatVal, err := strconv.ParseFloat(val, 64); err == nil {
+		return floatVal
+	}
+	if boolVar, err := strconv.ParseBool(val); err == nil {
+		return boolVar
+	}
+	return val
 }
 
 // doTerraformShow shells out to run `terraform show` and parses the result

--- a/pkg/provider/terraform/instance/show_test.go
+++ b/pkg/provider/terraform/instance/show_test.go
@@ -4,12 +4,190 @@ import (
 	"bytes"
 	"os"
 	"path"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/require"
 
 	. "github.com/docker/infrakit/pkg/testing"
 )
+
+func TestTerraformShowParseResultEmpty(t *testing.T) {
+	found, err := parseTerraformShowOutput(TResourceType("aws_vpc"), bytes.NewBuffer([]byte("")))
+	require.NoError(t, err)
+	require.Equal(t, map[TResourceName]TResourceProperties{}, found)
+}
+
+func TestTerraformShowParseResultResTypes(t *testing.T) {
+	data := []byte(`
+res-type1.host1:
+  id = type1-host1
+res-type1.host2:
+  id = type1-host2
+res-type2.host1:
+  id = type2-host1
+res-type3.host1:
+  id = type3-host1`)
+	found, err := parseTerraformShowOutput(TResourceType("unknown"), bytes.NewBuffer(data))
+	require.NoError(t, err)
+	require.Equal(t, map[TResourceName]TResourceProperties{}, found)
+
+	found, err = parseTerraformShowOutput(TResourceType("res-type1"), bytes.NewBuffer(data))
+	require.NoError(t, err)
+	require.Equal(t, TResourceProperties{"id": "type1-host1"}, found[TResourceName("host1")])
+	require.Equal(t, TResourceProperties{"id": "type1-host2"}, found[TResourceName("host2")])
+
+	found, err = parseTerraformShowOutput(TResourceType("res-type2"), bytes.NewBuffer(data))
+	require.NoError(t, err)
+	require.Equal(t, TResourceProperties{"id": "type2-host1"}, found[TResourceName("host1")])
+
+	found, err = parseTerraformShowOutput(TResourceType("res-type3"), bytes.NewBuffer(data))
+	require.NoError(t, err)
+	require.Equal(t, TResourceProperties{"id": "type3-host1"}, found[TResourceName("host1")])
+}
+
+func TestTerraformShowParseResultEmptyValues(t *testing.T) {
+	// {
+	//   "id": 123,
+	//   "destination_cidr_block": "0.0.0.0/0",
+	//   "destination_prefix_list_id": "",
+	//   "gateway_id": "",
+	//   "instance_id": "",
+	//   "instance_owner_id": "",
+	//   "pie": 3.14
+	// }
+	// Code editors tend to remove the trailing whitespace above, ensure that a space exists
+	// after the equals
+	input := strings.Replace(`
+type.host:
+  id                         = 123
+  destination_cidr_block     = 0.0.0.0/0
+  destination_prefix_list_id =
+  gateway_id                 = igw-c5fcffac
+  instance_id                =
+  instance_owner_id          =
+  pie                        = 3.14
+`, "=\n", "= \n", -1)
+	found, err := parseTerraformShowOutput(TResourceType("type"), bytes.NewBuffer([]byte(input)))
+	require.NoError(t, err)
+	require.Equal(t,
+		TResourceProperties{
+			"id": 123,
+			"destination_cidr_block":     "0.0.0.0/0",
+			"destination_prefix_list_id": "",
+			"gateway_id":                 "igw-c5fcffac",
+			"instance_id":                "",
+			"instance_owner_id":          "",
+			"pie":                        3.14,
+		},
+		found[TResourceName("host")])
+}
+
+func TestTerraformShowParseResultLists(t *testing.T) {
+	// {
+	//   "id": 1,
+	//   "tags": ["tag1", "tag2"],
+	//   "keys": [1, "k2", false],
+	//   "z-foo": "z-bar"
+	// }
+	data := []byte(`
+type.host:
+  id = 1
+  tags.# = 2
+  tags.123 = tag1
+  tags.234 = tag2
+  keys.# = 3
+  keys.123 = 1
+  keys.234 = k2
+  keys.345 = false
+  z-foo = z-bar
+`)
+	found, err := parseTerraformShowOutput(TResourceType("type"), bytes.NewBuffer(data))
+	require.NoError(t, err)
+	require.Equal(t,
+		TResourceProperties{
+			"id":    1,
+			"tags":  []interface{}{"tag1", "tag2"},
+			"keys":  []interface{}{1, "k2", false},
+			"z-foo": "z-bar",
+		},
+		found[TResourceName("host")])
+}
+
+func TestTerraformShowParseResultMaps(t *testing.T) {
+	// {
+	//   "id": 1,
+	//   "tags": {
+	//    "tag1": "v1",
+	//    "tag2": "v2"
+	//   },
+	//   "keys": {
+	//    "key1": 1,
+	//    "key2": "k2",
+	//    "key3": false
+	//   }
+	// }
+	data := []byte(`
+type.host:
+  id = 1
+  tags.% = 2
+  tags.tag1 = v1
+  tags.tag2 = v2
+  keys.% = 3
+  keys.key1 = 1
+  keys.key2 = k2
+  keys.key3 = false
+  z-foo = z-bar
+`)
+	found, err := parseTerraformShowOutput(TResourceType("type"), bytes.NewBuffer(data))
+	require.NoError(t, err)
+	require.Equal(t,
+		TResourceProperties{
+			"id":    1,
+			"tags":  map[string]interface{}{"tag1": "v1", "tag2": "v2"},
+			"keys":  map[string]interface{}{"key1": 1, "key2": "k2", "key3": false},
+			"z-foo": "z-bar",
+		},
+		found[TResourceName("host")])
+}
+
+func TestTerraformShowParseResultNested(t *testing.T) {
+	// {
+	//   "id": 1,
+	//   "tags": [
+	//     {"list1": [1, 2]},
+	//     5,
+	//     {"list2": [3, 4]},
+	//     [
+	//       true, false
+	//     ]
+	//   ]
+	// }
+	data := []byte(`
+type.host:
+  id = 1
+  tags.# = 3
+  tags.111.list1.# = 2
+  tags.111.list1.111 = 1
+  tags.111.list1.222 = 2
+  tags.222 = 5
+  tags.333.list2.# = 2
+  tags.333.list2.111 = 3
+  tags.333.list2.222 = 4
+`)
+	found, err := parseTerraformShowOutput(TResourceType("type"), bytes.NewBuffer(data))
+	require.NoError(t, err)
+	require.Equal(t, 1, len(found))
+	props := found[TResourceName("host")]
+	require.Equal(t, 2, len(props))
+	require.Equal(t, 1, props["id"])
+	// Tag list sort order not guaranteed
+	tags := props["tags"].([]interface{})
+	require.Equal(t, 3, len(tags))
+	require.Contains(t, tags, 5)
+	require.Contains(t, tags, map[string]interface{}{"list1": []interface{}{1, 2}})
+	require.Contains(t, tags, map[string]interface{}{"list2": []interface{}{3, 4}})
+}
 
 var terraformShowOutput = []byte(`
 aws_internet_gateway.default:
@@ -70,6 +248,28 @@ aws_subnet.default:
   tags.% = 1
   tags.provisioner = infrakit-terraform-demo
   vpc_id = vpc-f8d45a90
+ibm_compute_vm_instance.instance-1499827079:
+  id = 36147555
+  cores = 1
+  datacenter = dal10
+  file_storage_ids.# = 0
+  hostname = worker-1499827079
+  memory = 2048
+  ssh_key_ids.# = 1
+  ssh_key_ids.0 = 123456
+  tags.# = 5
+  tags.1516831048 = infrakit.group:workers
+  tags.3434794676 = infrakit.config_sha:tubmesopo6lrsfnl5otajlpvwd23v46j
+  tags.356689043 = name:instance-1499827079
+  tags.3639269190 = infrakit-link-context:swarm::c80s4c4kq0kgjs64ojxzvsdjz::worker
+  tags.838324444 = swarm-id:c80s4c4kq0kgjs64ojxzvsdjz
+  user_metadata = set -o errexit
+set -o nounset
+set -o xtrace
+apt-get -y update
+FOO=BAR
+echo $FOO
+  z_prop = z_val
 aws_vpc.default:
   id = vpc-f8d45a90
   cidr_block = 10.0.0.0/16
@@ -85,11 +285,33 @@ aws_vpc.default:
   tags.provisioner = infrakit-terraform-demo
 `)
 
-func TestTerraformShowParseResult(t *testing.T) {
+func TestTerraformShowParseResultTagsList(t *testing.T) {
 
+	found, err := parseTerraformShowOutput(TResourceType("ibm_compute_vm_instance"), bytes.NewBuffer(terraformShowOutput))
+	require.NoError(t, err)
+	require.Equal(t, TResourceProperties{
+		"id":               36147555,
+		"cores":            1,
+		"datacenter":       "dal10",
+		"file_storage_ids": []interface{}{},
+		"hostname":         "worker-1499827079",
+		"memory":           2048,
+		"ssh_key_ids":      []interface{}{123456},
+		"tags": []interface{}{
+			"infrakit.group:workers",
+			"infrakit.config_sha:tubmesopo6lrsfnl5otajlpvwd23v46j",
+			"name:instance-1499827079",
+			"infrakit-link-context:swarm::c80s4c4kq0kgjs64ojxzvsdjz::worker",
+			"swarm-id:c80s4c4kq0kgjs64ojxzvsdjz",
+		},
+		"user_metadata": "set -o errexit\nset -o nounset\nset -o xtrace\napt-get -y update\nFOO=BAR\necho $FOO",
+		"z_prop":        "z_val",
+	}, found[TResourceName("instance-1499827079")])
+}
+
+func TestTerraformShowParseResultAwsVpc(t *testing.T) {
 	found, err := parseTerraformShowOutput(TResourceType("aws_vpc"), bytes.NewBuffer(terraformShowOutput))
 	require.NoError(t, err)
-	T(100).Info(found)
 	require.Equal(t, TResourceProperties{
 		"id":                        "vpc-f8d45a90",
 		"cidr_block":                "10.0.0.0/16",
@@ -97,13 +319,80 @@ func TestTerraformShowParseResult(t *testing.T) {
 		"default_route_table_id":    "rtb-7bf68e13",
 		"default_security_group_id": "sg-1403ab7f",
 		"dhcp_options_id":           "dopt-b632fedf",
-		"enable_dns_hostnames":      "false",
-		"enable_dns_support":        "true",
+		"enable_dns_hostnames":      false,
+		"enable_dns_support":        true,
 		"instance_tenancy":          "default",
 		"main_route_table_id":       "rtb-7bf68e13",
-		"tags.%":                    "1",
-		"tags.provisioner":          "infrakit-terraform-demo",
+		"tags":                      map[string]interface{}{"provisioner": "infrakit-terraform-demo"},
 	}, found[TResourceName("default")])
+}
+
+func TestTerraformShowParseResultAwsSubnet(t *testing.T) {
+	found, err := parseTerraformShowOutput(TResourceType("aws_subnet"), bytes.NewBuffer(terraformShowOutput))
+	require.NoError(t, err)
+	require.Equal(t, TResourceProperties{
+		"id":                      "subnet-32feb75a",
+		"availability_zone":       "eu-central-1a",
+		"cidr_block":              "10.0.1.0/24",
+		"map_public_ip_on_launch": true,
+		"tags":   map[string]interface{}{"provisioner": "infrakit-terraform-demo"},
+		"vpc_id": "vpc-f8d45a90",
+	}, found[TResourceName("default")])
+}
+
+func TestTerraformShowParseResultAwsSecurityGroup(t *testing.T) {
+	found, err := parseTerraformShowOutput(TResourceType("aws_security_group"), bytes.NewBuffer(terraformShowOutput))
+	require.NoError(t, err)
+	require.Equal(t, 1, len(found))
+	props := found[TResourceName("default")]
+	// List sort order for "ingress" is not guananteed, check separately
+	ingress := props["ingress"].([]interface{})
+	delete(props, "ingress")
+	require.Equal(t, 2, len(ingress))
+	require.Contains(t,
+		ingress,
+		map[string]interface{}{
+			"cidr_blocks":     []interface{}{"10.0.0.0/16"},
+			"from_port":       80,
+			"protocol":        "tcp",
+			"security_groups": []interface{}{},
+			"self":            false,
+			"to_port":         80,
+		},
+	)
+	require.Contains(t,
+		ingress,
+		map[string]interface{}{
+			"cidr_blocks":     []interface{}{"0.0.0.0/0"},
+			"from_port":       22,
+			"protocol":        "tcp",
+			"security_groups": []interface{}{},
+			"self":            false,
+			"to_port":         22,
+		},
+	)
+	// Verify everything else
+	require.Equal(t, TResourceProperties{
+		"id":          "sg-b903abd2",
+		"description": "Used in the terraform",
+		"egress": []interface{}{
+			map[string]interface{}{
+				"cidr_blocks":     []interface{}{"0.0.0.0/0"},
+				"from_port":       0,
+				"prefix_list_ids": []interface{}{},
+				"protocol":        -1,
+				"security_groups": []interface{}{},
+				"self":            false,
+				"to_port":         0,
+			},
+		},
+		"name":     "terraform_example",
+		"owner_id": 41673875206,
+		"tags": map[string]interface{}{
+			"provisioner": "infrakit-terraform-demo",
+		},
+		"vpc_id": "vpc-f8d45a90",
+	}, props)
 }
 
 func TestRunTerraformShow(t *testing.T) {


### PR DESCRIPTION
The currently logic needs to be updated to handle:
* Native types: Do not assume that are values are strings
* Lists: Keys that end with `.#` denote a list
* Maps: Keys that end with `.%` denote a map
* Nested maps in a list: List keys with a hash value denote this
* Multi-line values: User-data scripts have newlines

Also adds support to parse the terraform output for a specific resource using `terraform state show <resource>`.