### PR TITLE
Use the global scope as prefix for terraform resource name.

### DIFF
--- a/pkg/provider/terraform/instance/plugin.go
+++ b/pkg/provider/terraform/instance/plugin.go
@@ -491,6 +491,8 @@ func (p *plugin) writeTerraformFiles(logicalID *instance.LogicalID, generatedNam
 				filename = fmt.Sprintf("%s-dedicated", generatedName)
 			default:
 				filename = fmt.Sprintf("scope-%s", scope)
+				// If the scope is global use it as the prefix for the resource name
+				newResourceName = fmt.Sprintf("%s-%s", scope, resourceName)
 			}
 			// Get the associated value in the file map
 			tfPersistence, has := fileMap[filename]

--- a/pkg/provider/terraform/instance/plugin_test.go
+++ b/pkg/provider/terraform/instance/plugin_test.go
@@ -1091,6 +1091,7 @@ func TestWriteTerraformFilesMultipleResourcesScopeTypes(t *testing.T) {
 	tf, dir := getPlugin(t)
 	defer os.RemoveAll(dir)
 	name := "instance-1234"
+	globalName := "managers"
 	m := map[TResourceType]map[TResourceName]TResourceProperties{
 		VMAmazon: {
 			TResourceName("host"): {
@@ -1107,7 +1108,7 @@ func TestWriteTerraformFilesMultipleResourcesScopeTypes(t *testing.T) {
 		TResourceType("softlayer_block_storage"): {
 			TResourceName("worker_bs"): {
 				"bsp1": "bsv1", "bsp2": "bsv2",
-				PropScope: "managers",
+				PropScope: globalName,
 			},
 		},
 		TResourceType("another-dedicated"): {
@@ -1137,7 +1138,8 @@ func TestWriteTerraformFilesMultipleResourcesScopeTypes(t *testing.T) {
 	}
 	require.Contains(t, filenames, fmt.Sprintf("%s.tf.json", name))
 	require.Contains(t, filenames, fmt.Sprintf("%s-dedicated.tf.json", name))
-	require.Contains(t, filenames, "scope-managers.tf.json")
+	expectedGlobalFilename := fmt.Sprintf("scope-%s.tf.json", globalName)
+	require.Contains(t, filenames, expectedGlobalFilename)
 	// Default
 	buff, err := ioutil.ReadFile(filepath.Join(tf.Dir, fmt.Sprintf("%s.tf.json", name)))
 	require.NoError(t, err)
@@ -1178,7 +1180,7 @@ func TestWriteTerraformFilesMultipleResourcesScopeTypes(t *testing.T) {
 		tFormat.Resource,
 	)
 	// Global
-	buff, err = ioutil.ReadFile(filepath.Join(tf.Dir, "scope-managers.tf.json"))
+	buff, err = ioutil.ReadFile(filepath.Join(tf.Dir, expectedGlobalFilename))
 	require.NoError(t, err)
 	tFormat = TFormat{}
 	err = types.AnyBytes(buff).Decode(&tFormat)
@@ -1186,7 +1188,7 @@ func TestWriteTerraformFilesMultipleResourcesScopeTypes(t *testing.T) {
 	require.Equal(t,
 		map[TResourceType]map[TResourceName]TResourceProperties{
 			TResourceType("softlayer_block_storage"): {
-				TResourceName(name + "-worker_bs"): {"bsp1": "bsv1", "bsp2": "bsv2"},
+				TResourceName(globalName + "-worker_bs"): {"bsp1": "bsv1", "bsp2": "bsv2"},
 			},
 		},
 		tFormat.Resource,


### PR DESCRIPTION
If specifying a resource with a global scope, the resource name
used in the terraform file should be \<scope>-\<resource> instead
of using instance id.

Signed-off-by: craigyam@us.ibm.com \<craigyam@us.ibm.com>