### PR TITLE
Change logging package

### DIFF
--- a/pkg/fsm/clock_test.go
+++ b/pkg/fsm/clock_test.go
@@ -4,7 +4,6 @@ import (
 	"testing"
 	"time"
 
-	log "github.com/golang/glog"
 	"github.com/stretchr/testify/require"
 )
 
@@ -25,19 +24,19 @@ func TestClock(t *testing.T) {
 		}
 	}()
 
-	log.Infoln("Start")
+	t.Log("Start")
 	close(start)
 	clock.Start()
 	clock.Tick()
 	clock.Tick()
 	clock.Tick()
 
-	log.Infoln("Stopping")
+	t.Log("Stopping")
 	clock.Stop()
 
-	log.Infoln("waiting for done")
+	t.Log("waiting for done")
 	<-done
-	log.Infoln("done")
+	t.Log("done")
 }
 
 func TestWallClock(t *testing.T) {
@@ -78,25 +77,25 @@ func TestWallClock2(t *testing.T) {
 			if !open {
 				return
 			}
-			log.Infoln("tick")
+			t.Log("tick")
 			ticks <- 1
 		}
 	}()
 
 	close(start)
 	clock.Start()
-	log.Infoln("starting")
+	t.Log("starting")
 
 	time.Sleep(1 * time.Second)
 
-	log.Infoln("Stopping")
+	t.Log("Stopping")
 	clock.Stop()
-	log.Infoln("Stopped")
+	t.Log("Stopped")
 
 	total := 0
 	for i := range ticks {
 		total += i
 	}
-	log.Infoln("count=", total)
+	t.Log("count=", total)
 	require.Equal(t, 10, total)
 }

--- a/pkg/fsm/flap.go
+++ b/pkg/fsm/flap.go
@@ -1,9 +1,5 @@
 package fsm
 
-import (
-	log "github.com/golang/glog"
-)
-
 func newFlaps() *flaps {
 	return &flaps{
 		history: []Index{},
@@ -32,7 +28,7 @@ func equals(i, j []Index) bool {
 
 func (f *flaps) record(a, b Index) {
 	old := append([]Index{}, f.history...)
-	defer func() { log.V(100).Infoln("record: before=", old, "|", a, b, "after=", f.history) }()
+	defer func() { log.Debug("record", "before", old, "a", a, "b", b, "after", f.history) }()
 
 	if len(f.history) == 0 {
 		f.history = []Index{a, b}
@@ -56,7 +52,7 @@ func (f *flaps) count(a, b Index) int {
 	}
 
 	count := 0
-	defer func() { log.Infoln("search: search=", search, "history=", f.history, "count=", count) }()
+	defer func() { log.Debug("search", "search", search, "history", f.history, "count", count) }()
 
 	for i := len(f.history); i > 2; i = i - 2 {
 		check := f.history[i-3 : i]

--- a/pkg/fsm/fsm.go
+++ b/pkg/fsm/fsm.go
@@ -1,9 +1,5 @@
 package fsm
 
-import (
-	log "github.com/golang/glog"
-)
-
 // Index is the index of the state in a FSM
 type Index int
 
@@ -88,7 +84,7 @@ func Define(s State, more ...State) (spec *Spec, err error) {
 	spec.states = states
 	spec.signals = signals
 
-	log.V(100).Infoln("signals=", signals)
+	log.Debug("signals", "signals", signals)
 	return
 }
 
@@ -116,7 +112,7 @@ func compile(m map[Index]State) (map[Signal]Signal, error) {
 		// Check all the signal references in Actions must be in transitions
 		for signal, action := range s.Actions {
 			if _, has := s.Transitions[signal]; !has {
-				log.Warningln("actions has signal that's not in state's transitions:", s.Index, signal)
+				log.Warn("actions has signal that's not in state's transitions", "state", s.Index, "signal", signal)
 				return nil, unknownTransition(signal)
 			}
 
@@ -135,7 +131,7 @@ func compile(m map[Index]State) (map[Signal]Signal, error) {
 	for _, s := range m {
 		if s.TTL.TTL > 0 {
 			if _, has := s.Transitions[s.TTL.Raise]; !has {
-				log.Warningln("expiry raises signal that's not in state's transitions:", s.Index, s.TTL)
+				log.Warn("expiry raises signal that's not in state's transitions", "state", s.Index, "TTL", s.TTL)
 				return nil, unknownSignal(s.TTL.Raise)
 			}
 
@@ -145,7 +141,7 @@ func compile(m map[Index]State) (map[Signal]Signal, error) {
 		}
 		if s.Visit.Value > 0 {
 			if _, has := s.Transitions[s.Visit.Raise]; !has {
-				log.Warningln("visit limit raises signal that's not in state's transitions:", s.Index, s.Visit)
+				log.Warn("visit limit raises signal that's not in state's transitions", "state", s.Index, "visit", s.Visit)
 				return nil, unknownSignal(s.Visit.Raise)
 			}
 
@@ -226,7 +222,7 @@ func (s *Spec) error(current Index, signal Signal) (next Index, err error) {
 // returns error if the transition is not possible.
 func (s *Spec) transition(current Index, signal Signal) (next Index, action Action, err error) {
 	defer func() {
-		log.V(200).Infoln("transition:", "[", current, "]--(", signal, ")-->[", next, "]", "action=", action, "err=", err)
+		log.Debug("transition:", "current", current, "signal", signal, "next", next, "action", action, "err", err)
 	}()
 
 	state, has := s.states[current]

--- a/pkg/fsm/init.go
+++ b/pkg/fsm/init.go
@@ -1,9 +1,7 @@
 package fsm
 
 import (
-	"flag"
+	logutil "github.com/docker/infrakit/pkg/log"
 )
 
-func init() {
-	flag.Parse()
-}
+var log = logutil.New("module", "core/fsm")

--- a/pkg/fsm/integration_test.go
+++ b/pkg/fsm/integration_test.go
@@ -7,7 +7,6 @@ import (
 	"testing"
 	"time"
 
-	log "github.com/golang/glog"
 	"github.com/stretchr/testify/require"
 )
 
@@ -168,7 +167,7 @@ func TestSimpleProvisionFlow(t *testing.T) {
 	require.NotNil(t, spec)
 
 	clock := Wall(time.Tick(100 * time.Millisecond)) // per tick
-	log.Infoln("Start the clock")
+	t.Log("Start the clock")
 	clock.Start()
 
 	for i := range myCluster.zones {
@@ -181,13 +180,13 @@ func TestSimpleProvisionFlow(t *testing.T) {
 		}
 	}()
 
-	log.Infoln("Creating", myCluster.size, "instances across", len(myCluster.zones), "zones.")
+	t.Log("Creating", myCluster.size, "instances across", len(myCluster.zones), "zones.")
 
 	for i := 0; i < myCluster.size; i++ {
 		myCluster.zones[i%zones].Add(specified)
 	}
 
-	log.Infoln("Specified all instances based on spec:")
+	t.Log("Specified all instances based on spec:")
 	require.Equal(t, myCluster.size, func() int {
 		total := 0
 		for i := range myCluster.zones {
@@ -207,7 +206,7 @@ func TestSimpleProvisionFlow(t *testing.T) {
 		world = append(world, id)
 	}
 
-	log.Infoln("Discover a few instances over 3 zones", described)
+	t.Log("Discover a few instances over 3 zones", described)
 	// label / associate with the fsm instances
 	associated := 0
 	for i := range make([]int, zones) {
@@ -278,7 +277,7 @@ func TestSimpleProvisionFlow(t *testing.T) {
 
 					az.Signal(found, id, instanceID)
 
-					log.Infoln("associated", id, "to", instanceID)
+					t.Log("associated", id, "to", instanceID)
 
 				}
 
@@ -293,7 +292,7 @@ func TestSimpleProvisionFlow(t *testing.T) {
 
 	require.Equal(t, 30, myCluster.countByState(allocated))
 
-	log.Infoln("make sure everyone is associated with an instance id from the infrastructure")
+	t.Log("make sure everyone is associated with an instance id from the infrastructure")
 
 	for i := range myCluster.zones {
 		az := myCluster.zones[i]

--- a/pkg/fsm/set_test.go
+++ b/pkg/fsm/set_test.go
@@ -5,7 +5,6 @@ import (
 	"testing"
 	"time"
 
-	log "github.com/golang/glog"
 	"github.com/stretchr/testify/require"
 )
 
@@ -146,7 +145,7 @@ func TestSetDeadlineTransition(t *testing.T) {
 
 	clock.Tick() // t = 5
 
-	time.Sleep(2 * time.Second) // give a little time for the set to settle
+	time.Sleep(3 * time.Second) // give a little time for the set to settle
 
 	require.Equal(t, 100, set.CountByState(running))
 	require.Equal(t, 0, set.CountByState(wait))
@@ -233,7 +232,7 @@ func TestSetFlapping(t *testing.T) {
 	require.Equal(t, 1, set.CountByState(running))
 	require.Equal(t, running, instance.State())
 
-	log.Infoln("************************* running -> down")
+	t.Log("************************* running -> down")
 
 	set.Signal(timeout, id) // flap 1 - a
 
@@ -246,40 +245,40 @@ func TestSetFlapping(t *testing.T) {
 
 	clock.Tick()
 
-	log.Infoln("************************* down -> running")
+	t.Log("************************* down -> running")
 
 	set.Signal(ping, id) // flap 1 - b
 
 	require.Equal(t, 1, set.CountByState(running))
 	require.Equal(t, running, instance.State())
 
-	log.Infoln("************************* running -> down")
+	t.Log("************************* running -> down")
 
 	set.Signal(timeout, id) // flap 2
 
 	require.Equal(t, 1, set.CountByState(down))
 	require.Equal(t, down, instance.State())
 
-	log.Infoln("************************* running -> down")
+	t.Log("************************* running -> down")
 
 	require.False(t, instance.CanReceive(timeout))
 
 	err = instance.Signal(timeout)
 	require.NoError(t, err) // This does no checking
 
-	log.Infoln("************************* down -> running")
+	t.Log("************************* down -> running")
 
 	set.Signal(ping, id) // flap 2
 
-	log.Infoln("************************* running -> down")
+	t.Log("************************* running -> down")
 
 	set.Signal(timeout, id) // flap 2
 
-	log.Infoln("************************* down -> running")
+	t.Log("************************* down -> running")
 
 	set.Signal(ping, id) // flap 3
 
-	log.Infoln("************************* running -> down")
+	t.Log("************************* running -> down")
 
 	set.Signal(timeout, id) // flap 3
 
@@ -449,5 +448,5 @@ func TestActionErrors(t *testing.T) {
 	// then automatically triggered to the unavailable state
 	require.Equal(t, unavailable, instance.State())
 
-	log.Infoln("stopping")
+	t.Log("stopping")
 }


### PR DESCRIPTION
The use of glog package for logging creates a conflict in the cobra commands and flags.  Specifically, the glog package defines flag `-v` which conflicts with the `-v` option of template variables (`--var`).  So whenever a package that uses glog is imported and used with standard infrakit cli services (see `pkg/cli`), we get a panic from Cobra complaining about redefinition of shorthand (`-v`).   

Since we have already decided to use glog only for test related  code, the FSM package should be cleaned up and modified to use the common logger in `pkg/log`.

Signed-off-by: David Chung <david.chung@docker.com>