### PR TITLE
Removed hardcoded paths to kernel/initrd

### DIFF
--- a/cmd/infrakit/x/remoteboot.go
+++ b/cmd/infrakit/x/remoteboot.go
@@ -16,7 +16,7 @@ const iPXEURL = "https://boot.ipxe.org/undionly.kpxe"
 func remoteBootCommand() *cobra.Command {
 
 	cmd := &cobra.Command{
-		Use:   "remoteboot",
+		Use:   "remoteboot [kernel] [initrd] [\"kernel string\"]",
 		Short: "Used to remotely boot OS instances",
 	}
 
@@ -35,6 +35,10 @@ func remoteBootCommand() *cobra.Command {
 	leasecount := cmd.Flags().Int("leasecount", 20, "Amount of leases to advertise")
 	startAddress := cmd.Flags().String("startAddress", "", "Start advertised address [REQUIRED]")
 
+	// kernelPath := cmd.Flags().String("kernel", "", "Path of the Kernel file [Needs to be within the current working directory]")
+	// initrdPath := cmd.Flags().String("initrd", "", "Path of the initrd file [Needs to be within the current working directory]")
+	// cmdLine := cmd.Flags().String("cmdline", "", "A string containing additional command line options to be passed to the kernel")
+
 	var pulliPXE = &cobra.Command{
 		Use:   "pulliPXE",
 		Short: "Attempts to download iPXE to the current working directory",
@@ -45,6 +49,15 @@ func remoteBootCommand() *cobra.Command {
 	cmd.AddCommand(pulliPXE)
 
 	cmd.RunE = func(c *cobra.Command, args []string) error {
+
+		if len(args) != 3 {
+			fmt.Printf("Argument count = %d\n", len(args))
+
+			if *enableHTTP == true {
+				log.Crit("The arguments for a kernel, initrd and cmdline string are needed")
+				return nil
+			}
+		}
 
 		if *adapter == "" {
 			cmd.Usage()
@@ -65,6 +78,11 @@ func remoteBootCommand() *cobra.Command {
 			*dns,
 			*leasecount,
 			*startAddress)
+		if *enableHTTP == true {
+			remote.Kernel = args[0]
+			remote.Initrd = args[1]
+			remote.Cmdline = args[2]
+		}
 
 		if err != nil {
 			log.Crit("%v", err)

--- a/pkg/x/remoteboot/README.md
+++ b/pkg/x/remoteboot/README.md
@@ -20,8 +20,17 @@ A PXE boot loader is needed to automate the booting process as the system comes 
 
 `./infrakit x remoteboot pulliPXE` 
 
-This will download the iPXE boot loader from the iPXE project site. 
+This will download the iPXE boot loader from the iPXE project site. On first run remoteboot will create a infrakit.ipxe file that contains the auto-built paths to the kernel and initrd. If you change the kernel you'd like to boot from then you'll need to rename or delete the ipxe script.
 
+#### Required Arguments:
+
+**First argument** - path to a kernel file
+
+**Second argument** - path to an initrd file
+
+**Third argument** - kernel command line options e.g. "console=tty0"
+
+e.g. `sudo ./infrakit x remoteboot ./linuxkit-kernel ./linuxkit-initrd.img "console=tty0"  ... flags`
 #### Required Flags:
 
 `--adapter=<X>` This flag is required in order to select the network adapter to bind to.
@@ -50,7 +59,10 @@ $ make build/infrakit
 $ sudo build/infrakit x remoteboot pulliPXE
 Beginning of iPXE download... Completed
 
-$ sudo build/infrakit x remoteboot --adapter=en0 \
+$ sudo build/infrakit x remoteboot ./linuxkit-kernel \
+./linuxkit-initrd.img \
+"console=tty0" \
+--adapter=en0 \
 --startAddress=192.168.0.2 \
 --leaseCount=50 \
 --enableDHCP \
@@ -67,7 +79,7 @@ $ sudo build/infrakit x remoteboot --adapter=en0 \
 ```
 
 ### DHCP
-**NOTE**:  As this advertising networking configuration it is advisable to only use on test networks. As a minimum speak to yur local friendly networking administrator before advertising networking details on their network. 
+**NOTE**:  As this advertising networking configuration it is advisable to only use on test networks. As a minimum speak to your local friendly networking administrator before advertising networking details on their network. 
 
 
 ## Reporting security issues

--- a/pkg/x/remoteboot/remoteboot_test.go
+++ b/pkg/x/remoteboot/remoteboot_test.go
@@ -1,0 +1,36 @@
+package remoteboot
+
+import (
+	"testing"
+)
+
+func TestConvertIP(t *testing.T) {
+	fixedIP := convertIP("10.0.0.1")
+	if len(fixedIP) != 4 {
+		t.Fatalf("Not converted IP address to a four byte sequence")
+	}
+}
+
+func TestNewController(t *testing.T) {
+	bootoutput, err := NewRemoteBoot("NICA",
+		"192.168.0.1",
+		"", //blank HTTP
+		"", //blank TFTP
+		"filename",
+		"", //blank DNS
+		"", //blank GATEWAY
+		20,
+		"192.168.0.2")
+	if bootoutput.httpAddress != bootoutput.dhcpAddress {
+		t.Fatalf("Error allocating HTTP address from DHCP address")
+	}
+	if bootoutput.tftpAddress != bootoutput.dhcpAddress {
+		t.Fatalf("Error allocating TFTP address from DHCP address")
+	}
+	if bootoutput.handler.ip.String() != bootoutput.dhcpAddress {
+		t.Fatalf("Error allocating DHCP lease address from DHCP address")
+	}
+	if err != nil {
+		t.Fatalf("%v", err)
+	}
+}


### PR DESCRIPTION
- Removed hardcoded paths
- Use three arguments to specify kernel/initrd/console
- Updated the ipxe script generate function
- Updated docs
Signed-off-by: Dan Finneran <daniel.finneran@gmail.com>