### PR TITLE
Include "-no-color" in the terraform commands with parsed output

### DIFF
--- a/pkg/provider/terraform/instance/show.go
+++ b/pkg/provider/terraform/instance/show.go
@@ -253,7 +253,7 @@ func convertToType(val string) interface{} {
 func doTerraformShow(dir string,
 	resourceType TResourceType) (result map[TResourceName]TResourceProperties, err error) {
 
-	command := exec.Command(`terraform show`).InheritEnvs(true).WithDir(dir)
+	command := exec.Command("terraform show -no-color").InheritEnvs(true).WithDir(dir)
 	command.StartWithHandlers(
 		nil,
 		func(r io.Reader) error {
@@ -271,7 +271,7 @@ func doTerraformShow(dir string,
 func doTerraformShowForInstance(dir string,
 	instance string) (result TResourceProperties, err error) {
 
-	command := exec.Command(fmt.Sprintf("terraform state show %v", instance)).InheritEnvs(true).WithDir(dir)
+	command := exec.Command(fmt.Sprintf("terraform state show %v -no-color", instance)).InheritEnvs(true).WithDir(dir)
 	command.StartWithHandlers(
 		nil,
 		func(r io.Reader) error {


### PR DESCRIPTION
By default, terraform includes color codes in the output; these are nice to look at but break the regex parsing for the lines (since unexpected characters like `\x1b[0m` are included).

Signed-off-by: Steven Kaufer <kaufer@us.ibm.com>