### PR TITLE
Add support to prune tf.json files that are not in tf state

### DIFF
--- a/pkg/provider/terraform/instance/apply.go
+++ b/pkg/provider/terraform/instance/apply.go
@@ -1,12 +1,19 @@
 package main
 
 import (
+	"bufio"
+	"io"
+	"io/ioutil"
 	"os"
+	"path/filepath"
+	"strings"
 	"time"
 
 	log "github.com/Sirupsen/logrus"
 	manager_discovery "github.com/docker/infrakit/pkg/manager/discovery"
+	"github.com/docker/infrakit/pkg/types"
 	"github.com/docker/infrakit/pkg/util/exec"
+	"github.com/spf13/afero"
 )
 
 // terraformApply starts a goroutine that executes "terraform apply" at the
@@ -36,13 +43,29 @@ func (p *plugin) terraformApply() error {
 		for {
 			// Conditionally apply terraform
 			if p.shouldApply() {
-				attempted, err := p.doTerraformApply(initial)
-				initial = false
-				if err != nil {
-					log.Errorf("Executing 'terraform apply' failed: %v", err)
+				fns := tfFuncs{
+					tfRefresh: func() error {
+						command := exec.Command("terraform refresh").InheritEnvs(true).WithDir(p.Dir)
+						if err := command.WithStdout(os.Stdout).WithStderr(os.Stdout).Start(); err != nil {
+							return err
+						}
+						return command.Wait()
+					},
+					tfStateList: doTerraformStateList,
 				}
-				if !attempted {
-					log.Infof("Can't acquire apply lock, waiting %v seconds", p.pollInterval)
+				// The trigger for an apply is typically from a group commit, sleep for a few seconds so
+				// that multiple .tf.json.new files have time to be created
+				if initial {
+					time.Sleep(time.Second * 5)
+				}
+				if err := p.handleFiles(fns); err == nil {
+					if err = p.doTerraformApply(); err == nil {
+						initial = false
+					} else {
+						log.Errorf("Failed to execute 'terraform apply': %v", err)
+					}
+				} else {
+					log.Errorf("Not executing 'terraform apply' due to error: %v", err)
 				}
 			} else {
 				log.Infof("Not applying terraform, checking again in %v seconds", p.pollInterval)
@@ -64,25 +87,15 @@ func (p *plugin) terraformApply() error {
 	return nil
 }
 
-// doTerraformApply executes "terraform apply" if it can aquire the lock. Returns
-// true/false if the command was executed and an error
-func (p *plugin) doTerraformApply(initial bool) (bool, error) {
-	if err := p.fsLock.TryLock(); err == nil {
-		defer p.fsLock.Unlock()
-		// The trigger for the initial apply is typically from a group commit, sleep
-		// for a few seconds so that multiple .tf.json files have time to be created
-		if initial {
-			time.Sleep(time.Second * 5)
-		}
-		log.Infoln("Applying plan")
-		command := exec.Command(`terraform apply`).InheritEnvs(true).WithDir(p.Dir)
-		err := command.WithStdout(os.Stdout).WithStderr(os.Stdout).Start()
-		if err != nil {
-			return true, err
-		}
-		return true, command.Wait()
+// doTerraformApply executes "terraform apply"
+func (p *plugin) doTerraformApply() error {
+	log.Infoln("Applying plan")
+	command := exec.Command("terraform apply -refresh=false").InheritEnvs(true).WithDir(p.Dir)
+	err := command.WithStdout(os.Stdout).WithStderr(os.Stdout).Start()
+	if err == nil {
+		return command.Wait()
 	}
-	return false, nil
+	return err
 }
 
 // shouldApply returns true if "terraform apply" should execute; this happens if
@@ -109,4 +122,163 @@ func (p *plugin) shouldApply() bool {
 	}
 	log.Infof("Not running on leader manager, not applying terraform")
 	return false
+}
+
+// External functions to use during when pruning files; broken out for testing
+type tfFuncs struct {
+	tfRefresh   func() error
+	tfStateList func(string) (map[TResourceType]map[TResourceName]struct{}, error)
+}
+
+// handleFiles handles resource pruning and new resources via:
+// 1. Acquire file system lock
+// 2. Execute "terraform refresh" to refresh state
+// 3. Identity and remove ".tf.json" files that are in the terraform state
+// 4. Remove all "tf.json.new" files to "tf.json"
+// Once these steps are done then "terraform apply" can execute without the
+// file system lock.
+func (p *plugin) handleFiles(fns tfFuncs) error {
+	if err := p.fsLock.TryLock(); err != nil {
+		log.Infof("In handleFiles, cannot acquire file lock")
+		return err
+	}
+	defer p.fsLock.Unlock()
+
+	// Refresh resources and get updated resources names
+	if err := fns.tfRefresh(); err != nil {
+		return err
+	}
+	tfStateResources, err := fns.tfStateList(p.Dir)
+	if err != nil {
+		return err
+	}
+
+	// Get current file system instances
+	tfFiles := map[TResourceType]map[TResourceName]string{}
+	tfNewFiles := map[TResourceType]map[TResourceName]string{}
+	fs := &afero.Afero{Fs: p.fs}
+	// just scan the directory for the instance-*.tf.json[.new] files
+	err = fs.Walk(p.Dir,
+		func(path string, info os.FileInfo, err error) error {
+			matches := tfFileRegex.FindStringSubmatch(info.Name())
+			if len(matches) == 4 {
+				buff, err := ioutil.ReadFile(filepath.Join(p.Dir, info.Name()))
+				if err != nil {
+					log.Warningln("Cannot parse:", err)
+					return err
+				}
+				tf := TFormat{}
+				if err = types.AnyBytes(buff).Decode(&tf); err != nil {
+					return err
+				}
+				vmType, vmName, _, err := FindVM(&tf)
+				if err != nil {
+					return err
+				}
+				// Populate the correct tf map
+				var tfMap map[TResourceType]map[TResourceName]string
+				if matches[3] == ".new" {
+					tfMap = tfNewFiles
+				} else {
+					tfMap = tfFiles
+				}
+				if _, has := tfMap[vmType]; !has {
+					tfMap[vmType] = map[TResourceName]string{}
+				}
+				tfMap[vmType][vmName] = info.Name()
+			}
+			return nil
+		},
+	)
+	if err != nil {
+		return err
+	}
+
+	// Determine files to prune
+	prunes := []string{}
+	for resType, resNameFilenameMap := range tfFiles {
+		log.Infof("Detected %v tf.json files for resource type %v", len(resNameFilenameMap), resType)
+		if tfStateResNames, has := tfStateResources[resType]; has {
+			// State files have instances of this type, check each resource name
+			for resName, filename := range resNameFilenameMap {
+				if _, has = tfStateResNames[resName]; has {
+					log.Infof("Instance %v.%v exists in terraform state", resType, resName)
+				} else {
+					log.Infof("Detected instance %v.%v to prune at file: %v", resType, resName, filename)
+					prunes = append(prunes, filename)
+				}
+			}
+		} else {
+			// No instances of this type in the state file, all should be removed
+			log.Infof("State files has no resources of type %v, pruning all %v instances ...", resType, len(resNameFilenameMap))
+			for resName, filename := range resNameFilenameMap {
+				log.Infof("Detected instance %v.%v to prune at file: %v", resType, resName, filename)
+				prunes = append(prunes, filename)
+			}
+		}
+	}
+
+	log.Infof("Pruning %v tf.json files", len(prunes))
+	for _, filename := range prunes {
+		path := filepath.Join(p.Dir, filename)
+		err = p.fs.Remove(path)
+		if err != nil {
+			return err
+		}
+	}
+
+	// Move any tf.json.new files
+	if len(tfNewFiles) == 0 {
+		log.Infof("No tf.json.new files to move")
+	} else {
+		for _, resNameFileMap := range tfNewFiles {
+			for _, filename := range resNameFileMap {
+				path := filepath.Join(p.Dir, filename)
+				log.Infof("Removing .new suffix from file: %v", path)
+				err = p.fs.Rename(path, strings.Replace(path, "tf.json.new", "tf.json", -1))
+				if err != nil {
+					return err
+				}
+			}
+		}
+	}
+
+	return nil
+}
+
+// doTerraformStateList shells out to run `terraform state list` and parses the result
+func doTerraformStateList(dir string) (map[TResourceType]map[TResourceName]struct{}, error) {
+	result := map[TResourceType]map[TResourceName]struct{}{}
+	command := exec.Command("terraform state list -no-color").InheritEnvs(true).WithDir(dir)
+	command.StartWithHandlers(
+		nil,
+		func(r io.Reader) error {
+			reader := bufio.NewReader(r)
+			for {
+				lineBytes, _, err := reader.ReadLine()
+				if err != nil {
+					break
+				}
+				line := string(lineBytes)
+				log.Debugf("'terraform state list' output: %v", line)
+				// Every line should have <resource-type>.<resource-name>
+				if !strings.Contains(line, ".") {
+					log.Errorf("Invalid line from 'terraform state list': %v", line)
+					continue
+				}
+				split := strings.Split(strings.TrimSpace(line), ".")
+				resType := TResourceType(split[0])
+				resName := TResourceName(split[1])
+				if resourceMap, has := result[resType]; has {
+					resourceMap[resName] = struct{}{}
+				} else {
+					result[resType] = map[TResourceName]struct{}{resName: {}}
+				}
+			}
+			return nil
+		},
+		nil)
+
+	err := command.Wait()
+	return result, err
 }

--- a/pkg/provider/terraform/instance/apply_test.go
+++ b/pkg/provider/terraform/instance/apply_test.go
@@ -1,12 +1,17 @@
 package main
 
 import (
+	"encoding/json"
+	"fmt"
 	"io/ioutil"
 	"os"
 	"path"
+	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 
+	"github.com/spf13/afero"
 	"github.com/stretchr/testify/require"
 
 	. "github.com/docker/infrakit/pkg/testing"
@@ -22,9 +27,8 @@ func TestRunTerraformApply(t *testing.T) {
 	dir = path.Join(dir, "aws-two-tier")
 	terraform := NewTerraformInstancePlugin(dir, 1*time.Second, false, nil)
 	p, _ := terraform.(*plugin)
-	attempted, err := p.doTerraformApply(false)
+	err = p.doTerraformApply()
 	require.NoError(t, err)
-	require.True(t, attempted)
 }
 
 func TestContinuePollingStandalone(t *testing.T) {
@@ -35,4 +39,314 @@ func TestContinuePollingStandalone(t *testing.T) {
 	p, _ := terraform.(*plugin)
 	shoudApply := p.shouldApply()
 	require.True(t, shoudApply)
+}
+
+// fileInfo holds the data for a file to create in the plugin's working dir
+type fileInfo struct {
+	ResType TResourceType
+	ResName TResourceName
+	NewFile bool
+	Plugin  *plugin
+}
+
+// writeFile is a utility function to write out a terraform file
+func writeFile(info fileInfo, t *testing.T) {
+	inst := make(map[TResourceType]map[TResourceName]TResourceProperties)
+	inst[info.ResType] = map[TResourceName]TResourceProperties{
+		info.ResName: {"key": "val"},
+	}
+	buff, err := json.MarshalIndent(TFormat{Resource: inst}, " ", " ")
+	require.NoError(t, err)
+	var filename string
+	if info.NewFile {
+		filename = fmt.Sprintf("%v.tf.json.new", string(info.ResName))
+	} else {
+		filename = fmt.Sprintf("%v.tf.json", string(info.ResName))
+	}
+	err = afero.WriteFile(info.Plugin.fs, filepath.Join(info.Plugin.Dir, filename), buff, 0644)
+	require.NoError(t, err)
+}
+
+// getFilesname is a utility function to a list of terraform files
+func getFilenames(t *testing.T, p *plugin) (tfFiles []string, tfNewFiles []string) {
+	fs := &afero.Afero{Fs: p.fs}
+	err := fs.Walk(p.Dir,
+		func(path string, info os.FileInfo, err error) error {
+			if strings.HasSuffix(info.Name(), ".tf.json") {
+				tfFiles = append(tfFiles, info.Name())
+			} else if strings.HasSuffix(info.Name(), ".tf.json.new") {
+				tfNewFiles = append(tfNewFiles, info.Name())
+			}
+			return nil
+		},
+	)
+	require.NoError(t, err)
+	return
+}
+
+func TestHandleFilesRefreshFail(t *testing.T) {
+	tf, dir := getPlugin(t)
+	defer os.RemoveAll(dir)
+
+	// Write out 10 files, should not be changed since refresh failed
+	for i := 100; i < 110; i++ {
+		newFile := false
+		if i >= 105 {
+			newFile = true
+		}
+		info := fileInfo{
+			ResType: VMIBMCloud,
+			ResName: TResourceName(fmt.Sprintf("instance-%v", i)),
+			NewFile: newFile,
+			Plugin:  tf,
+		}
+		writeFile(info, t)
+	}
+
+	fns := tfFuncs{
+		tfRefresh: func() error {
+			return fmt.Errorf("Custom refresh error")
+		},
+	}
+	err := tf.handleFiles(fns)
+	require.Error(t, err)
+	require.Equal(t, "Custom refresh error", err.Error())
+
+	// No files changed
+	tfFiles, tfFilesNew := getFilenames(t, tf)
+	require.Len(t, tfFilesNew, 5)
+	require.Len(t, tfFiles, 5)
+	for i := 100; i < 105; i++ {
+		require.Contains(t, tfFiles, fmt.Sprintf("instance-%v.tf.json", i))
+	}
+	for i := 105; i < 110; i++ {
+		require.Contains(t, tfFilesNew, fmt.Sprintf("instance-%v.tf.json.new", i))
+	}
+}
+
+func TestHandleFilesStateListFail(t *testing.T) {
+	tf, dir := getPlugin(t)
+	defer os.RemoveAll(dir)
+
+	refreshInvoked := false
+	fns := tfFuncs{
+		tfRefresh: func() error {
+			refreshInvoked = true
+			return nil
+		},
+		tfStateList: func(dirArg string) (map[TResourceType]map[TResourceName]struct{}, error) {
+			require.Equal(t, dir, dirArg)
+			return nil, fmt.Errorf("Custom state list error")
+		},
+	}
+	err := tf.handleFiles(fns)
+	require.Error(t, err)
+	require.Equal(t, "Custom state list error", err.Error())
+	require.True(t, refreshInvoked)
+}
+
+func TestHandleFilesNoFiles(t *testing.T) {
+	tf, dir := getPlugin(t)
+	defer os.RemoveAll(dir)
+
+	fns := tfFuncs{
+		tfRefresh: func() error { return nil },
+		tfStateList: func(dir string) (map[TResourceType]map[TResourceName]struct{}, error) {
+			return map[TResourceType]map[TResourceName]struct{}{}, nil
+		},
+	}
+	err := tf.handleFiles(fns)
+	require.NoError(t, err)
+}
+
+func TestHandleFilesNoPruneNoNewFiles(t *testing.T) {
+	tf, dir := getPlugin(t)
+	defer os.RemoveAll(dir)
+
+	// Write out 5 files
+	for i := 100; i < 105; i++ {
+		info := fileInfo{
+			ResType: VMIBMCloud,
+			ResName: TResourceName(fmt.Sprintf("instance-%v", i)),
+			NewFile: false,
+			Plugin:  tf,
+		}
+		writeFile(info, t)
+	}
+	tfFiles, tfFilesNew := getFilenames(t, tf)
+	require.Len(t, tfFilesNew, 0)
+	require.Len(t, tfFiles, 5)
+
+	fns := tfFuncs{
+		tfRefresh: func() error { return nil },
+		tfStateList: func(dir string) (map[TResourceType]map[TResourceName]struct{}, error) {
+			// Return 5 files
+			result := map[TResourceName]struct{}{}
+			for i := 100; i < 105; i++ {
+				result[TResourceName(fmt.Sprintf("instance-%v", i))] = struct{}{}
+			}
+			return map[TResourceType]map[TResourceName]struct{}{
+				VMIBMCloud: result,
+			}, nil
+		},
+	}
+	err := tf.handleFiles(fns)
+	require.NoError(t, err)
+
+	// No files removed
+	tfFiles, tfFilesNew = getFilenames(t, tf)
+	require.Len(t, tfFilesNew, 0)
+	require.Len(t, tfFiles, 5)
+	for i := 100; i < 105; i++ {
+		require.Contains(t, tfFiles, fmt.Sprintf("instance-%v.tf.json", i))
+	}
+}
+
+func TestHandleFilesNoPruneWithNewFiles(t *testing.T) {
+	tf, dir := getPlugin(t)
+	defer os.RemoveAll(dir)
+
+	// Write out 10 files, 5 existing and 5 new
+	for i := 100; i < 110; i++ {
+		newFile := false
+		if i >= 105 {
+			newFile = true
+		}
+		info := fileInfo{
+			ResType: VMIBMCloud,
+			ResName: TResourceName(fmt.Sprintf("instance-%v", i)),
+			NewFile: newFile,
+			Plugin:  tf,
+		}
+		writeFile(info, t)
+	}
+	tfFiles, tfFilesNew := getFilenames(t, tf)
+	require.Len(t, tfFilesNew, 5)
+	require.Len(t, tfFiles, 5)
+
+	fns := tfFuncs{
+		tfRefresh: func() error { return nil },
+		tfStateList: func(dir string) (map[TResourceType]map[TResourceName]struct{}, error) {
+			// Return the 5 existing instances
+			result := map[TResourceName]struct{}{}
+			for i := 100; i < 105; i++ {
+				result[TResourceName(fmt.Sprintf("instance-%v", i))] = struct{}{}
+			}
+			return map[TResourceType]map[TResourceName]struct{}{
+				VMIBMCloud: result,
+			}, nil
+		},
+	}
+	err := tf.handleFiles(fns)
+	require.NoError(t, err)
+
+	// New files renamed, nothing removed
+	tfFiles, tfFilesNew = getFilenames(t, tf)
+	require.Len(t, tfFilesNew, 0)
+	require.Len(t, tfFiles, 10)
+	for i := 100; i < 110; i++ {
+		require.Contains(t, tfFiles, fmt.Sprintf("instance-%v.tf.json", i))
+	}
+}
+
+func TestHandleFilesPruneMultipleResourceTypes(t *testing.T) {
+	tf, dir := getPlugin(t)
+	defer os.RemoveAll(dir)
+
+	// Write out 9 files, 3 different VM types
+	for i := 100; i < 109; i++ {
+		var resType TResourceType
+		if i < 103 {
+			resType = VMIBMCloud
+		} else if i < 106 {
+			resType = VMAmazon
+		} else {
+			resType = VMGoogleCloud
+		}
+		info := fileInfo{
+			ResType: resType,
+			ResName: TResourceName(fmt.Sprintf("instance-%v", i)),
+			NewFile: false,
+			Plugin:  tf,
+		}
+		writeFile(info, t)
+	}
+	tfFiles, tfFilesNew := getFilenames(t, tf)
+	require.Len(t, tfFilesNew, 0)
+	require.Len(t, tfFiles, 9)
+
+	fns := tfFuncs{
+		tfRefresh: func() error { return nil },
+		tfStateList: func(dir string) (map[TResourceType]map[TResourceName]struct{}, error) {
+			// Return all of 1 type, 1 of another type, 0 of the last type
+			return map[TResourceType]map[TResourceName]struct{}{
+				VMIBMCloud: {
+					TResourceName("instance-100"): {},
+					TResourceName("instance-101"): {},
+					TResourceName("instance-102"): {},
+				},
+				VMAmazon: {
+					TResourceName("instance-103"): {},
+				},
+			}, nil
+		},
+	}
+	err := tf.handleFiles(fns)
+	require.NoError(t, err)
+
+	// New files renamed, instances 104+ removed
+	tfFiles, tfFilesNew = getFilenames(t, tf)
+	require.Len(t, tfFilesNew, 0)
+	require.Len(t, tfFiles, 4)
+	for i := 100; i < 104; i++ {
+		require.Contains(t, tfFiles, fmt.Sprintf("instance-%v.tf.json", i))
+	}
+}
+
+func TestHandleFilesPruneWithNewFiles(t *testing.T) {
+	tf, dir := getPlugin(t)
+	defer os.RemoveAll(dir)
+
+	// Write out 10 files, 5 existing and 5 new
+	for i := 100; i < 110; i++ {
+		newFile := false
+		if i >= 105 {
+			newFile = true
+		}
+		info := fileInfo{
+			ResType: VMIBMCloud,
+			ResName: TResourceName(fmt.Sprintf("instance-%v", i)),
+			NewFile: newFile,
+			Plugin:  tf,
+		}
+		writeFile(info, t)
+	}
+	tfFiles, tfFilesNew := getFilenames(t, tf)
+	require.Len(t, tfFilesNew, 5)
+	require.Len(t, tfFiles, 5)
+
+	fns := tfFuncs{
+		tfRefresh: func() error { return nil },
+		tfStateList: func(dir string) (map[TResourceType]map[TResourceName]struct{}, error) {
+			// Return only 3 of the five existing
+			result := map[TResourceName]struct{}{
+				TResourceName("instance-102"): {},
+				TResourceName("instance-103"): {},
+				TResourceName("instance-104"): {},
+			}
+			return map[TResourceType]map[TResourceName]struct{}{
+				VMIBMCloud: result,
+			}, nil
+		},
+	}
+	err := tf.handleFiles(fns)
+	require.NoError(t, err)
+
+	// New files renamed, instances 100, 101 remvoed
+	tfFiles, tfFilesNew = getFilenames(t, tf)
+	require.Len(t, tfFilesNew, 0)
+	require.Len(t, tfFiles, 8)
+	for i := 102; i < 110; i++ {
+		require.Contains(t, tfFiles, fmt.Sprintf("instance-%v.tf.json", i))
+	}
 }

--- a/pkg/provider/terraform/instance/plugin_test.go
+++ b/pkg/provider/terraform/instance/plugin_test.go
@@ -434,7 +434,7 @@ func TestProvisionDescribeDestroyScope(t *testing.T) {
 		"scope-managers",
 	}
 	for _, path := range expectedPaths {
-		tfPath1 := filepath.Join(dir, path+".tf.json")
+		tfPath1 := filepath.Join(dir, path+".tf.json.new")
 		_, err = ioutil.ReadFile(tfPath1)
 		require.NoError(t, err, fmt.Sprintf("Expected path %s does not exist", path))
 	}
@@ -450,7 +450,7 @@ func TestProvisionDescribeDestroyScope(t *testing.T) {
 		"scope-managers",
 	}
 	for _, path := range expectedPaths {
-		tfPath1 := filepath.Join(dir, path+".tf.json")
+		tfPath1 := filepath.Join(dir, path+".tf.json.new")
 		_, err = ioutil.ReadFile(tfPath1)
 		require.NoError(t, err, fmt.Sprintf("Expected path %s does not exist", path))
 	}
@@ -639,7 +639,7 @@ func runValidateProvisionDescribe(t *testing.T, resourceType, properties string)
 	}
 	id1, err := tf.Provision(instanceSpec1)
 	require.NoError(t, err)
-	tfPath1 := filepath.Join(dir, string(*id1)+".tf.json")
+	tfPath1 := filepath.Join(dir, string(*id1)+".tf.json.new")
 	_, err = ioutil.ReadFile(tfPath1)
 	require.NoError(t, err)
 
@@ -664,7 +664,7 @@ func runValidateProvisionDescribe(t *testing.T, resourceType, properties string)
 	require.NoError(t, err)
 	require.NotEqual(t, id1, id2)
 
-	tfPath2 := filepath.Join(dir, string(*id2)+".tf.json")
+	tfPath2 := filepath.Join(dir, string(*id2)+".tf.json.new")
 	buff, err := ioutil.ReadFile(tfPath2)
 	require.NoError(t, err)
 
@@ -1017,7 +1017,7 @@ func TestWriteTerraformFilesVMOnly(t *testing.T) {
 	files, err := ioutil.ReadDir(tf.Dir)
 	require.NoError(t, err)
 	require.Len(t, files, 1)
-	buff, err := ioutil.ReadFile(filepath.Join(tf.Dir, name+".tf.json"))
+	buff, err := ioutil.ReadFile(filepath.Join(tf.Dir, name+".tf.json.new"))
 	require.NoError(t, err)
 	tFormat := TFormat{}
 	err = types.AnyBytes(buff).Decode(&tFormat)
@@ -1049,7 +1049,7 @@ func TestWriteTerraformFilesVMOnlyLogicalId(t *testing.T) {
 	files, err := ioutil.ReadDir(tf.Dir)
 	require.NoError(t, err)
 	require.Len(t, files, 1)
-	buff, err := ioutil.ReadFile(filepath.Join(tf.Dir, name+".tf.json"))
+	buff, err := ioutil.ReadFile(filepath.Join(tf.Dir, name+".tf.json.new"))
 	require.NoError(t, err)
 	tFormat := TFormat{}
 	err = types.AnyBytes(buff).Decode(&tFormat)
@@ -1086,7 +1086,7 @@ func TestWriteTerraformFilesMultipleDefaultResources(t *testing.T) {
 	files, err := ioutil.ReadDir(tf.Dir)
 	require.NoError(t, err)
 	require.Len(t, files, 1)
-	buff, err := ioutil.ReadFile(filepath.Join(tf.Dir, name+".tf.json"))
+	buff, err := ioutil.ReadFile(filepath.Join(tf.Dir, name+".tf.json.new"))
 	require.NoError(t, err)
 	tFormat := TFormat{}
 	err = types.AnyBytes(buff).Decode(&tFormat)
@@ -1174,12 +1174,12 @@ func TestWriteTerraformFilesMultipleResourcesScopeTypes(t *testing.T) {
 	for _, file := range files {
 		filenames = append(filenames, file.Name())
 	}
-	require.Contains(t, filenames, fmt.Sprintf("%s.tf.json", name))
-	require.Contains(t, filenames, fmt.Sprintf("%s-dedicated.tf.json", name))
-	expectedGlobalFilename := fmt.Sprintf("scope-%s.tf.json", globalName)
+	require.Contains(t, filenames, fmt.Sprintf("%s.tf.json.new", name))
+	require.Contains(t, filenames, fmt.Sprintf("%s-dedicated.tf.json.new", name))
+	expectedGlobalFilename := fmt.Sprintf("scope-%s.tf.json.new", globalName)
 	require.Contains(t, filenames, expectedGlobalFilename)
 	// Default
-	buff, err := ioutil.ReadFile(filepath.Join(tf.Dir, fmt.Sprintf("%s.tf.json", name)))
+	buff, err := ioutil.ReadFile(filepath.Join(tf.Dir, fmt.Sprintf("%s.tf.json.new", name)))
 	require.NoError(t, err)
 	tFormat := TFormat{}
 	err = types.AnyBytes(buff).Decode(&tFormat)
@@ -1201,7 +1201,7 @@ func TestWriteTerraformFilesMultipleResourcesScopeTypes(t *testing.T) {
 		tFormat.Resource,
 	)
 	// Dedicated
-	buff, err = ioutil.ReadFile(filepath.Join(tf.Dir, fmt.Sprintf("%s-dedicated.tf.json", name)))
+	buff, err = ioutil.ReadFile(filepath.Join(tf.Dir, fmt.Sprintf("%s-dedicated.tf.json.new", name)))
 	require.NoError(t, err)
 	tFormat = TFormat{}
 	err = types.AnyBytes(buff).Decode(&tFormat)
@@ -1270,10 +1270,10 @@ func TestWriteTerraformFilesMultipleResourcesDedicatedScope(t *testing.T) {
 	for _, file := range files {
 		filenames = append(filenames, file.Name())
 	}
-	require.Contains(t, filenames, fmt.Sprintf("%s.tf.json", name))
-	require.Contains(t, filenames, fmt.Sprintf("%s-dedicated.tf.json", name))
+	require.Contains(t, filenames, fmt.Sprintf("%s.tf.json.new", name))
+	require.Contains(t, filenames, fmt.Sprintf("%s-dedicated.tf.json.new", name))
 	// VM file
-	buff, err := ioutil.ReadFile(filepath.Join(tf.Dir, name+".tf.json"))
+	buff, err := ioutil.ReadFile(filepath.Join(tf.Dir, name+".tf.json.new"))
 	require.NoError(t, err)
 	tFormat := TFormat{}
 	err = types.AnyBytes(buff).Decode(&tFormat)
@@ -1293,7 +1293,7 @@ func TestWriteTerraformFilesMultipleResourcesDedicatedScope(t *testing.T) {
 		vmType,
 	)
 	// File storage and block storage
-	buff, err = ioutil.ReadFile(filepath.Join(tf.Dir, fmt.Sprintf("%s-dedicated.tf.json", name)))
+	buff, err = ioutil.ReadFile(filepath.Join(tf.Dir, fmt.Sprintf("%s-dedicated.tf.json.new", name)))
 	require.NoError(t, err)
 	tFormat = TFormat{}
 	err = types.AnyBytes(buff).Decode(&tFormat)
@@ -2029,36 +2029,22 @@ func TestDestroyRollingUpdate(t *testing.T) {
 	files, err = ioutil.ReadDir(dir)
 	require.NoError(t, err)
 	require.Len(t, files, 1)
-	path := filepath.Join(dir, fmt.Sprintf("%s-dedicated.tf.json", string(*id)))
+	path := filepath.Join(dir, fmt.Sprintf("%s-dedicated.tf.json.new", string(*id)))
 	_, err = ioutil.ReadFile(path)
 	require.NoError(t, err, fmt.Sprintf("Expected path %s does not exist", path))
 }
 
-func TestParseAttachTagFromFileNoFile(t *testing.T) {
-	_, err := parseAttachTagFromFile("")
-	require.Error(t, err)
-}
-
-func TestParseAttachTagFromFileNoVM(t *testing.T) {
-	tf, dir := getPlugin(t)
-	defer os.RemoveAll(dir)
-	tformat := TFormat{
+func TestParseAttachTagNoVM(t *testing.T) {
+	tFormat := TFormat{
 		Resource: map[TResourceType]map[TResourceName]TResourceProperties{},
 	}
-	buff, err := json.MarshalIndent(tformat, " ", " ")
-	require.NoError(t, err)
-	fp := filepath.Join(tf.Dir, "instance-1234.tf.json")
-	err = afero.WriteFile(tf.fs, fp, buff, 0644)
-	require.NoError(t, err)
-	_, err = parseAttachTagFromFile(fp)
+	_, err := parseAttachTag(&tFormat)
 	require.Error(t, err)
 	require.Equal(t, "not found", err.Error())
 }
 
-func TestParseAttachTagFromFileMap(t *testing.T) {
-	tf, dir := getPlugin(t)
-	defer os.RemoveAll(dir)
-	tformat := TFormat{
+func TestParseAttachTagMap(t *testing.T) {
+	tFormat := TFormat{
 		Resource: map[TResourceType]map[TResourceName]TResourceProperties{
 			VMAmazon: {
 				TResourceName("host1"): {
@@ -2070,20 +2056,13 @@ func TestParseAttachTagFromFileMap(t *testing.T) {
 			},
 		},
 	}
-	buff, err := json.MarshalIndent(tformat, " ", " ")
-	require.NoError(t, err)
-	fp := filepath.Join(tf.Dir, "instance-1234.tf.json")
-	err = afero.WriteFile(tf.fs, fp, buff, 0644)
-	require.NoError(t, err)
-	results, err := parseAttachTagFromFile(fp)
+	results, err := parseAttachTag(&tFormat)
 	require.NoError(t, err)
 	require.Equal(t, []string{"attach1", "attach2"}, results)
 }
 
-func TestParseAttachTagFromFileSlice(t *testing.T) {
-	tf, dir := getPlugin(t)
-	defer os.RemoveAll(dir)
-	tformat := TFormat{
+func TestParseAttachTagSlice(t *testing.T) {
+	tFormat := TFormat{
 		Resource: map[TResourceType]map[TResourceName]TResourceProperties{
 			VMSoftLayer: {
 				TResourceName("host1"): {
@@ -2095,12 +2074,7 @@ func TestParseAttachTagFromFileSlice(t *testing.T) {
 			},
 		},
 	}
-	buff, err := json.MarshalIndent(tformat, " ", " ")
-	require.NoError(t, err)
-	fp := filepath.Join(tf.Dir, "instance-1234.tf.json")
-	err = afero.WriteFile(tf.fs, fp, buff, 0644)
-	require.NoError(t, err)
-	results, err := parseAttachTagFromFile(fp)
+	results, err := parseAttachTag(&tFormat)
 	require.NoError(t, err)
 	require.Equal(t, []string{"attach1", "attach2"}, results)
 }
@@ -2113,11 +2087,11 @@ func TestDescribeNoFiles(t *testing.T) {
 	require.Equal(t, []instance.Description{}, results)
 }
 
-func TestDescribe(t *testing.T) {
+func TestDescribeWithNewFile(t *testing.T) {
 	tf, dir := getPlugin(t)
 	defer os.RemoveAll(dir)
 
-	// Instance1, unique tag and shared tag
+	// Instance1, unique tag and shared tag (and give it the ".new" file suffix)
 	inst1 := make(map[TResourceType]map[TResourceName]TResourceProperties)
 	id1 := "instance-1"
 	tags1 := []string{"tag1:val1", "tagShared:valShared"}
@@ -2126,7 +2100,7 @@ func TestDescribe(t *testing.T) {
 	}
 	buff, err := json.MarshalIndent(TFormat{Resource: inst1}, " ", " ")
 	require.NoError(t, err)
-	err = afero.WriteFile(tf.fs, filepath.Join(tf.Dir, fmt.Sprintf("%v.tf.json", id1)), buff, 0644)
+	err = afero.WriteFile(tf.fs, filepath.Join(tf.Dir, fmt.Sprintf("%v.tf.json.new", id1)), buff, 0644)
 	require.NoError(t, err)
 	// Instance1, unique tag and shared tag
 	inst2 := make(map[TResourceType]map[TResourceName]TResourceProperties)
@@ -2228,7 +2202,7 @@ func TestDescribeAttachTag(t *testing.T) {
 	}
 	buff, err := json.MarshalIndent(TFormat{Resource: inst1}, " ", " ")
 	require.NoError(t, err)
-	err = afero.WriteFile(tf.fs, filepath.Join(tf.Dir, fmt.Sprintf("%v.tf.json", id1)), buff, 0644)
+	err = afero.WriteFile(tf.fs, filepath.Join(tf.Dir, fmt.Sprintf("%v.tf.json.new", id1)), buff, 0644)
 	require.NoError(t, err)
 
 	inst2 := make(map[TResourceType]map[TResourceName]TResourceProperties)
@@ -2474,7 +2448,7 @@ func TestWriteTfJSONForImport(t *testing.T) {
 	id := "instance-12345"
 	err := tf.writeTfJSONForImport(specProps, importedProps, VMIBMCloud, id)
 	require.NoError(t, err)
-	buff, err := ioutil.ReadFile(filepath.Join(tf.Dir, id+".tf.json"))
+	buff, err := ioutil.ReadFile(filepath.Join(tf.Dir, id+".tf.json.new"))
 	require.NoError(t, err)
 	tFormat := TFormat{}
 	err = types.AnyBytes(buff).Decode(&tFormat)
@@ -2719,7 +2693,7 @@ func TestImportResourceTagMap(t *testing.T) {
 	require.NoError(t, err)
 	require.False(t, cleanInvoked)
 
-	buff, err := ioutil.ReadFile(filepath.Join(tf.Dir, fmt.Sprintf("%v.tf.json", *id)))
+	buff, err := ioutil.ReadFile(filepath.Join(tf.Dir, fmt.Sprintf("%v.tf.json.new", *id)))
 	require.NoError(t, err)
 	tFormat := TFormat{}
 	err = types.AnyBytes(buff).Decode(&tFormat)
@@ -2793,7 +2767,7 @@ func TestImportResourceTagSlice(t *testing.T) {
 	require.NoError(t, err)
 	require.False(t, cleanInvoked)
 
-	buff, err := ioutil.ReadFile(filepath.Join(tf.Dir, fmt.Sprintf("%v.tf.json", *id)))
+	buff, err := ioutil.ReadFile(filepath.Join(tf.Dir, fmt.Sprintf("%v.tf.json.new", *id)))
 	require.NoError(t, err)
 	tFormat := TFormat{}
 	err = types.AnyBytes(buff).Decode(&tFormat)
@@ -2816,4 +2790,71 @@ func TestImportResourceTagSlice(t *testing.T) {
 			"spec-key": "actual-val",
 		},
 		props)
+}
+
+func TestParseFileForInstanceIDNoMatch(t *testing.T) {
+	tf, dir := getPlugin(t)
+	defer os.RemoveAll(dir)
+	_, _, err := tf.parseFileForInstanceID(instance.ID("instance-1234"))
+	require.Error(t, err)
+}
+
+func TestParseFileForInstanceID(t *testing.T) {
+	tf, dir := getPlugin(t)
+	defer os.RemoveAll(dir)
+
+	tformat := TFormat{Resource: map[TResourceType]map[TResourceName]TResourceProperties{
+		VMIBMCloud: {"instance-1234": {}}},
+	}
+	buff, err := json.MarshalIndent(tformat, "  ", "  ")
+	require.NoError(t, err)
+	err = afero.WriteFile(tf.fs, filepath.Join(tf.Dir, "instance-1234.tf.json.new"), buff, 0644)
+	require.NoError(t, err)
+	tformat = TFormat{Resource: map[TResourceType]map[TResourceName]TResourceProperties{
+		VMSoftLayer: {"instance-2345": {}}},
+	}
+	buff, err = json.MarshalIndent(tformat, "  ", "  ")
+	require.NoError(t, err)
+	err = afero.WriteFile(tf.fs, filepath.Join(tf.Dir, "instance-2345.tf.json.new"), buff, 0644)
+	require.NoError(t, err)
+	tformat = TFormat{Resource: map[TResourceType]map[TResourceName]TResourceProperties{
+		VMAmazon: {"instance-3456": {}}},
+	}
+	buff, err = json.MarshalIndent(tformat, "  ", "  ")
+	require.NoError(t, err)
+	err = afero.WriteFile(tf.fs, filepath.Join(tf.Dir, "instance-3456.tf.json"), buff, 0644)
+	require.NoError(t, err)
+
+	tFormat, filename, err := tf.parseFileForInstanceID(instance.ID("instance-1234"))
+	require.NoError(t, err)
+	require.Equal(t, "instance-1234.tf.json.new", filename)
+	require.Equal(t,
+		TFormat{Resource: map[TResourceType]map[TResourceName]TResourceProperties{
+			VMIBMCloud: {"instance-1234": {}}},
+		},
+		*tFormat)
+
+	tFormat, filename, err = tf.parseFileForInstanceID(instance.ID("instance-2345"))
+	require.NoError(t, err)
+	require.Equal(t, "instance-2345.tf.json.new", filename)
+	require.Equal(t,
+		TFormat{Resource: map[TResourceType]map[TResourceName]TResourceProperties{
+			VMSoftLayer: {"instance-2345": {}}},
+		},
+		*tFormat)
+
+	tFormat, filename, err = tf.parseFileForInstanceID(instance.ID("instance-3456"))
+	require.NoError(t, err)
+	require.Equal(t, "instance-3456.tf.json", filename)
+	require.Equal(t,
+		TFormat{Resource: map[TResourceType]map[TResourceName]TResourceProperties{
+			VMAmazon: {"instance-3456": {}}},
+		},
+		*tFormat)
+
+	// Instance file does not exist
+	tFormat, filename, err = tf.parseFileForInstanceID(instance.ID("instance-4567"))
+	require.Error(t, err)
+	require.Nil(t, tFormat)
+	require.Equal(t, "", filename)
 }


### PR DESCRIPTION
When a resource is destroyed outside of Infrakit/terraform, we need to remove the associated `tf.json` file. In order to handle this, the following logic is added:
    
On `Provision` the file created will have a `tf.json.new` suffix; `terraform apply` will ignore these files but the Instance's `Destroy`/`Describe`/`Label` functions will not. The `apply` goroutine will execute:
    
1. Acquire file lock
2. `terraform refresh`
3. Detect orphan `tf.json` files and delete; we can run `terraform state list` to get the list of resource in the state file and then remove any `tf.json` files that correspond to resources that are not listed
4. Rename `tf.json.new` files to `tf.json` so that terraform will create them
5. Release file lock
6. `terraform apply`
    
But naming new files with the `.tf.json.new` suffix we can differentiate between orphaned resources and those queued up for creation.

Closes #645

Signed-off-by: Steven Kaufer <kaufer@us.ibm.com>