### PR TITLE
Improve logging

### DIFF
--- a/pkg/cli/logging.go
+++ b/pkg/cli/logging.go
@@ -24,9 +24,13 @@ func SetLogLevel(level int) {
 func Flags(o *logutil.Options) *pflag.FlagSet {
 	f := pflag.NewFlagSet("logging", pflag.ExitOnError)
 	f.IntVar(&o.Level, "log", o.Level, "log level")
+	f.IntVar(&o.DebugV, "log-debug-V", o.DebugV, "log debug verbosity level. 0=logs all")
 	f.BoolVar(&o.Stdout, "log-stdout", o.Stdout, "log to stdout")
 	f.BoolVar(&o.CallFunc, "log-caller", o.CallFunc, "include caller function")
 	f.BoolVar(&o.CallStack, "log-stack", o.CallStack, "include caller stack")
 	f.StringVar(&o.Format, "log-format", o.Format, "log format: logfmt|term|json")
+	f.BoolVar(&o.DebugMatchExclude, "log-debug-match-exclude", false, "True to exclude; otherwise only include matches")
+	f.StringSliceVar(&o.DebugMatchKeyValuePairs, "log-debug-match", []string{},
+		"debug mode only -- select records with any of the k=v pairs")
 	return f
 }

--- a/pkg/leader/file/file.go
+++ b/pkg/leader/file/file.go
@@ -8,9 +8,11 @@ import (
 	"strings"
 	"time"
 
-	log "github.com/Sirupsen/logrus"
 	"github.com/docker/infrakit/pkg/leader"
+	logutil "github.com/docker/infrakit/pkg/log"
 )
+
+var log = logutil.New("module", "leader/file")
 
 // NewDetector return an implementation of leader detector
 // This implementation checks a file for its content.  If the content matches the id of the detector
@@ -32,7 +34,7 @@ func NewDetector(pollInterval time.Duration, filename, id string) (*leader.Polle
 
 			match := strings.Trim(string(content), " \t\n")
 
-			log.Debugf("ID (%s) - checked %s for leadership: %s, err=%v, leader=%v", id, filename, match, err, match == id)
+			log.Debug("poll for leadership", "id", id, "file", filename, "match", match, "err", err)
 
 			return match == id, err
 		}), nil

--- a/pkg/leader/swarm/swarm.go
+++ b/pkg/leader/swarm/swarm.go
@@ -4,12 +4,14 @@ import (
 	"net/url"
 	"time"
 
-	log "github.com/Sirupsen/logrus"
 	"github.com/docker/docker/api/types/swarm"
 	"github.com/docker/infrakit/pkg/leader"
+	logutil "github.com/docker/infrakit/pkg/log"
 	"github.com/docker/infrakit/pkg/util/docker"
 	"golang.org/x/net/context"
 )
+
+var log = logutil.New("module", "leader/swarm")
 
 // NewDetector return an implementation of leader detector
 func NewDetector(pollInterval time.Duration, client docker.APIClientCloser) *leader.Poller {
@@ -35,7 +37,7 @@ func amISwarmLeader(ctx context.Context, client docker.APIClientCloser) (bool, e
 	if node.ManagerStatus == nil {
 		return false, nil
 	}
-	log.Debugln("leader=", node.ManagerStatus.Leader, "node=", node)
+	log.Debug("Leadership", "leader", node.ManagerStatus.Leader, "node", node)
 	return node.ManagerStatus.Leader, nil
 }
 
@@ -77,7 +79,7 @@ func (s Store) GetLocation() (*url.URL, error) {
 
 	if info.ClusterInfo.Spec.Annotations.Labels != nil {
 		if l, has := info.ClusterInfo.Spec.Annotations.Labels[SwarmLabel]; has {
-			log.Debugln("leader.loc=", l)
+			log.Debug("leader location", "location", l)
 			return url.Parse(l)
 		}
 	}

--- a/pkg/log/log.go
+++ b/pkg/log/log.go
@@ -2,7 +2,9 @@ package log
 
 import (
 	"flag"
+	"fmt"
 	"os"
+	"strings"
 
 	"github.com/Sirupsen/logrus"
 	"gopkg.in/inconshreveable/log15.v2"
@@ -28,7 +30,20 @@ type Options struct {
 	Format    string
 	CallFunc  bool
 	CallStack bool
+
+	// DebugMatchKeyValuePairs is the '=' delimited kv pair for filtering contexts in records for DEBUG
+	DebugMatchKeyValuePairs []string
+
+	// DebugMatchExclude excludes the record if any of the context params matches those in the MatchKeyValuePairs
+	DebugMatchExclude bool
+
+	// DebugV is a value of verbosity for checking debug records where there's a context param of type DebugV
+	DebugV int
 }
+
+// V is the Verbosity level.  To set a verbosity level, just put a log.V(100) in the context
+// (e.g. .Debug(msg, "key", log.V(100))
+type V int
 
 // DevDefaults is the default options for development
 var DevDefaults = Options{
@@ -103,7 +118,9 @@ func Configure(options *Options) {
 	case 4:
 		h = log15.LvlFilterHandler(log15.LvlInfo, h)
 	case 5:
-		h = log15.LvlFilterHandler(log15.LvlDebug, h)
+		h = log15.LvlFilterHandler(log15.LvlDebug,
+			verbosityFilterHandler(V(options.DebugV),
+				matchAnyFilterHandler(options.DebugMatchKeyValuePairs, h, !options.DebugMatchExclude)))
 	default:
 		h = log15.LvlFilterHandler(log15.LvlInfo, h)
 	}
@@ -111,4 +128,54 @@ func Configure(options *Options) {
 
 	// Necessary to stop glog from complaining / noisy logs
 	flag.CommandLine.Parse([]string{})
+}
+
+func verbosityFilterHandler(l V, h log15.Handler) log15.Handler {
+	return log15.FilterHandler(func(r *log15.Record) bool {
+		if l == 0 {
+			return true
+		}
+		for i := 0; i < len(r.Ctx); i += 2 {
+			switch v := r.Ctx[i+1].(type) {
+			case V:
+				return !(v > l)
+			default:
+				continue
+			}
+		}
+		return true
+	}, h)
+}
+
+func matchAnyFilterHandler(kv []string, h log15.Handler, log bool) log15.Handler {
+	index := map[interface{}]map[interface{}]struct{}{}
+	for _, s := range kv {
+		p := strings.Split(s, "=")
+		if len(p) != 2 {
+			fmt.Fprintf(os.Stderr, "Bad filter: %v\n", s)
+			continue
+		}
+
+		if _, has := index[p[0]]; !has {
+			index[p[0]] = map[interface{}]struct{}{}
+		}
+		index[p[0]][p[1]] = struct{}{}
+	}
+
+	return log15.FilterHandler(func(r *log15.Record) bool {
+		if len(index) == 0 {
+			return true
+		}
+
+		// find ANY of the context keys and values in the index
+		for i := 0; i < len(r.Ctx); i += 2 {
+			if m, has := index[r.Ctx[i]]; has {
+				check := fmt.Sprintf("%v", r.Ctx[i+1])
+				if _, has := m[check]; has {
+					return log
+				}
+			}
+		}
+		return !log
+	}, h)
 }

--- a/pkg/run/manager/manager.go
+++ b/pkg/run/manager/manager.go
@@ -212,7 +212,7 @@ func (m *Manager) WaitForAllShutdown() {
 			targets = append(targets, lookup)
 
 		case <-checkNow:
-			log.Debug("Checking on targets", "targets", targets)
+			log.Debug("Checking on targets", "targets", targets, "V", logutil.V(100))
 			if m, err := m.plugins().List(); err == nil {
 				if countMatches(targets, m) == 0 {
 					log.Info("Scan found plugins not running now", "plugins", targets)
@@ -228,7 +228,7 @@ func countMatches(list []string, found map[string]*plugin.Endpoint) int {
 	c := 0
 	for _, l := range list {
 		if _, has := found[l]; has {
-			log.Debug("Scan found", "lookup", l)
+			log.Debug("Scan found", "lookup", l, "V", logutil.V(100))
 			c++
 		}
 	}


### PR DESCRIPTION
For DEBUG logging (`--log 5`), there are new options:

   + match by context via `--log-debug-match key=value` (repeatable) specifies a list of context key value pairs to match.   This is used in conjunction with
   + `--log-debug-exclude` will log everything *except* those that contain contexts that match the kv pairs specified via `--log-debug-match` pairs.  Otherwise, *only those matching* are logged.
   + `--log-debug-V [int]` is a verbosity level for any log entries, in DEBUG, that has a context value of `pkg/logging/V(n)` and is at a value *less* than specified.

For example,  log lines like this:
```
import (
   logutil "github.com/docker/infrakit/pkg/log"
)
var log = logutil.New("module", "my/module")
//...
log.Debug("this is note-worthy", "key1", "something", "anyKey", logutil.V(100))
```
Will be checked for logging only when `--log 5` is specified (debug mode) plus the following:

|  CLI example                                                        |  logged?  |
| -----------------------------------------------| ---------|
|  no other flags   | no -- matched context, but not level (default 0)  |
|  `--log-debug-match "module=my/module`      | no - matched context, but not level (default 0) |
|  `--log-debug-match "module=my/module --log-debug-exclude --log-debug-V 200`    |  no -matched context and level but is excluded  |
|  `--log-debug-V 200`    | yes - matched context (none specified), and matched level 200 > 100 |
|  `--log-debug-match "module=other/module`      | no - no matched context,  no matched level (default 0) |
|  `--log-debug-match "module=other/module --log-debug-V 200`     | no - no matched context,  even though matched level (200 > 100) |




Signed-off-by: David Chung <david.chung@docker.com>