### PR TITLE
New methods to the Group SPI

### DIFF
--- a/cmd/infrakit/plugin/plugin.go
+++ b/cmd/infrakit/plugin/plugin.go
@@ -27,6 +27,7 @@ import (
 	_ "github.com/docker/infrakit/pkg/run/v0/hyperkit"
 	_ "github.com/docker/infrakit/pkg/run/v0/kubernetes"
 	_ "github.com/docker/infrakit/pkg/run/v0/selector"
+	_ "github.com/docker/infrakit/pkg/run/v0/simulator"
 	_ "github.com/docker/infrakit/pkg/run/v0/swarm"
 	_ "github.com/docker/infrakit/pkg/run/v0/tailer"
 	_ "github.com/docker/infrakit/pkg/run/v0/time"

--- a/cmd/infrakit/plugin/plugin.go
+++ b/cmd/infrakit/plugin/plugin.go
@@ -131,7 +131,7 @@ func Command(plugins func() discovery.Plugins) *cobra.Command {
 		}
 
 		if !*quiet {
-			fmt.Printf("%-20s%-50s%-s\n", "INTERFACE", "LISTEN", "NAME")
+			fmt.Printf("%-20s%-30s%-s\n", "INTERFACE", "NAME", "LISTEN")
 		}
 
 		sort.Strings(keys)
@@ -139,7 +139,7 @@ func Command(plugins func() discovery.Plugins) *cobra.Command {
 		for _, k := range keys {
 
 			ep := view[k]
-			fmt.Printf("%-20s%-50s%-s\n", ep.spi, ep.listen, ep.name)
+			fmt.Printf("%-20s%-30s%-s\n", ep.spi, ep.name, ep.listen)
 
 		}
 

--- a/cmd/infrakit/remote/remote.go
+++ b/cmd/infrakit/remote/remote.go
@@ -114,7 +114,7 @@ func Command(plugins func() discovery.Plugins) *cobra.Command {
 			return output(os.Stdout, hosts,
 				func(io.Writer, interface{}) error {
 					if !*quiet {
-						fmt.Printf("%-20s\t%-10s\t%-60v\n", "HOST", "SSH TUNNEL", "URL LIST")
+						fmt.Printf("%-20s\t%-20s\t%-v\n", "HOST", "SSH TUNNEL", "URL LIST")
 					}
 
 					h := []string{}
@@ -126,7 +126,7 @@ func Command(plugins func() discovery.Plugins) *cobra.Command {
 
 					for _, name := range h {
 						remote := hosts[name]
-						fmt.Printf("%-20v\t%-10v\t%-60v\n", name, remote.SSH, remote.Endpoints)
+						fmt.Printf("%-20v\t%-20v\t%-v\n", name, remote.SSH, remote.Endpoints)
 					}
 					return nil
 				})

--- a/docs/plugins/group.md
+++ b/docs/plugins/group.md
@@ -1,6 +1,6 @@
 # Group plugin API
 
-<!-- SOURCE-CHECKSUM pkg/spi/group/* 98638b90e25c24c9c750b61d8a288ee332977214 -->
+<!-- SOURCE-CHECKSUM pkg/spi/group/* a6d8f72dcc8a12031839fa737631c6bfaa6af355 -->
 
 ## API
 
@@ -138,3 +138,81 @@ Parameters: None
 
 Fields:
 - `Groups`: An array of [Group Specs](types.md#group-spec)
+
+### Method `Group.DestroyInstances`
+Destroy instances identified from the given group.  Returns error if any of the given
+are not found in the group or if the destroy fails.
+
+#### Request
+```json
+{
+  "ID" : "group_id",
+  "Instances" : [
+     "instance-id1",
+     "instance-id2",
+     "instance-id3"
+  ]
+}
+```
+
+Parameters: None
+
+Fields:
+- `ID`: The group id.
+- `Instances` : An array of Instance IDs
+
+#### Response
+```json
+{
+  "ID": "group_id"
+}
+```
+
+### Method `Group.Size`
+Returns the desired / target size of the group.  This may not match the size of
+the list from DescribeGroup()
+
+#### Request
+```json
+{
+  "ID" : "group_id"
+}
+```
+
+Parameters: None
+
+Fields:
+- `ID`: The group id.
+
+#### Response
+```json
+{
+  "ID": "group_id"
+  "Size": 100
+}
+```
+
+### Method `Group.SetSize`
+Sets the desired / target size of the group.  This is the same as editing the config
+and call commit.
+
+#### Request
+```json
+{
+  "ID" : "group_id",
+  "Size" : 100
+}
+```
+
+Parameters: None
+
+Fields:
+- `ID`: The group id.
+- `Size`: The group target size.
+
+#### Response
+```json
+{
+  "ID" : "group_id"
+}
+```

--- a/pkg/cli/registry.go
+++ b/pkg/cli/registry.go
@@ -140,7 +140,7 @@ func LoadAll(services *Services) ([]*cobra.Command, error) {
 				})
 			}
 
-			command.Short = fmt.Sprintf("Access plugin %s which implements %s",
+			command.Short = fmt.Sprintf("Access object %s which implements %s",
 				name, strings.Join(list, ","))
 
 			commands = append(commands, command)

--- a/pkg/cli/v0/controller/cmd.go
+++ b/pkg/cli/v0/controller/cmd.go
@@ -1,0 +1,29 @@
+package controller
+
+import (
+	"github.com/docker/infrakit/pkg/cli"
+	"github.com/docker/infrakit/pkg/controller"
+	"github.com/docker/infrakit/pkg/discovery"
+	logutil "github.com/docker/infrakit/pkg/log"
+	"github.com/docker/infrakit/pkg/plugin"
+	controller_rpc "github.com/docker/infrakit/pkg/rpc/controller"
+)
+
+var log = logutil.New("module", "cli/v0/controller")
+
+func init() {
+	cli.Register(controller.InterfaceSpec,
+		[]cli.CmdBuilder{
+			Describe,
+		})
+}
+
+// Load loads the typed object
+func Load(plugins discovery.Plugins, name string) (controller.Controller, error) {
+	pn := plugin.Name(name)
+	endpoint, err := plugins.Find(pn)
+	if err != nil {
+		return nil, err
+	}
+	return controller_rpc.NewClient(pn, endpoint.Address)
+}

--- a/pkg/cli/v0/controller/describe.go
+++ b/pkg/cli/v0/controller/describe.go
@@ -1,0 +1,66 @@
+package controller
+
+import (
+	"fmt"
+	"io"
+	"os"
+
+	"github.com/docker/infrakit/pkg/cli"
+	"github.com/docker/infrakit/pkg/types"
+	"github.com/spf13/cobra"
+)
+
+// Describe returns the describe command
+func Describe(name string, services *cli.Services) *cobra.Command {
+	describe := &cobra.Command{
+		Use:   "describe",
+		Short: "Describe all managed objects",
+	}
+	describe.Flags().AddFlagSet(services.OutputFlags)
+
+	tags := describe.Flags().StringSlice("tags", []string{}, "Tags to filter")
+	objectName := describe.Flags().String("name", "", "Name of object")
+	objectID := describe.Flags().String("id", "", "ID of object")
+
+	describe.RunE = func(cmd *cobra.Command, args []string) error {
+		if len(args) != 0 {
+			cmd.Usage()
+			os.Exit(1)
+		}
+
+		controller, err := Load(services.Plugins(), name)
+		if err != nil {
+			return nil
+		}
+		cli.MustNotNil(controller, "controller not found", "name", name)
+
+		search := (types.Metadata{
+			Name: *objectName,
+		}).AddTagsFromStringSlice(*tags)
+
+		if *objectID != "" {
+			search.Identity = &types.Identity{
+				ID: *objectID,
+			}
+		}
+		objects, err := controller.Describe(&search)
+		if err != nil {
+			return err
+		}
+
+		return services.Output(os.Stdout, objects,
+			func(w io.Writer, v interface{}) error {
+
+				for _, o := range objects {
+
+					buff, err := types.AnyValueMust(o).MarshalYAML()
+					if err != nil {
+						return err
+					}
+					fmt.Printf("%v\n", string(buff))
+				}
+				return nil
+			})
+	}
+	return describe
+}

--- a/pkg/cli/v0/group/cmd.go
+++ b/pkg/cli/v0/group/cmd.go
@@ -20,6 +20,9 @@ func init() {
 			Commit,
 			Free,
 			Destroy,
+			Size,
+			SetSize,
+			DestroyInstances,
 		})
 }
 

--- a/pkg/cli/v0/group/destroy_instances.go
+++ b/pkg/cli/v0/group/destroy_instances.go
@@ -1,0 +1,49 @@
+package group
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/docker/infrakit/pkg/cli"
+	"github.com/docker/infrakit/pkg/spi/group"
+	"github.com/docker/infrakit/pkg/spi/instance"
+	"github.com/spf13/cobra"
+)
+
+// DestroyInstances returns the DestroyInstances command
+func DestroyInstances(name string, services *cli.Services) *cobra.Command {
+
+	destroy := &cobra.Command{
+		Use:   "destroy-instances <groupID> <instance ID>...",
+		Short: "Destroy a group's instances",
+		RunE: func(cmd *cobra.Command, args []string) error {
+
+			if len(args) < 2 {
+				cmd.Usage()
+				os.Exit(1)
+			}
+
+			groupPlugin, err := LoadPlugin(services.Plugins(), name)
+			if err != nil {
+				return nil
+			}
+			cli.MustNotNil(groupPlugin, "group plugin not found", "name", name)
+
+			groupID := group.ID(args[0])
+
+			instances := []instance.ID{}
+			for i := 1; i < len(args); i++ {
+				instances = append(instances, instance.ID(i))
+			}
+
+			err = groupPlugin.DestroyInstances(groupID, instances)
+			if err != nil {
+				return err
+			}
+
+			fmt.Println("DestroyInstances", groupID, "initiated for instances", instances)
+			return nil
+		},
+	}
+	return destroy
+}

--- a/pkg/cli/v0/group/size.go
+++ b/pkg/cli/v0/group/size.go
@@ -1,0 +1,78 @@
+package group
+
+import (
+	"fmt"
+	"os"
+	"strconv"
+
+	"github.com/docker/infrakit/pkg/cli"
+	"github.com/docker/infrakit/pkg/spi/group"
+	"github.com/spf13/cobra"
+)
+
+// Size returns the size command
+func Size(name string, services *cli.Services) *cobra.Command {
+
+	size := &cobra.Command{
+		Use:   "size <groupID>",
+		Short: "Returns size of a group",
+		RunE: func(cmd *cobra.Command, args []string) error {
+
+			if len(args) < 1 {
+				cmd.Usage()
+				os.Exit(1)
+			}
+
+			groupPlugin, err := LoadPlugin(services.Plugins(), name)
+			if err != nil {
+				return nil
+			}
+			cli.MustNotNil(groupPlugin, "group plugin not found", "name", name)
+
+			groupID := group.ID(args[0])
+
+			target, err := groupPlugin.Size(groupID)
+			if err != nil {
+				return err
+			}
+			fmt.Println("Group", groupID, "target size=", target)
+			return nil
+		},
+	}
+	return size
+}
+
+// SetSize returns the set size command
+func SetSize(name string, services *cli.Services) *cobra.Command {
+
+	set := &cobra.Command{
+		Use:   "set-size <groupID> <size>",
+		Short: "Sets target size of a group",
+		RunE: func(cmd *cobra.Command, args []string) error {
+
+			if len(args) < 2 {
+				cmd.Usage()
+				os.Exit(1)
+			}
+
+			groupPlugin, err := LoadPlugin(services.Plugins(), name)
+			if err != nil {
+				return nil
+			}
+			cli.MustNotNil(groupPlugin, "group plugin not found", "name", name)
+
+			groupID := group.ID(args[0])
+			target, err := strconv.Atoi(args[1])
+			if err != nil {
+				return err
+			}
+			err = groupPlugin.SetSize(groupID, target)
+			if err != nil {
+				return err
+			}
+			fmt.Println("Group", groupID, "set target to", target)
+			return nil
+		},
+	}
+	return set
+}

--- a/pkg/cli/v0/info.go
+++ b/pkg/cli/v0/info.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 
 	"github.com/docker/infrakit/pkg/cli"
+	"github.com/docker/infrakit/pkg/controller"
 	"github.com/docker/infrakit/pkg/plugin"
 	"github.com/docker/infrakit/pkg/rpc/client"
 	"github.com/docker/infrakit/pkg/spi/flavor"
@@ -16,6 +17,7 @@ import (
 	"github.com/spf13/cobra"
 
 	// v0 loads these packages
+	_ "github.com/docker/infrakit/pkg/cli/v0/controller"
 	_ "github.com/docker/infrakit/pkg/cli/v0/event"
 	_ "github.com/docker/infrakit/pkg/cli/v0/flavor"
 	_ "github.com/docker/infrakit/pkg/cli/v0/group"
@@ -25,6 +27,11 @@ import (
 )
 
 func init() {
+	cli.Register(controller.InterfaceSpec,
+		[]cli.CmdBuilder{
+			Info,
+		})
+
 	cli.Register(instance.InterfaceSpec,
 		[]cli.CmdBuilder{
 			Info,

--- a/pkg/cli/v0/info.go
+++ b/pkg/cli/v0/info.go
@@ -22,6 +22,7 @@ import (
 	_ "github.com/docker/infrakit/pkg/cli/v0/flavor"
 	_ "github.com/docker/infrakit/pkg/cli/v0/group"
 	_ "github.com/docker/infrakit/pkg/cli/v0/instance"
+	_ "github.com/docker/infrakit/pkg/cli/v0/loadbalancer"
 	_ "github.com/docker/infrakit/pkg/cli/v0/metadata"
 	_ "github.com/docker/infrakit/pkg/cli/v0/resource"
 )

--- a/pkg/cli/v0/loadbalancer/backends.go
+++ b/pkg/cli/v0/loadbalancer/backends.go
@@ -1,0 +1,52 @@
+package loadbalancer
+
+import (
+	"fmt"
+	"io"
+	"os"
+
+	"github.com/docker/infrakit/pkg/cli"
+	"github.com/docker/infrakit/pkg/types"
+	"github.com/spf13/cobra"
+)
+
+// Backends returns the describe command
+func Backends(name string, services *cli.Services) *cobra.Command {
+	backends := &cobra.Command{
+		Use:   "backends",
+		Short: "List all backends",
+	}
+	backends.Flags().AddFlagSet(services.OutputFlags)
+	backends.RunE = func(cmd *cobra.Command, args []string) error {
+		if len(args) != 0 {
+			cmd.Usage()
+			os.Exit(1)
+		}
+
+		l4, err := Load(services.Plugins(), name)
+		if err != nil {
+			return nil
+		}
+		cli.MustNotNil(l4, "L4 not found", "name", name)
+
+		list, err := l4.Backends()
+		if err != nil {
+			return err
+		}
+
+		return services.Output(os.Stdout, list,
+			func(w io.Writer, v interface{}) error {
+
+				for _, r := range list {
+
+					buff, err := types.AnyValueMust(r).MarshalYAML()
+					if err != nil {
+						return err
+					}
+					fmt.Printf("%v\n", string(buff))
+				}
+				return nil
+			})
+	}
+	return backends
+}

--- a/pkg/cli/v0/loadbalancer/cmd.go
+++ b/pkg/cli/v0/loadbalancer/cmd.go
@@ -1,0 +1,30 @@
+package loadbalancer
+
+import (
+	"github.com/docker/infrakit/pkg/cli"
+	"github.com/docker/infrakit/pkg/discovery"
+	logutil "github.com/docker/infrakit/pkg/log"
+	"github.com/docker/infrakit/pkg/plugin"
+	loadbalancer_rpc "github.com/docker/infrakit/pkg/rpc/loadbalancer"
+	"github.com/docker/infrakit/pkg/spi/loadbalancer"
+)
+
+var log = logutil.New("module", "cli/v0/loadbalancer")
+
+func init() {
+	cli.Register(loadbalancer.InterfaceSpec,
+		[]cli.CmdBuilder{
+			Routes,
+			Backends,
+		})
+}
+
+// Load loads the typed object
+func Load(plugins discovery.Plugins, name string) (loadbalancer.L4, error) {
+	pn := plugin.Name(name)
+	endpoint, err := plugins.Find(pn)
+	if err != nil {
+		return nil, err
+	}
+	return loadbalancer_rpc.NewClient(pn, endpoint.Address)
+}

--- a/pkg/cli/v0/loadbalancer/routes.go
+++ b/pkg/cli/v0/loadbalancer/routes.go
@@ -1,0 +1,52 @@
+package loadbalancer
+
+import (
+	"fmt"
+	"io"
+	"os"
+
+	"github.com/docker/infrakit/pkg/cli"
+	"github.com/docker/infrakit/pkg/types"
+	"github.com/spf13/cobra"
+)
+
+// Routes returns the describe command
+func Routes(name string, services *cli.Services) *cobra.Command {
+	routes := &cobra.Command{
+		Use:   "routes",
+		Short: "List all routes",
+	}
+	routes.Flags().AddFlagSet(services.OutputFlags)
+	routes.RunE = func(cmd *cobra.Command, args []string) error {
+		if len(args) != 0 {
+			cmd.Usage()
+			os.Exit(1)
+		}
+
+		l4, err := Load(services.Plugins(), name)
+		if err != nil {
+			return nil
+		}
+		cli.MustNotNil(l4, "L4 not found", "name", name)
+
+		list, err := l4.Routes()
+		if err != nil {
+			return err
+		}
+
+		return services.Output(os.Stdout, list,
+			func(w io.Writer, v interface{}) error {
+
+				for _, r := range list {
+
+					buff, err := types.AnyValueMust(r).MarshalYAML()
+					if err != nil {
+						return err
+					}
+					fmt.Printf("%v\n", string(buff))
+				}
+				return nil
+			})
+	}
+	return routes
+}

--- a/pkg/cli/v0/loadbalancer/routes.go
+++ b/pkg/cli/v0/loadbalancer/routes.go
@@ -6,7 +6,7 @@ import (
 	"os"
 
 	"github.com/docker/infrakit/pkg/cli"
-	"github.com/docker/infrakit/pkg/types"
+	"github.com/docker/infrakit/pkg/spi/loadbalancer"
 	"github.com/spf13/cobra"
 )
 
@@ -14,10 +14,66 @@ import (
 func Routes(name string, services *cli.Services) *cobra.Command {
 	routes := &cobra.Command{
 		Use:   "routes",
-		Short: "List all routes",
+		Short: "Loadbalancer routes",
 	}
-	routes.Flags().AddFlagSet(services.OutputFlags)
-	routes.RunE = func(cmd *cobra.Command, args []string) error {
+
+	ls := &cobra.Command{
+		Use:   "ls",
+		Short: "List loadbalancer routes",
+	}
+
+	publish := &cobra.Command{
+		Use:   "publish",
+		Short: "Publish a loadbalancer route",
+	}
+	unpublish := &cobra.Command{
+		Use:   "unpublish",
+		Short: "Unpublish a loadbalancer route",
+	}
+
+	routes.AddCommand(ls, publish, unpublish)
+
+	port := publish.Flags().Uint32("port", 80, "Backend listening port")
+	protocol := publish.Flags().String("protocol", "http", "Protocol: http|https|tcp|udp|ssl")
+	frontendPort := publish.Flags().Uint32("frontend-port", 80, "Frontend loadbalancer port")
+	cert := publish.Flags().String("cert", "", "Certificate")
+
+	publish.RunE = func(cmd *cobra.Command, args []string) error {
+		l4, err := Load(services.Plugins(), name)
+		if err != nil {
+			return nil
+		}
+		cli.MustNotNil(l4, "L4 not found", "name", name)
+
+		route := loadbalancer.Route{
+			Port:             *port,
+			LoadBalancerPort: *frontendPort,
+			Protocol:         loadbalancer.Protocol(*protocol),
+		}
+		if *cert != "" {
+			copy := *cert
+			route.Certificate = &copy
+		}
+		res, err := l4.Publish(route)
+		fmt.Println(res)
+		return err
+	}
+
+	extPort := unpublish.Flags().Uint32("frontend-port", 80, "External loadbalancer port")
+	unpublish.RunE = func(cmd *cobra.Command, args []string) error {
+		l4, err := Load(services.Plugins(), name)
+		if err != nil {
+			return nil
+		}
+		cli.MustNotNil(l4, "L4 not found", "name", name)
+
+		res, err := l4.Unpublish(*extPort)
+		fmt.Println(res)
+		return err
+	}
+
+	ls.Flags().AddFlagSet(services.OutputFlags)
+	ls.RunE = func(cmd *cobra.Command, args []string) error {
 		if len(args) != 0 {
 			cmd.Usage()
 			os.Exit(1)
@@ -37,13 +93,13 @@ func Routes(name string, services *cli.Services) *cobra.Command {
 		return services.Output(os.Stdout, list,
 			func(w io.Writer, v interface{}) error {
 
+				fmt.Printf("%-15v  %-10v %-10v  %-20v\n", "FRONTEND PORT", "PROTOCOL", "BACKEND PORT", "CERT")
 				for _, r := range list {
-
-					buff, err := types.AnyValueMust(r).MarshalYAML()
-					if err != nil {
-						return err
+					cert := ""
+					if r.Certificate != nil {
+						cert = *r.Certificate
 					}
-					fmt.Printf("%v\n", string(buff))
+					fmt.Printf("%-15v  %-10v %-10v %-20v\n", r.LoadBalancerPort, r.Protocol, r.Port, cert)
 				}
 				return nil
 			})

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -1,0 +1,54 @@
+package controller
+
+import (
+	"github.com/docker/infrakit/pkg/spi"
+	"github.com/docker/infrakit/pkg/types"
+)
+
+// Plan models the steps the controller will take to fulfill specification when committed.
+type Plan struct {
+	// Message contains human-friendly message
+	Message []string
+}
+
+// Operation is the action to be taken for a commit
+type Operation int
+
+const (
+	// Manage represents create, update, reconcile operations
+	Manage = iota
+
+	// Destroy is the destroy operation. Destroy also implies Free.
+	Destroy
+)
+
+var (
+	// InterfaceSpec is the current name and version of the Instance API.
+	InterfaceSpec = spi.InterfaceSpec{
+		Name:    "Controller",
+		Version: "0.1.0",
+	}
+)
+
+// Controller is the interface that all controllers implement.  Controllers are managed by pkg/manager/Manager
+type Controller interface {
+
+	// Plan is a commit without actually making the changes.  The controller returns a proposed object state
+	// after commit, with a Plan, or error.
+	Plan(Operation, types.Spec) (types.Object, Plan, error)
+
+	// Commit commits the spec to the controller for management or destruction.  The controller's job is to ensure reality
+	// matches the operation and the specification.  The spec can be composed and references other controllers or plugins.
+	// When a spec is committed to a controller, the controller returns the object state corresponding to
+	// the spec.  When operation is Destroy, only Metadata portion of the spec is needed to identify
+	// the object to be destroyed.
+	Commit(Operation, types.Spec) (types.Object, error)
+
+	// Describe returns a list of objects matching the metadata provided. A list of objects are possible because
+	// metadata can be a tags search.  An object has state, and its original spec can be accessed as well.
+	// A nil Metadata will instruct the controller to return all objects under management.
+	Describe(*types.Metadata) ([]types.Object, error)
+
+	// Free tells the controller to pause management of objects matching.  To resume, commit again.
+	Free(*types.Metadata) ([]types.Object, error)
+}

--- a/pkg/controller/ingress/controller_test.go
+++ b/pkg/controller/ingress/controller_test.go
@@ -65,7 +65,7 @@ func TestControllerStartStop(t *testing.T) {
 	stateObject := controller.object()
 	require.NotNil(t, stateObject)
 	require.NoError(t, stateObject.Validate())
-	require.Equal(t, "ingress-singleton", stateObject.Metadata.Identity.UID)
+	require.Equal(t, "ingress-singleton", stateObject.Metadata.Identity.ID)
 	require.Equal(t, "ingress-controller", stateObject.Metadata.Name)
 
 	// initial state

--- a/pkg/controller/ingress/controller_test.go
+++ b/pkg/controller/ingress/controller_test.go
@@ -42,8 +42,8 @@ func TestControllerStartStop(t *testing.T) {
 	}
 
 	spec := types.Spec{
-		Kind:       "ingress-controller",
-		SpiVersion: "0.1",
+		Kind:    "ingress-controller",
+		Version: "0.1",
 		Metadata: types.Metadata{
 			Name: "ingress-controller",
 		},

--- a/pkg/controller/ingress/fsm.go
+++ b/pkg/controller/ingress/fsm.go
@@ -148,7 +148,7 @@ func (c *Controller) init(in types.Spec) (err error) {
 		},
 
 		core.NewObjects(func(o *types.Object) []interface{} {
-			return []interface{}{o.Metadata.Name, o.Metadata.Identity.UID}
+			return []interface{}{o.Metadata.Name, o.Metadata.Identity.ID}
 		}),
 
 		c.plugins,
@@ -201,7 +201,7 @@ func mustTrue(v bool, e error) bool {
 
 func (c *Controller) construct(spec types.Spec, properties *types.Any) (*types.Identity, *types.Any, error) {
 	state, err := types.AnyValue(c.state())
-	return &types.Identity{UID: "ingress-singleton"}, state, err
+	return &types.Identity{ID: "ingress-singleton"}, state, err
 }
 
 func (c *Controller) object() *types.Object {

--- a/pkg/core/depend_test.go
+++ b/pkg/core/depend_test.go
@@ -15,7 +15,7 @@ func TestFindSpecs0(t *testing.T) {
 
 	spec := `
 kind:        top
-spiVersion:   top-version
+version:   top-version
 metadata:
   name: top
 properties:
@@ -38,17 +38,17 @@ func TestFindSpecs1(t *testing.T) {
 
 	spec := `
 kind:        top
-spiVersion:   top-version
+version:   top-version
 metadata:
   name: top
 properties:
   kind: nest1
-  spiVersion: nest1-version
+  version: nest1-version
   metadata:
     name: nest1
   properties:
     kind: nest2
-    spiVersion: nest2-version
+    version: nest2-version
     metadata:
       name: nest2
 `
@@ -69,28 +69,28 @@ func TestFindSpecs2(t *testing.T) {
 
 	spec := `
 kind:        top
-spiVersion:   top-version
+version:   top-version
 metadata:
   name: top
 properties:
   instance:
     kind: nest1
-    spiVersion: nest1-version
+    version: nest1-version
     metadata:
       name: nest1
     properties:
       kind: nest2
-      spiVersion: nest2-version
+      version: nest2-version
       metadata:
         name: nest2
   flavor:
     kind: nest3
-    spiVersion: nest3-version
+    version: nest3-version
     metadata:
       name: nest3
     properties:
       kind: nest4
-      spiVersion: nest4-version
+      version: nest4-version
       metadata:
         name: nest4
 `
@@ -111,41 +111,41 @@ func TestFindSpecs3(t *testing.T) {
 
 	spec := `
 kind:        top
-spiVersion:   top-version
+version:   top-version
 metadata:
   name: top
 properties:
   instance:
     kind: nest1
-    spiVersion: nest1-version
+    version: nest1-version
     metadata:
       name: nest1
     properties:
       kind: nest2
-      spiVersion: nest2-version
+      version: nest2-version
       metadata:
         name: nest2
       properties:
         - kind: nest5
-          spiVersion: nest5-version
+          version: nest5-version
           metadata:
             name: nest5
         - kind: nest6
-          spiVersion: nest6-version
+          version: nest6-version
           metadata:
             name: nest6
         - kind: nest7
-          spiVersion: nest7-version
+          version: nest7-version
           metadata:
             name: nest7
   flavor:
     kind: nest3
-    spiVersion: nest3-version
+    version: nest3-version
     metadata:
       name: nest3
     properties:
       kind: nest4
-      spiVersion: nest4-version
+      version: nest4-version
       metadata:
         name: nest4
 `
@@ -191,18 +191,18 @@ func TestDepedencyOrder1(t *testing.T) {
 
 	testDependency(t, `
 - kind:        top1C
-  spiVersion:   top1-version
+  version:   top1-version
   metadata:
     name: top1N
   properties:
     instance:
       kind: nest1C
-      spiVersion: nest1-version
+      version: nest1-version
       metadata:
         name: nest1N
       properties:
         kind: nest2C
-        spiVersion: nest2-version
+        version: nest2-version
         metadata:
           name: nest2N
         properties:
@@ -210,25 +210,25 @@ func TestDepedencyOrder1(t *testing.T) {
           nest2Prop2: nest2Val2
     flavor:
       kind: nest3C
-      spiVersion: nest3-version
+      version: nest3-version
       metadata:
         name: nest3N
 - kind:        top2C
-  spiVersion:   top2-version
+  version:   top2-version
   metadata:
     name: top2N
   depends:
     - kind: top1C
       name: top1N
 - kind:        top3C
-  spiVersion:   top3-version
+  version:   top3-version
   metadata:
     name: top3N
   depends:
     - kind: top2C
       name: top2N
 - kind:        top4C
-  spiVersion:   top4-version
+  version:   top4-version
   metadata:
     name: top4N
   depends:
@@ -241,26 +241,26 @@ func TestDepedencyOrder1(t *testing.T) {
 
 	testDependency(t, `
 - kind:        top1C
-  spiVersion:   top1-version
+  version:   top1-version
   metadata:
     name: top1N
   properties:
 - kind:        top2C
-  spiVersion:   top2-version
+  version:   top2-version
   metadata:
     name: top2N
   depends:
     - kind: top3C
       name: top3N
 - kind:        top3C
-  spiVersion:   top3-version
+  version:   top3-version
   metadata:
     name: top3N
   depends:
     - kind: top4C
       name: top4N
 - kind:        top4C
-  spiVersion:   top4-version
+  version:   top4-version
   metadata:
     name: top4N
 `,
@@ -270,26 +270,26 @@ func TestDepedencyOrder1(t *testing.T) {
 
 	testDependency(t, `
 - kind:        top1C
-  spiVersion:   top1-version
+  version:   top1-version
   metadata:
     name: top1N
   properties:
 - kind:        top2C
-  spiVersion:   top2-version
+  version:   top2-version
   metadata:
     name: top2N
   depends:
     - kind: top1C
       name: top1N
 - kind:        top3C
-  spiVersion:   top3-version
+  version:   top3-version
   metadata:
     name: top3N
   depends:
     - kind: top1C
       name: top1N
 - kind:        top4C
-  spiVersion:   top4-version
+  version:   top4-version
   metadata:
     name: top4N
   depends:
@@ -302,40 +302,40 @@ func TestDepedencyOrder1(t *testing.T) {
 
 	testDependency(t, `
 - kind:        pool
-  spiVersion:   poolVersion
+  version:   poolVersion
   metadata:
     name: pool1
   properties:
     instance:
       kind: ebs
-      spiVersion: ebsVersion
+      version: ebsVersion
       metadata:
         name: ebs1
 
 - kind:        pool
-  spiVersion:   poolVersion
+  version:   poolVersion
   metadata:
     name: pool2
   properties:
     instance:
       kind: ebs
-      spiVersion: ebsVersion
+      version: ebsVersion
       metadata:
         name: ebs2
 
 - kind:        group
-  spiVersion:   groupVersion
+  version:   groupVersion
   metadata:
     name: managers
   properties:
     instance:
        kind : instance
-       spiVersion: instanceVersion
+       version: instanceVersion
        metadata:
           name: instance-managers
     flavor:
        kind : flavor
-       spiVersion: flavorVersion
+       version: flavorVersion
        metadata:
           name: flavor-swarm-manager
   depends:
@@ -343,18 +343,18 @@ func TestDepedencyOrder1(t *testing.T) {
       name: pool1
 
 - kind:        group
-  spiVersion:   groupVersion
+  version:   groupVersion
   metadata:
     name: workers
   properties:
     instance:
        kind : instance
-       spiVersion: instanceVersion
+       version: instanceVersion
        metadata:
           name: instance-workers
     flavor:
        kind : flavor
-       spiVersion: flavorVersion
+       version: flavorVersion
        metadata:
           name: flavor-swarm-worker
   depends:
@@ -406,18 +406,18 @@ func TestDepedencyOrder2Cycles(t *testing.T) {
 
 	testDependencyCycles(t, `
 - kind:        top1C
-  spiVersion:   top1-version
+  version:   top1-version
   metadata:
     name: top1N
   properties:
     instance:
       kind: nest1C
-      spiVersion: nest1-version
+      version: nest1-version
       metadata:
         name: nest1N
       properties:
         kind: nest2C
-        spiVersion: nest2-version
+        version: nest2-version
         metadata:
           name: nest2N
         properties:
@@ -425,18 +425,18 @@ func TestDepedencyOrder2Cycles(t *testing.T) {
           nest2Prop2: nest2Val2
     flavor:
       kind: nest3C
-      spiVersion: nest3-version
+      version: nest3-version
       metadata:
         name: nest3N
 - kind:        top2C
-  spiVersion:   top2-version
+  version:   top2-version
   metadata:
     name: top2N
   depends:
     - kind: top1C
       name: top1N
 - kind:        top3C
-  spiVersion:   top3-version
+  version:   top3-version
   metadata:
     name: top3N
   depends:
@@ -445,7 +445,7 @@ func TestDepedencyOrder2Cycles(t *testing.T) {
     - kind: top4C
       name: top4N
 - kind:        top4C
-  spiVersion:   top4-version
+  version:   top4-version
   metadata:
     name: top4N
   depends:

--- a/pkg/core/object_test.go
+++ b/pkg/core/object_test.go
@@ -33,7 +33,7 @@ func TestObject(t *testing.T) {
     - kind: instance-aws/ec2-volume
       name: disk1
       bind:
-         volume/id : metadata/uid
+         volume/id : metadata/id
          volume/size: properties/sizeGb
 
 - kind:        instance-aws/ec2-volume
@@ -74,7 +74,7 @@ func TestObject(t *testing.T) {
 	disk := objects.FindBy("instance-aws/ec2-volume", "disk1")
 	require.NotNil(t, disk)
 
-	disk.Metadata.Identity = &types.Identity{UID: "disk-11234"}
+	disk.Metadata.Identity = &types.Identity{ID: "disk-11234"}
 
 	host := objects.FindBy("instance-aws/ec2-volume", "host1")
 	require.Nil(t, host) // wrong kind
@@ -127,15 +127,15 @@ func TestObjectNested(t *testing.T) {
         - kind: instance-aws/ec2-volume
           name: disk1
           bind:
-            disk1VolumeId : metadata/uid
+            disk1VolumeId : metadata/id
         - kind: instance-aws/ec2-volume
           name: disk2
           bind:
-            disk2VolumeId : metadata/uid
+            disk2VolumeId : metadata/id
         - kind: instance-aws/ec2-volume
           name: disk3
           bind:
-            disk3VolumeId : metadata/uid
+            disk3VolumeId : metadata/id
 
     flavor:
       kind:        flavor-swarm/manager
@@ -231,7 +231,7 @@ func TestObjectNested(t *testing.T) {
 	for i, n := range []string{"disk1", "disk2", "disk3"} {
 		disk := objects.FindBy("instance-aws/ec2-volume", n)
 		require.NotNil(t, disk)
-		disk.Metadata.Identity = &types.Identity{UID: fmt.Sprintf("disk-%d", i)}
+		disk.Metadata.Identity = &types.Identity{ID: fmt.Sprintf("disk-%d", i)}
 	}
 
 	node := objects.FindBy("instance-aws/ec2-instance", "manager-node")

--- a/pkg/core/object_test.go
+++ b/pkg/core/object_test.go
@@ -15,7 +15,7 @@ func TestObject(t *testing.T) {
 
 	text := `
 - kind:        instance-aws/ec2-instance
-  spiVersion:   instance/v0.1.0
+  version:   instance/v0.1.0
   metadata:
     name: host1
     tags:
@@ -37,7 +37,7 @@ func TestObject(t *testing.T) {
          volume/size: properties/sizeGb
 
 - kind:        instance-aws/ec2-volume
-  spiVersion:   instance/v0.1.0
+  version:   instance/v0.1.0
   metadata:
     name: disk1
     tags:
@@ -100,7 +100,7 @@ func TestObjectNested(t *testing.T) {
 
 	text := `
 - kind:        group
-  spiVersion:   group/v0.1.0
+  version:   group/v0.1.0
   metadata:
     name: managers
     tags:
@@ -109,7 +109,7 @@ func TestObjectNested(t *testing.T) {
   properties:
     instance:
       kind:        instance-aws/ec2-instance
-      spiVersion:   instance/v0.1.0
+      version:   instance/v0.1.0
       metadata:
         name: manager-node
         tags:
@@ -139,7 +139,7 @@ func TestObjectNested(t *testing.T) {
 
     flavor:
       kind:        flavor-swarm/manager
-      spiVersion:   flavor/v0.1.0
+      version:   flavor/v0.1.0
       metadata:
         name: swarm-manager
         tags:
@@ -150,7 +150,7 @@ func TestObjectNested(t *testing.T) {
           region: us-west-1
           stack:  test
 - kind:        instance-aws/ec2-volume
-  spiVersion:   instance/v0.1.0
+  version:   instance/v0.1.0
   metadata:
     name: disk1
     tags:
@@ -164,7 +164,7 @@ func TestObjectNested(t *testing.T) {
     region: us-west-1
     stack:  test
 - kind:        instance-aws/ec2-volume
-  spiVersion:   instance/v0.1.0
+  version:   instance/v0.1.0
   metadata:
     name: disk2
     tags:
@@ -178,7 +178,7 @@ func TestObjectNested(t *testing.T) {
     region: us-west-1
     stack:  test
 - kind:        instance-aws/ec2-volume
-  spiVersion:   instance/v0.1.0
+  version:   instance/v0.1.0
   metadata:
     name: disk3
     tags:

--- a/pkg/core/process_test.go
+++ b/pkg/core/process_test.go
@@ -268,7 +268,7 @@ func TestProcess(t *testing.T) {
 	)
 
 	store := NewObjects(func(o *types.Object) []interface{} {
-		return []interface{}{o.Metadata.Name, o.Metadata.Identity.UID}
+		return []interface{}{o.Metadata.Name, o.Metadata.Identity.ID}
 	})
 
 	createArgs := make(chan *types.Any)
@@ -304,7 +304,7 @@ func TestProcess(t *testing.T) {
 			Constructor: func(spec types.Spec, properties *types.Any) (*types.Identity, *types.Any, error) {
 				createArgs <- properties
 				createSpec <- spec
-				return &types.Identity{UID: "new"}, nil, nil
+				return &types.Identity{ID: "new"}, nil, nil
 			},
 		},
 
@@ -345,5 +345,5 @@ func TestProcess(t *testing.T) {
 	// get the object
 	obj := proc.Object(instance)
 	require.NotNil(t, obj)
-	require.Equal(t, "new", obj.Metadata.Identity.UID)
+	require.Equal(t, "new", obj.Metadata.Identity.ID)
 }

--- a/pkg/core/process_test.go
+++ b/pkg/core/process_test.go
@@ -109,7 +109,7 @@ func TestRenderProperties(t *testing.T) {
 	// Case - no template, just properties. Note the escapes here.
 	testRenderProperties(t, `
 - kind:        instance-aws/ec2-instance
-  spiVersion:   instance/v0.1.0
+  version:   instance/v0.1.0
   metadata:
     name: host1
     tags:
@@ -159,7 +159,7 @@ func TestRenderProperties(t *testing.T) {
 	// Case - has template.  No properties
 	testRenderProperties(t, `
 - kind:        instance-aws/ec2-instance
-  spiVersion:   instance/v0.1.0
+  version:   instance/v0.1.0
   metadata:
     name: host1
     tags:
@@ -190,7 +190,7 @@ func TestRenderProperties(t *testing.T) {
 	// Case - has template, with properties override
 	testRenderProperties(t, `
 - kind:        instance-aws/ec2-instance
-  spiVersion:   instance/v0.1.0
+  version:   instance/v0.1.0
   metadata:
     name: host1
     tags:
@@ -233,7 +233,7 @@ func TestProcess(t *testing.T) {
 
 	text := `
 - kind:        instance-aws/ec2-instance
-  spiVersion:   instance/v0.1.0
+  version:   instance/v0.1.0
   metadata:
     name: workers
     tags:

--- a/pkg/core/testdata/simple.yml
+++ b/pkg/core/testdata/simple.yml
@@ -17,7 +17,7 @@
     - kind: instance-aws/ec2-volume
       name: disk1
       bind:
-         volumeId : metadata/UID
+         volumeId : metadata/ID
 
 - kind:        instance-aws/ec2-volume
   version:   instance/v0.1.0

--- a/pkg/core/testdata/simple.yml
+++ b/pkg/core/testdata/simple.yml
@@ -1,5 +1,5 @@
 - kind:        instance-aws/ec2-instance
-  spiVersion:   instance/v0.1.0
+  version:   instance/v0.1.0
   metadata:
     name: host1
     tags:
@@ -20,7 +20,7 @@
          volumeId : metadata/UID
 
 - kind:        instance-aws/ec2-volume
-  spiVersion:   instance/v0.1.0
+  version:   instance/v0.1.0
   metadata:
     name: disk1
     tags:

--- a/pkg/discovery/local/dir.go
+++ b/pkg/discovery/local/dir.go
@@ -11,6 +11,7 @@ import (
 	"sync"
 
 	"github.com/docker/infrakit/pkg/discovery"
+	logutil "github.com/docker/infrakit/pkg/log"
 	"github.com/docker/infrakit/pkg/plugin"
 )
 
@@ -147,7 +148,7 @@ func (r *dirPluginDiscovery) List() (map[string]*plugin.Endpoint, error) {
 				continue
 			}
 
-			log.Debug("Discovered plugin", "address", instance.Address)
+			log.Debug("Discovered plugin", "address", instance.Address, "V", logutil.V(500))
 			plugins[instance.Name] = instance
 		}
 	}

--- a/pkg/leader/file/file.go
+++ b/pkg/leader/file/file.go
@@ -34,7 +34,7 @@ func NewDetector(pollInterval time.Duration, filename, id string) (*leader.Polle
 
 			match := strings.Trim(string(content), " \t\n")
 
-			log.Debug("poll for leadership", "id", id, "file", filename, "match", match, "err", err)
+			log.Debug("poll for leadership", "id", id, "file", filename, "match", match, "err", err, "V", logutil.V(500))
 
 			return match == id, err
 		}), nil

--- a/pkg/manager/controller_proxy.go
+++ b/pkg/manager/controller_proxy.go
@@ -1,0 +1,176 @@
+package manager
+
+import (
+	"fmt"
+
+	"github.com/docker/infrakit/pkg/controller"
+	"github.com/docker/infrakit/pkg/spi/group"
+	"github.com/docker/infrakit/pkg/types"
+)
+
+// GroupControllers returns a map of *scoped* group controllers by ID of the group.
+func (m *manager) GroupControllers() (map[string]controller.Controller, error) {
+	base := newControllerProxy(nil, m.Plugin)
+	controllers := map[string]controller.Controller{
+		"controller": base,
+	}
+	all, err := m.Plugin.InspectGroups()
+	if err != nil {
+		return controllers, nil
+	}
+	for _, spec := range all {
+		gid := spec.ID
+		controllers[string(gid)] = newControllerProxy(&gid, m.Plugin)
+	}
+	log.Debug("GroupControllers", "map", controllers)
+	return controllers, nil
+}
+
+// newControllerProxy returns a Controller implementation that optionally
+// enforces scoping by group ID if provided
+func newControllerProxy(id *group.ID, g group.Plugin) controller.Controller {
+	return &pController{
+		plugin: g,
+		scope:  id,
+	}
+}
+
+// This controller is used to implement a generic controller *as well as* a named controller
+// for a group.  When id is specified, the controller is scoped to the id.  When input is missing
+// id, it will be injected.  If input has mismatched id, requests will error.
+type pController struct {
+	scope  *group.ID
+	plugin group.Plugin
+}
+
+func (c *pController) translateSpec(spec types.Spec) (group.Spec, error) {
+	gSpec := group.Spec{
+		Properties: spec.Properties,
+	}
+	if c.scope == nil {
+		if spec.Metadata.Name == "" {
+			return gSpec, fmt.Errorf("no group name")
+		}
+		gSpec.ID = group.ID(spec.Metadata.Name)
+		return gSpec, nil
+	}
+
+	if spec.Metadata.Name != string(*c.scope) {
+		return group.Spec{}, fmt.Errorf("wrong group: %v", *c.scope)
+	}
+
+	gSpec.ID = *c.scope
+	return gSpec, nil
+}
+
+func objectFromSpec(spec types.Spec) types.Object {
+	return types.Object{
+		Spec: spec,
+	}
+}
+
+func (c *pController) Plan(operation controller.Operation,
+	spec types.Spec) (object types.Object, plan controller.Plan, err error) {
+
+	gSpec, e := c.translateSpec(spec)
+	if e != nil {
+		err = e
+		return
+	}
+
+	plan = controller.Plan{}
+	object = objectFromSpec(spec)
+	if resp, cerr := c.plugin.CommitGroup(gSpec, true); cerr == nil {
+		plan.Message = []string{resp}
+	} else {
+		err = cerr
+	}
+	return
+}
+
+func (c *pController) Commit(operation controller.Operation, spec types.Spec) (object types.Object, err error) {
+
+	gSpec, e := c.translateSpec(spec)
+	if e != nil {
+		err = e
+		return
+	}
+
+	object = objectFromSpec(spec)
+	switch operation {
+	case controller.Manage:
+		_, err = c.plugin.CommitGroup(gSpec, false)
+	case controller.Destroy:
+		err = c.plugin.DestroyGroup(group.ID(spec.Metadata.Name))
+	}
+	return
+}
+
+func (c *pController) helpFind(search *types.Metadata) ([]string, map[string]group.Spec, error) {
+	specs := map[string]group.Spec{}
+
+	all, err := c.plugin.InspectGroups()
+	if err != nil {
+		return nil, nil, err
+	}
+	for _, gs := range all {
+		specs[string(gs.ID)] = gs
+	}
+
+	ids := []string{}
+	if search == nil {
+		for k := range specs {
+			ids = append(ids, k)
+		}
+	} else {
+		ids = append(ids, search.Name)
+	}
+
+	// Scoping by group id
+	if c.scope != nil {
+		ids = []string{string(*c.scope)}
+
+	}
+	return ids, specs, nil
+}
+
+func (c *pController) Describe(search *types.Metadata) (objects []types.Object, err error) {
+	var ids []string
+	var specs map[string]group.Spec
+
+	ids, specs, err = c.helpFind(search)
+	if err != nil {
+		return
+	}
+
+	objects = []types.Object{}
+
+	for _, id := range ids {
+
+		var desc group.Description
+		desc, err = c.plugin.DescribeGroup(group.ID(id))
+		if err != nil {
+			return
+		}
+		state := types.Object{
+			Spec: types.Spec{
+				Kind:    "group",
+				Version: group.InterfaceSpec.Encode(),
+				Metadata: types.Metadata{
+					Identity: &types.Identity{ID: id},
+					Name:     id,
+				},
+				Properties: types.AnyValueMust(specs[id]),
+			},
+			State: types.AnyValueMust(desc),
+		}
+		objects = append(objects, state)
+	}
+	return
+}
+
+func (c *pController) Free(search *types.Metadata) (objects []types.Object, err error) {
+	objects, err = c.Describe(search)
+	err = c.plugin.FreeGroup(group.ID(search.Name))
+	return
+}

--- a/pkg/manager/controller_proxy.go
+++ b/pkg/manager/controller_proxy.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 
 	"github.com/docker/infrakit/pkg/controller"
+	logutil "github.com/docker/infrakit/pkg/log"
 	"github.com/docker/infrakit/pkg/spi/group"
 	"github.com/docker/infrakit/pkg/types"
 )
@@ -22,7 +23,7 @@ func (m *manager) GroupControllers() (map[string]controller.Controller, error) {
 		gid := spec.ID
 		controllers[string(gid)] = newControllerProxy(&gid, m.Plugin)
 	}
-	log.Debug("GroupControllers", "map", controllers)
+	log.Debug("GroupControllers", "map", controllers, "V", logutil.V(500))
 	return controllers, nil
 }
 

--- a/pkg/manager/group_plugin_impl.go
+++ b/pkg/manager/group_plugin_impl.go
@@ -19,7 +19,7 @@ func (m *manager) proxyForGroupPlugin(name string) (group.Plugin, error) {
 
 	// A late-binding proxy so that we don't have a problem with having to
 	// start up the manager as the last of all the plugins.
-	return newProxy(func() (group.Plugin, error) {
+	return newGroupProxy(func() (group.Plugin, error) {
 		endpoint, err := m.plugins.Find(plugin.Name(name))
 		if err != nil {
 			return nil, err

--- a/pkg/manager/group_proxy.go
+++ b/pkg/manager/group_proxy.go
@@ -7,92 +7,104 @@ import (
 	"github.com/docker/infrakit/pkg/spi/instance"
 )
 
-// newProxy returns a plugin interface.  The proxy is late-binding in that
-// it does not resolve plugin until a method is called.
-func newProxy(finder func() (group.Plugin, error)) group.Plugin {
-	return &proxy{finder: finder}
-}
-
 type proxy struct {
 	lock   sync.Mutex
 	client group.Plugin
 	finder func() (group.Plugin, error)
 }
 
-func (c *proxy) run(f func(group.Plugin) error) error {
-	c.lock.Lock()
-	defer c.lock.Unlock()
+type pluginHelper interface {
+	getPlugin() (group.Plugin, error)
+}
 
-	if c.client == nil {
-		if p, err := c.finder(); err == nil {
-			c.client = p
-		} else {
-			return err
-		}
+func (p *proxy) getPlugin() (group.Plugin, error) {
+	p.lock.Lock()
+	defer p.lock.Unlock()
+
+	if p.client != nil {
+		return p.client, nil
 	}
-
-	return f(c.client)
+	return p.finder()
 }
 
-func (c *proxy) CommitGroup(grp group.Spec, pretend bool) (resp string, err error) {
-	err = c.run(func(g group.Plugin) error {
-		resp, err = g.CommitGroup(grp, pretend)
-		return err
-	})
-	return
+// newGroupProxy returns a plugin interface.  The proxy is late-binding in that
+// it does not resolve plugin until a method is called.
+func newGroupProxy(finder func() (group.Plugin, error)) group.Plugin {
+	return &pGroup{&proxy{finder: finder}}
 }
 
-func (c *proxy) FreeGroup(id group.ID) (err error) {
-	err = c.run(func(g group.Plugin) error {
-		err = g.FreeGroup(id)
-		return err
-	})
-	return
+type pGroup struct {
+	pluginHelper
 }
 
-func (c *proxy) DescribeGroup(id group.ID) (desc group.Description, err error) {
-	err = c.run(func(g group.Plugin) error {
-		desc, err = g.DescribeGroup(id)
-		return err
-	})
-	return
+func (c *pGroup) CommitGroup(grp group.Spec, pretend bool) (resp string, err error) {
+	var p group.Plugin
+	p, err = c.getPlugin()
+	if err != nil {
+		return
+	}
+	return p.CommitGroup(grp, pretend)
 }
 
-func (c *proxy) DestroyGroup(id group.ID) (err error) {
-	err = c.run(func(g group.Plugin) error {
-		err = g.DestroyGroup(id)
-		return err
-	})
-	return
+func (c *pGroup) FreeGroup(id group.ID) (err error) {
+	var p group.Plugin
+	p, err = c.getPlugin()
+	if err != nil {
+		return
+	}
+	return p.FreeGroup(id)
 }
 
-func (c *proxy) InspectGroups() (specs []group.Spec, err error) {
-	err = c.run(func(g group.Plugin) error {
-		specs, err = g.InspectGroups()
-		return err
-	})
-	return
+func (c *pGroup) DescribeGroup(id group.ID) (desc group.Description, err error) {
+	var p group.Plugin
+	p, err = c.getPlugin()
+	if err != nil {
+		return
+	}
+	return p.DescribeGroup(id)
 }
 
-func (c *proxy) DestroyInstances(id group.ID, instances []instance.ID) (err error) {
-	err = c.run(func(g group.Plugin) error {
-		return g.DestroyInstances(id, instances)
-	})
-	return
+func (c *pGroup) DestroyGroup(id group.ID) (err error) {
+	var p group.Plugin
+	p, err = c.getPlugin()
+	if err != nil {
+		return
+	}
+	return p.DestroyGroup(id)
 }
 
-func (c *proxy) Size(id group.ID) (size int, err error) {
-	err = c.run(func(g group.Plugin) error {
-		size, err = g.Size(id)
-		return err
-	})
-	return
+func (c *pGroup) InspectGroups() (specs []group.Spec, err error) {
+	var p group.Plugin
+	p, err = c.getPlugin()
+	if err != nil {
+		return
+	}
+	return p.InspectGroups()
 }
 
-func (c *proxy) SetSize(id group.ID, size int) (err error) {
-	err = c.run(func(g group.Plugin) error {
-		err = g.SetSize(id, size)
-		return err
-	})
-	return
+func (c *pGroup) DestroyInstances(id group.ID, instances []instance.ID) (err error) {
+	var p group.Plugin
+	p, err = c.getPlugin()
+	if err != nil {
+		return
+	}
+	return p.DestroyInstances(id, instances)
+}
+
+func (c *pGroup) Size(id group.ID) (size int, err error) {
+	var p group.Plugin
+	p, err = c.getPlugin()
+	if err != nil {
+		return
+	}
+	return p.Size(id)
+}
+
+func (c *pGroup) SetSize(id group.ID, size int) (err error) {
+	var p group.Plugin
+	p, err = c.getPlugin()
+	if err != nil {
+		return
+	}
+	return p.SetSize(id, size)
 }

--- a/pkg/manager/group_proxy.go
+++ b/pkg/manager/group_proxy.go
@@ -4,6 +4,7 @@ import (
 	"sync"
 
 	"github.com/docker/infrakit/pkg/spi/group"
+	"github.com/docker/infrakit/pkg/spi/instance"
 )
 
 // newProxy returns a plugin interface.  The proxy is late-binding in that
@@ -68,6 +69,29 @@ func (c *proxy) DestroyGroup(id group.ID) (err error) {
 func (c *proxy) InspectGroups() (specs []group.Spec, err error) {
 	err = c.run(func(g group.Plugin) error {
 		specs, err = g.InspectGroups()
+		return err
+	})
+	return
+}
+
+func (c *proxy) DestroyInstances(id group.ID, instances []instance.ID) (err error) {
+	err = c.run(func(g group.Plugin) error {
+		return g.DestroyInstances(id, instances)
+	})
+	return
+}
+
+func (c *proxy) Size(id group.ID) (size int, err error) {
+	err = c.run(func(g group.Plugin) error {
+		size, err = g.Size(id)
+		return err
+	})
+	return
+}
+
+func (c *proxy) SetSize(id group.ID, size int) (err error) {
+	err = c.run(func(g group.Plugin) error {
+		err = g.SetSize(id, size)
 		return err
 	})
 	return

--- a/pkg/manager/group_proxy_test.go
+++ b/pkg/manager/group_proxy_test.go
@@ -11,7 +11,7 @@ import (
 func TestErrorOnCallsToNilPlugin(t *testing.T) {
 
 	errMessage := "no-plugin"
-	proxy := newProxy(func() (group.Plugin, error) {
+	proxy := newGroupProxy(func() (group.Plugin, error) {
 		return nil, errors.New(errMessage)
 	})
 
@@ -45,7 +45,7 @@ func TestDelayPluginLookupCallingMethod(t *testing.T) {
 		},
 	}
 
-	proxy := newProxy(func() (group.Plugin, error) { return fake, nil })
+	proxy := newGroupProxy(func() (group.Plugin, error) { return fake, nil })
 
 	require.False(t, called)
 
@@ -66,7 +66,7 @@ func TestDelayPluginLookupCallingMethodReturnsError(t *testing.T) {
 		},
 	}
 
-	proxy := newProxy(func() (group.Plugin, error) { return fake, nil })
+	proxy := newGroupProxy(func() (group.Plugin, error) { return fake, nil })
 
 	require.False(t, called)
 
@@ -93,7 +93,7 @@ func TestDelayPluginLookupCallingMultipleMethods(t *testing.T) {
 		},
 	}
 
-	proxy := newProxy(func() (group.Plugin, error) { return fake, nil })
+	proxy := newGroupProxy(func() (group.Plugin, error) { return fake, nil })
 
 	require.False(t, called)
 

--- a/pkg/manager/manager.go
+++ b/pkg/manager/manager.go
@@ -6,6 +6,7 @@ import (
 	"net/url"
 	"sync"
 
+	"github.com/docker/infrakit/pkg/controller"
 	"github.com/docker/infrakit/pkg/discovery"
 	"github.com/docker/infrakit/pkg/leader"
 	logutil "github.com/docker/infrakit/pkg/log"
@@ -44,6 +45,8 @@ type Manager interface {
 // Backend is the admin / server interface
 type Backend interface {
 	group.Plugin
+
+	GroupControllers() (map[string]controller.Controller, error)
 
 	Manager
 
@@ -91,12 +94,12 @@ func NewManager(
 		snapshot:    snapshot,
 	}
 
-	gp, err := m.proxyForGroupPlugin(backendName)
+	var err error
+	m.Plugin, err = m.proxyForGroupPlugin(backendName)
 	if err != nil {
 		return nil, err
 	}
 
-	m.Plugin = gp
 	return m, nil
 }
 

--- a/pkg/mock/plugin/group/group.go
+++ b/pkg/mock/plugin/group/group.go
@@ -38,8 +38,10 @@ func (_mr *_MockScaledRecorder) CreateOne(arg0 interface{}) *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "CreateOne", arg0)
 }
 
-func (_m *MockScaled) Destroy(_param0 instance.Description, _param1 instance.Context) {
-	_m.ctrl.Call(_m, "Destroy", _param0, _param1)
+func (_m *MockScaled) Destroy(_param0 instance.Description, _param1 instance.Context) error {
+	ret := _m.ctrl.Call(_m, "Destroy", _param0, _param1)
+	ret0, _ := ret[0].(error)
+	return ret0
 }
 
 func (_mr *_MockScaledRecorder) Destroy(arg0, arg1 interface{}) *gomock.Call {

--- a/pkg/mock/spi/group/group.go
+++ b/pkg/mock/spi/group/group.go
@@ -5,6 +5,7 @@ package group
 
 import (
 	group "github.com/docker/infrakit/pkg/spi/group"
+	instance "github.com/docker/infrakit/pkg/spi/instance"
 	gomock "github.com/golang/mock/gomock"
 )
 
@@ -61,6 +62,16 @@ func (_mr *_MockPluginRecorder) DestroyGroup(arg0 interface{}) *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "DestroyGroup", arg0)
 }
 
+func (_m *MockPlugin) DestroyInstances(_param0 group.ID, _param1 []instance.ID) error {
+	ret := _m.ctrl.Call(_m, "DestroyInstances", _param0, _param1)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+func (_mr *_MockPluginRecorder) DestroyInstances(arg0, arg1 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "DestroyInstances", arg0, arg1)
+}
+
 func (_m *MockPlugin) FreeGroup(_param0 group.ID) error {
 	ret := _m.ctrl.Call(_m, "FreeGroup", _param0)
 	ret0, _ := ret[0].(error)
@@ -80,4 +91,25 @@ func (_m *MockPlugin) InspectGroups() ([]group.Spec, error) {
 
 func (_mr *_MockPluginRecorder) InspectGroups() *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "InspectGroups")
+}
+
+func (_m *MockPlugin) SetSize(_param0 group.ID, _param1 int) error {
+	ret := _m.ctrl.Call(_m, "SetSize", _param0, _param1)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+func (_mr *_MockPluginRecorder) SetSize(arg0, arg1 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "SetSize", arg0, arg1)
+}
+
+func (_m *MockPlugin) Size(_param0 group.ID) (int, error) {
+	ret := _m.ctrl.Call(_m, "Size", _param0)
+	ret0, _ := ret[0].(int)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+func (_mr *_MockPluginRecorder) Size(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "Size", arg0)
 }

--- a/pkg/provider/google/plugin/group/plugin.go
+++ b/pkg/provider/google/plugin/group/plugin.go
@@ -310,6 +310,20 @@ func (p *plugin) InspectGroups() ([]group.Spec, error) {
 	return specs, nil
 }
 
+// DestroyInstances TODO(chungers) - implement this
+func (p *plugin) DestroyInstances(id group.ID, instances []instance.ID) error {
+	return fmt.Errorf("not implemented")
+}
+
+// Size TODO(chungers) - implement this
+func (p *plugin) Size(id group.ID) (int, error) {
+	return 0, fmt.Errorf("not implemented")
+}
+
+func (p *plugin) SetSize(id group.ID, size int) error {
+	return p.API.ResizeInstanceGroupManager(string(id), int64(size))
+}
+
 func last(url string) string {
 	parts := strings.Split(url, "/")
 	return parts[len(parts)-1]

--- a/pkg/rpc/controller/client.go
+++ b/pkg/rpc/controller/client.go
@@ -1,0 +1,80 @@
+package controller
+
+import (
+	"github.com/docker/infrakit/pkg/controller"
+	"github.com/docker/infrakit/pkg/plugin"
+	rpc_client "github.com/docker/infrakit/pkg/rpc/client"
+	"github.com/docker/infrakit/pkg/types"
+)
+
+// NewClient returns a plugin interface implementation connected to a remote plugin
+func NewClient(name plugin.Name, socketPath string) (controller.Controller, error) {
+	rpcClient, err := rpc_client.New(socketPath, controller.InterfaceSpec)
+	if err != nil {
+		return nil, err
+	}
+	return Adapt(name, rpcClient), nil
+}
+
+// Adapt converts a rpc client to a Controller object
+func Adapt(name plugin.Name, rpcClient rpc_client.Client) controller.Controller {
+	return &client{name: name, client: rpcClient}
+}
+
+type client struct {
+	name   plugin.Name
+	client rpc_client.Client
+}
+
+// Plan is a commit without actually making the changes.  The controller returns a proposed object state
+// after commit, with a Plan, or error.
+func (c client) Plan(operation controller.Operation, spec types.Spec) (types.Object, controller.Plan, error) {
+	req := ChangeRequest{
+		Name:      c.name,
+		Operation: operation,
+		Spec:      spec,
+	}
+	resp := ChangeResponse{}
+	err := c.client.Call("Controller.Plan", req, &resp)
+	return resp.Object, resp.Plan, err
+}
+
+// Commit commits the spec to the controller for management.  The controller's job is to ensure reality
+// matches the specification.  The spec can be composed and references other controllers or plugins.
+// When a spec is committed to a controller, the controller returns the object state corresponding to
+// the spec.  When operation is Destroy, only Metadata portion of the spec is needed to identify
+// the object to be destroyed.
+func (c client) Commit(operation controller.Operation, spec types.Spec) (types.Object, error) {
+	req := ChangeRequest{
+		Name:      c.name,
+		Operation: operation,
+		Spec:      spec,
+	}
+	resp := ChangeResponse{}
+	err := c.client.Call("Controller.Commit", req, &resp)
+	return resp.Object, err
+}
+
+// Describe returns a list of objects matching the metadata provided. A list of objects are possible because
+// metadata can be a tags search.  An object has state, and its original spec can be accessed as well.
+// A nil Metadata will instruct the controller to return all objects under management.
+func (c client) Describe(metadata *types.Metadata) ([]types.Object, error) {
+	req := FindRequest{
+		Name:     c.name,
+		Metadata: metadata,
+	}
+	resp := FindResponse{}
+	err := c.client.Call("Controller.Describe", req, &resp)
+	return resp.Objects, err
+}
+
+// Free tells the controller to pause management of objects matching.  To resume, commit again.
+func (c client) Free(metadata *types.Metadata) ([]types.Object, error) {
+	req := FindRequest{
+		Name:     c.name,
+		Metadata: metadata,
+	}
+	resp := FindResponse{}
+	err := c.client.Call("Controller.Free", req, &resp)
+	return resp.Objects, err
+}

--- a/pkg/rpc/controller/rpc_multi_test.go
+++ b/pkg/rpc/controller/rpc_multi_test.go
@@ -1,0 +1,324 @@
+package controller
+
+import (
+	"fmt"
+	"io/ioutil"
+	"path/filepath"
+	"testing"
+
+	"github.com/docker/infrakit/pkg/controller"
+	"github.com/docker/infrakit/pkg/plugin"
+	rpc_server "github.com/docker/infrakit/pkg/rpc/server"
+	testing_controller "github.com/docker/infrakit/pkg/testing/controller"
+	"github.com/docker/infrakit/pkg/types"
+	"github.com/stretchr/testify/require"
+)
+
+func tempSocket() string {
+	dir, err := ioutil.TempDir("", "infrakit-test-")
+	if err != nil {
+		panic(err)
+	}
+
+	return filepath.Join(dir, "controller-impl-test")
+}
+
+func must(i controller.Controller, err error) controller.Controller {
+	if err != nil {
+		panic(err)
+	}
+	return i
+}
+
+func TestMultiControllerPlan(t *testing.T) {
+	socketPath := tempSocket()
+	name := filepath.Base(socketPath)
+
+	smallSpec := types.Spec{Metadata: types.Metadata{Name: "small"}}
+	smallObject := types.Object{Spec: smallSpec}
+	smallPlan := controller.Plan{Message: []string{"increase size"}}
+	largeSpec := types.Spec{Metadata: types.Metadata{Name: "large"}}
+	largeObject := types.Object{Spec: largeSpec}
+	largePlan := controller.Plan{Message: []string{"decrease size"}}
+
+	smallActual := make(chan []interface{}, 1)
+	largeActual := make(chan []interface{}, 1)
+
+	small := &testing_controller.Controller{
+		DoPlan: func(operation controller.Operation, spec types.Spec) (types.Object, controller.Plan, error) {
+
+			smallActual <- []interface{}{operation, spec}
+
+			return smallObject, smallPlan, nil
+		},
+	}
+	large := &testing_controller.Controller{
+		DoPlan: func(operation controller.Operation, spec types.Spec) (types.Object, controller.Plan, error) {
+
+			largeActual <- []interface{}{operation, spec}
+
+			return largeObject, largePlan, nil
+		},
+	}
+	server, err := rpc_server.StartPluginAtPath(socketPath, ServerWithTypes(
+		func() (map[string]controller.Controller, error) {
+			return map[string]controller.Controller{
+				"small": small,
+				"large": large,
+			}, nil
+		},
+	))
+	require.NoError(t, err)
+
+	a1, p1, err := must(NewClient(plugin.Name(name+"/small"), socketPath)).Plan(controller.Manage, smallSpec)
+	require.NoError(t, err)
+
+	a2, p2, err := must(NewClient(plugin.Name(name+"/large"), socketPath)).Plan(controller.Destroy, largeSpec)
+	require.NoError(t, err)
+
+	_, _, err = must(NewClient(plugin.Name(name+"/typeUnknown"), socketPath)).Plan(controller.Manage, largeSpec)
+	require.Error(t, err)
+	require.Equal(t, "no-controller:controller-impl-test/typeUnknown", err.Error())
+
+	smallArgs := <-smallActual
+	largeArgs := <-largeActual
+
+	require.EqualValues(t, controller.Manage, smallArgs[0].(controller.Operation))
+	require.Equal(t, smallSpec, smallArgs[1])
+	require.Equal(t, smallObject, a1)
+	require.Equal(t, smallPlan, p1)
+
+	require.EqualValues(t, controller.Destroy, largeArgs[0].(controller.Operation))
+	require.Equal(t, largeSpec, largeArgs[1])
+	require.Equal(t, largeObject, a2)
+	require.Equal(t, largePlan, p2)
+
+	// now return error
+	small.DoPlan = func(operation controller.Operation, spec types.Spec) (types.Object, controller.Plan, error) {
+		return largeObject, largePlan, fmt.Errorf("boom")
+	}
+
+	_, _, err = must(NewClient(plugin.Name(name+"/small"), socketPath)).Plan(controller.Manage, smallSpec)
+	require.Error(t, err)
+
+	server.Stop()
+
+}
+
+func TestMultiControllerCommit(t *testing.T) {
+	socketPath := tempSocket()
+	name := filepath.Base(socketPath)
+
+	smallSpec := types.Spec{Metadata: types.Metadata{Name: "small"}}
+	smallObject := types.Object{Spec: smallSpec}
+
+	largeSpec := types.Spec{Metadata: types.Metadata{Name: "large"}}
+	largeObject := types.Object{Spec: largeSpec}
+
+	smallActual := make(chan []interface{}, 1)
+	largeActual := make(chan []interface{}, 1)
+
+	small := &testing_controller.Controller{
+		DoCommit: func(operation controller.Operation, spec types.Spec) (types.Object, error) {
+
+			smallActual <- []interface{}{operation, spec}
+
+			return smallObject, nil
+		},
+	}
+	large := &testing_controller.Controller{
+		DoCommit: func(operation controller.Operation, spec types.Spec) (types.Object, error) {
+
+			largeActual <- []interface{}{operation, spec}
+
+			return largeObject, nil
+		},
+	}
+	server, err := rpc_server.StartPluginAtPath(socketPath, ServerWithTypes(
+		func() (map[string]controller.Controller, error) {
+			return map[string]controller.Controller{
+				"small": small,
+				"large": large,
+			}, nil
+		},
+	))
+	require.NoError(t, err)
+
+	a1, err := must(NewClient(plugin.Name(name+"/small"), socketPath)).Commit(controller.Manage, smallSpec)
+	require.NoError(t, err)
+
+	a2, err := must(NewClient(plugin.Name(name+"/large"), socketPath)).Commit(controller.Destroy, largeSpec)
+	require.NoError(t, err)
+
+	_, err = must(NewClient(plugin.Name(name+"/typeUnknown"), socketPath)).Commit(controller.Manage, largeSpec)
+	require.Error(t, err)
+	require.Equal(t, "no-controller:controller-impl-test/typeUnknown", err.Error())
+
+	smallArgs := <-smallActual
+	largeArgs := <-largeActual
+
+	require.EqualValues(t, controller.Manage, smallArgs[0].(controller.Operation))
+	require.Equal(t, smallSpec, smallArgs[1])
+	require.Equal(t, smallObject, a1)
+
+	require.EqualValues(t, controller.Destroy, largeArgs[0].(controller.Operation))
+	require.Equal(t, largeSpec, largeArgs[1])
+	require.Equal(t, largeObject, a2)
+
+	// now return error
+	small.DoCommit = func(operation controller.Operation, spec types.Spec) (types.Object, error) {
+		return largeObject, fmt.Errorf("boom")
+	}
+
+	_, err = must(NewClient(plugin.Name(name+"/small"), socketPath)).Commit(controller.Manage, smallSpec)
+	require.Error(t, err)
+
+	server.Stop()
+
+}
+
+func TestMultiControllerDescribe(t *testing.T) {
+	socketPath := tempSocket()
+	name := filepath.Base(socketPath)
+
+	smallSpec := types.Spec{Metadata: types.Metadata{Name: "small"}}
+	smallObject := types.Object{Spec: smallSpec}
+
+	largeSpec := types.Spec{Metadata: types.Metadata{Name: "large"}}
+	largeObject := types.Object{Spec: largeSpec}
+
+	smallActual := make(chan []interface{}, 1)
+	largeActual := make(chan []interface{}, 1)
+
+	small := &testing_controller.Controller{
+		DoDescribe: func(search *types.Metadata) ([]types.Object, error) {
+
+			smallActual <- []interface{}{*search}
+
+			return []types.Object{smallObject}, nil
+		},
+	}
+	large := &testing_controller.Controller{
+		DoDescribe: func(search *types.Metadata) ([]types.Object, error) {
+
+			largeActual <- []interface{}{*search}
+
+			return []types.Object{largeObject}, nil
+		},
+	}
+	server, err := rpc_server.StartPluginAtPath(socketPath, ServerWithTypes(
+		func() (map[string]controller.Controller, error) {
+			return map[string]controller.Controller{
+				"small": small,
+				"large": large,
+			}, nil
+		},
+	))
+	require.NoError(t, err)
+
+	smallSearch := (types.Metadata{Name: "small"}).AddTagsFromStringSlice([]string{"a=b", "c=d"})
+	largeSearch := types.Metadata{Name: "large"}
+
+	a1, err := must(NewClient(plugin.Name(name+"/small"), socketPath)).Describe(&smallSearch)
+	require.NoError(t, err)
+
+	a2, err := must(NewClient(plugin.Name(name+"/large"), socketPath)).Describe(&largeSearch)
+	require.NoError(t, err)
+
+	_, err = must(NewClient(plugin.Name(name+"/typeUnknown"), socketPath)).Describe(nil)
+	require.Error(t, err)
+	require.Equal(t, "no-controller:controller-impl-test/typeUnknown", err.Error())
+
+	smallArgs := <-smallActual
+	largeArgs := <-largeActual
+
+	require.EqualValues(t, smallSearch, smallArgs[0])
+	require.Equal(t, []types.Object{smallObject}, a1)
+
+	require.EqualValues(t, largeSearch, largeArgs[0])
+	require.Equal(t, []types.Object{largeObject}, a2)
+
+	// now return error
+	small.DoDescribe = func(search *types.Metadata) ([]types.Object, error) {
+		require.Nil(t, search)
+		return nil, fmt.Errorf("boom")
+	}
+	_, err = must(NewClient(plugin.Name(name+"/small"), socketPath)).Describe(nil)
+	require.Error(t, err)
+
+	server.Stop()
+
+}
+
+func TestMultiControllerFree(t *testing.T) {
+	socketPath := tempSocket()
+	name := filepath.Base(socketPath)
+
+	smallSpec := types.Spec{Metadata: types.Metadata{Name: "small"}}
+	smallObject := types.Object{Spec: smallSpec}
+
+	largeSpec := types.Spec{Metadata: types.Metadata{Name: "large"}}
+	largeObject := types.Object{Spec: largeSpec}
+
+	smallActual := make(chan []interface{}, 1)
+	largeActual := make(chan []interface{}, 1)
+
+	small := &testing_controller.Controller{
+		DoFree: func(search *types.Metadata) ([]types.Object, error) {
+
+			smallActual <- []interface{}{*search}
+
+			return []types.Object{smallObject}, nil
+		},
+	}
+	large := &testing_controller.Controller{
+		DoFree: func(search *types.Metadata) ([]types.Object, error) {
+
+			largeActual <- []interface{}{*search}
+
+			return []types.Object{largeObject}, nil
+		},
+	}
+	server, err := rpc_server.StartPluginAtPath(socketPath, ServerWithTypes(
+		func() (map[string]controller.Controller, error) {
+			return map[string]controller.Controller{
+				"small": small,
+				"large": large,
+			}, nil
+		},
+	))
+	require.NoError(t, err)
+
+	smallSearch := (types.Metadata{Name: "small"}).AddTagsFromStringSlice([]string{"a=b", "c=d"})
+	largeSearch := types.Metadata{Name: "large"}
+
+	a1, err := must(NewClient(plugin.Name(name+"/small"), socketPath)).Free(&smallSearch)
+	require.NoError(t, err)
+
+	a2, err := must(NewClient(plugin.Name(name+"/large"), socketPath)).Free(&largeSearch)
+	require.NoError(t, err)
+
+	_, err = must(NewClient(plugin.Name(name+"/typeUnknown"), socketPath)).Free(nil)
+	require.Error(t, err)
+	require.Equal(t, "no-controller:controller-impl-test/typeUnknown", err.Error())
+
+	smallArgs := <-smallActual
+	largeArgs := <-largeActual
+
+	require.EqualValues(t, smallSearch, smallArgs[0])
+	require.Equal(t, []types.Object{smallObject}, a1)
+
+	require.EqualValues(t, largeSearch, largeArgs[0])
+	require.Equal(t, []types.Object{largeObject}, a2)
+
+	// now return error
+	small.DoFree = func(search *types.Metadata) ([]types.Object, error) {
+		require.Nil(t, search)
+		return nil, fmt.Errorf("boom")
+	}
+	_, err = must(NewClient(plugin.Name(name+"/small"), socketPath)).Free(nil)
+	require.Error(t, err)
+
+	server.Stop()
+
+}

--- a/pkg/rpc/controller/rpc_test.go
+++ b/pkg/rpc/controller/rpc_test.go
@@ -1,0 +1,190 @@
+package controller
+
+import (
+	"fmt"
+	"path/filepath"
+	"reflect"
+	"testing"
+
+	"github.com/docker/infrakit/pkg/controller"
+	"github.com/docker/infrakit/pkg/plugin"
+	rpc_server "github.com/docker/infrakit/pkg/rpc/server"
+	testing_controller "github.com/docker/infrakit/pkg/testing/controller"
+	"github.com/docker/infrakit/pkg/types"
+	"github.com/stretchr/testify/require"
+)
+
+func TestControllerPlan(t *testing.T) {
+	socketPath := tempSocket()
+	name := filepath.Base(socketPath)
+
+	smallSpec := types.Spec{Metadata: types.Metadata{Name: "small"}}
+	largeSpec := types.Spec{Metadata: types.Metadata{Name: "large"}}
+	smallObject := types.Object{Spec: smallSpec}
+	smallPlan := controller.Plan{Message: []string{"increase size"}}
+
+	smallActual := make(chan []interface{}, 1)
+
+	small := &testing_controller.Controller{
+		DoPlan: func(operation controller.Operation, spec types.Spec) (types.Object, controller.Plan, error) {
+			if reflect.DeepEqual(spec, largeSpec) {
+				return smallObject, smallPlan, fmt.Errorf("bad")
+			}
+
+			smallActual <- []interface{}{operation, spec}
+
+			return smallObject, smallPlan, nil
+		},
+	}
+	server, err := rpc_server.StartPluginAtPath(socketPath, Server(small))
+	require.NoError(t, err)
+
+	a1, p1, err := must(NewClient(plugin.Name(name), socketPath)).Plan(controller.Manage, smallSpec)
+	require.NoError(t, err)
+
+	_, _, err = must(NewClient(plugin.Name("unknown"), socketPath)).Plan(controller.Manage, smallSpec)
+	require.Error(t, err)
+
+	smallArgs := <-smallActual
+
+	require.EqualValues(t, controller.Manage, smallArgs[0].(controller.Operation))
+	require.Equal(t, smallSpec, smallArgs[1])
+	require.Equal(t, smallObject, a1)
+	require.Equal(t, smallPlan, p1)
+
+	// now return error
+	_, _, err = must(NewClient(plugin.Name(name), socketPath)).Plan(controller.Manage, largeSpec)
+	require.Error(t, err)
+
+	server.Stop()
+
+}
+
+func TestControllerCommit(t *testing.T) {
+	socketPath := tempSocket()
+	name := filepath.Base(socketPath)
+
+	smallSpec := types.Spec{Metadata: types.Metadata{Name: "small"}}
+	largeSpec := types.Spec{Metadata: types.Metadata{Name: "large"}}
+	smallObject := types.Object{Spec: smallSpec}
+
+	smallActual := make(chan []interface{}, 1)
+
+	small := &testing_controller.Controller{
+		DoCommit: func(operation controller.Operation, spec types.Spec) (types.Object, error) {
+			if reflect.DeepEqual(spec, largeSpec) {
+				return smallObject, fmt.Errorf("bad")
+			}
+
+			smallActual <- []interface{}{operation, spec}
+
+			return smallObject, nil
+		},
+	}
+	server, err := rpc_server.StartPluginAtPath(socketPath, Server(small))
+	require.NoError(t, err)
+
+	a1, err := must(NewClient(plugin.Name(name), socketPath)).Commit(controller.Manage, smallSpec)
+	require.NoError(t, err)
+
+	_, err = must(NewClient(plugin.Name("unknown"), socketPath)).Commit(controller.Manage, smallSpec)
+	require.Error(t, err)
+
+	smallArgs := <-smallActual
+
+	require.EqualValues(t, controller.Manage, smallArgs[0].(controller.Operation))
+	require.Equal(t, smallSpec, smallArgs[1])
+	require.Equal(t, smallObject, a1)
+
+	_, err = must(NewClient(plugin.Name(name), socketPath)).Commit(controller.Manage, largeSpec)
+	require.Error(t, err)
+	server.Stop()
+
+}
+
+func TestControllerDescribe(t *testing.T) {
+	socketPath := tempSocket()
+	name := filepath.Base(socketPath)
+
+	smallSpec := types.Spec{Metadata: types.Metadata{Name: "small"}}
+	smallObject := types.Object{Spec: smallSpec}
+
+	smallActual := make(chan []interface{}, 1)
+
+	small := &testing_controller.Controller{
+		DoDescribe: func(search *types.Metadata) ([]types.Object, error) {
+			if search == nil {
+				return nil, fmt.Errorf("boom")
+			}
+
+			smallActual <- []interface{}{*search}
+
+			return []types.Object{smallObject}, nil
+		},
+	}
+	server, err := rpc_server.StartPluginAtPath(socketPath, Server(small))
+	require.NoError(t, err)
+
+	smallSearch := (types.Metadata{Name: "small"}).AddTagsFromStringSlice([]string{"a=b", "c=d"})
+
+	a1, err := must(NewClient(plugin.Name(name), socketPath)).Describe(&smallSearch)
+	require.NoError(t, err)
+
+	_, err = must(NewClient(plugin.Name("unknown"), socketPath)).Describe(&smallSearch)
+	require.Error(t, err)
+
+	smallArgs := <-smallActual
+
+	require.EqualValues(t, smallSearch, smallArgs[0])
+	require.Equal(t, []types.Object{smallObject}, a1)
+
+	// now return error
+	_, err = must(NewClient(plugin.Name(name), socketPath)).Describe(nil)
+	require.Error(t, err)
+
+	server.Stop()
+
+}
+
+func TestControllerFree(t *testing.T) {
+	socketPath := tempSocket()
+	name := filepath.Base(socketPath)
+
+	smallSpec := types.Spec{Metadata: types.Metadata{Name: "small"}}
+	smallObject := types.Object{Spec: smallSpec}
+
+	smallActual := make(chan []interface{}, 1)
+
+	small := &testing_controller.Controller{
+		DoFree: func(search *types.Metadata) ([]types.Object, error) {
+			if search == nil {
+				return nil, fmt.Errorf("boom")
+			}
+			smallActual <- []interface{}{*search}
+
+			return []types.Object{smallObject}, nil
+		},
+	}
+	server, err := rpc_server.StartPluginAtPath(socketPath, Server(small))
+	require.NoError(t, err)
+
+	smallSearch := (types.Metadata{Name: "small"}).AddTagsFromStringSlice([]string{"a=b", "c=d"})
+
+	a1, err := must(NewClient(plugin.Name(name), socketPath)).Free(&smallSearch)
+	require.NoError(t, err)
+
+	_, err = must(NewClient(plugin.Name("unknown"), socketPath)).Free(&smallSearch)
+	require.Error(t, err)
+
+	smallArgs := <-smallActual
+
+	require.EqualValues(t, smallSearch, smallArgs[0])
+	require.Equal(t, []types.Object{smallObject}, a1)
+
+	// now return error
+	_, err = must(NewClient(plugin.Name(name), socketPath)).Free(nil)
+	require.Error(t, err)
+
+	server.Stop()
+
+}

--- a/pkg/rpc/controller/service.go
+++ b/pkg/rpc/controller/service.go
@@ -39,7 +39,6 @@ func (c *Controller) ImplementedInterface() spi.InterfaceSpec {
 // Types returns the types exposed by this kind of RPC service
 func (c *Controller) Types() []string {
 	m, err := c.subcontrollers()
-	log.Warn(">>>>>>>>> TYPES", "m", m, "err", err)
 	if err != nil {
 		return nil
 	}

--- a/pkg/rpc/controller/service.go
+++ b/pkg/rpc/controller/service.go
@@ -1,0 +1,124 @@
+package controller
+
+import (
+	"fmt"
+	"net/http"
+
+	"github.com/docker/infrakit/pkg/controller"
+	logutil "github.com/docker/infrakit/pkg/log"
+	"github.com/docker/infrakit/pkg/plugin"
+	"github.com/docker/infrakit/pkg/spi"
+)
+
+var log = logutil.New("module", "rpc/controller")
+
+// ServerWithTypes returns a Controller map
+func ServerWithTypes(subcontrollers func() (map[string]controller.Controller, error)) *Controller {
+	return &Controller{subcontrollers: subcontrollers}
+}
+
+// Server returns a Controller that conforms to the net/rpc rpc call convention.
+func Server(c controller.Controller) *Controller {
+	return ServerWithTypes(func() (map[string]controller.Controller, error) {
+		return map[string]controller.Controller{
+			".": c,
+		}, nil
+	})
+}
+
+// Controller is the exported type for json-rpc
+type Controller struct {
+	subcontrollers func() (map[string]controller.Controller, error)
+}
+
+// ImplementedInterface returns the interface implemented by this RPC service.
+func (c *Controller) ImplementedInterface() spi.InterfaceSpec {
+	return controller.InterfaceSpec
+}
+
+// Types returns the types exposed by this kind of RPC service
+func (c *Controller) Types() []string {
+	m, err := c.subcontrollers()
+	log.Warn(">>>>>>>>> TYPES", "m", m, "err", err)
+	if err != nil {
+		return nil
+	}
+	types := []string{}
+	for k := range m {
+		types = append(types, k)
+	}
+	return types
+}
+
+func (c *Controller) subController(name plugin.Name) (controller.Controller, error) {
+	m, err := c.subcontrollers()
+	if err != nil {
+		return nil, err
+	}
+	_, subtype := name.GetLookupAndType()
+	key := subtype
+	if subtype == "." || subtype == "" {
+		key = "."
+	}
+	if p, has := m[key]; has {
+		return p, nil
+	}
+	return nil, fmt.Errorf("no-controller:%v", name)
+}
+
+// Plan is the rpc method for Plan
+func (c *Controller) Plan(_ *http.Request, req *ChangeRequest, resp *ChangeResponse) error {
+	resp.Name = req.Name
+	subcontroller, err := c.subController(req.Name)
+	if err != nil {
+		return err
+	}
+	object, plan, err := subcontroller.Plan(req.Operation, req.Spec)
+	if err == nil {
+		resp.Object = object
+		resp.Plan = plan
+	}
+	return err
+}
+
+// Commit is the rpc method for Commit
+func (c *Controller) Commit(_ *http.Request, req *ChangeRequest, resp *ChangeResponse) error {
+	resp.Name = req.Name
+	subcontroller, err := c.subController(req.Name)
+	if err != nil {
+		return err
+	}
+	object, err := subcontroller.Commit(req.Operation, req.Spec)
+	if err == nil {
+		resp.Object = object
+	}
+	return err
+}
+
+// Describe is the rpc method for Describe
+func (c *Controller) Describe(_ *http.Request, req *FindRequest, resp *FindResponse) error {
+	resp.Name = req.Name
+	subcontroller, err := c.subController(req.Name)
+	if err != nil {
+		return err
+	}
+	objects, err := subcontroller.Describe(req.Metadata)
+	if err == nil {
+		resp.Objects = objects
+	}
+	return err
+}
+
+// Free is the rpc method for Free
+func (c *Controller) Free(_ *http.Request, req *FindRequest, resp *FindResponse) error {
+	resp.Name = req.Name
+	subcontroller, err := c.subController(req.Name)
+	if err != nil {
+		return err
+	}
+	objects, err := subcontroller.Free(req.Metadata)
+	if err == nil {
+		resp.Objects = objects
+	}
+	return err
+}

--- a/pkg/rpc/controller/types.go
+++ b/pkg/rpc/controller/types.go
@@ -1,0 +1,33 @@
+package controller
+
+import (
+	"github.com/docker/infrakit/pkg/controller"
+	"github.com/docker/infrakit/pkg/plugin"
+	"github.com/docker/infrakit/pkg/types"
+)
+
+// ChangeRequest is the common request message for Plan and Commit
+type ChangeRequest struct {
+	Name      plugin.Name
+	Operation controller.Operation
+	Spec      types.Spec
+}
+
+// ChangeResponse is the common response message for Plan and Commit
+type ChangeResponse struct {
+	Name   plugin.Name
+	Object types.Object
+	Plan   controller.Plan
+}
+
+// FindRequest is the common request message for Describe and Free
+type FindRequest struct {
+	Name     plugin.Name
+	Metadata *types.Metadata
+}
+
+// FindResponse is the common response message for Describe and Free
+type FindResponse struct {
+	Name    plugin.Name
+	Objects []types.Object
+}

--- a/pkg/rpc/group/client.go
+++ b/pkg/rpc/group/client.go
@@ -3,6 +3,7 @@ package group
 import (
 	rpc_client "github.com/docker/infrakit/pkg/rpc/client"
 	"github.com/docker/infrakit/pkg/spi/group"
+	"github.com/docker/infrakit/pkg/spi/instance"
 )
 
 // NewClient returns a plugin interface implementation connected to a remote plugin
@@ -42,7 +43,7 @@ func (c client) FreeGroup(id group.ID) error {
 	if err != nil {
 		return err
 	}
-	resp.OK = true
+	resp.ID = id
 	return nil
 }
 
@@ -60,7 +61,7 @@ func (c client) DestroyGroup(id group.ID) error {
 	if err != nil {
 		return err
 	}
-	resp.OK = true
+	resp.ID = id
 	return nil
 }
 
@@ -69,4 +70,33 @@ func (c client) InspectGroups() ([]group.Spec, error) {
 	resp := InspectGroupsResponse{}
 	err := c.client.Call("Group.InspectGroups", req, &resp)
 	return resp.Groups, err
+}
+
+func (c client) DestroyInstances(id group.ID, instances []instance.ID) error {
+	req := DestroyInstancesRequest{
+		ID:        id,
+		Instances: instances,
+	}
+	resp := DestroyInstancesResponse{}
+	return c.client.Call("Group.DestroyInstances", req, &resp)
+}
+
+func (c client) Size(id group.ID) (int, error) {
+	req := SizeRequest{
+		ID: id,
+	}
+	resp := SizeResponse{}
+	err := c.client.Call("Group.Size", req, &resp)
+	return resp.Size, err
+}
+
+func (c client) SetSize(id group.ID, size int) error {
+	req := SetSizeRequest{
+		ID:   id,
+		Size: size,
+	}
+	resp := SetSizeResponse{
+		ID: id,
+	}
+	return c.client.Call("Group.SetSize", req, &resp)
 }

--- a/pkg/rpc/group/service.go
+++ b/pkg/rpc/group/service.go
@@ -52,6 +52,7 @@ func (p *Group) CommitGroup(_ *http.Request, req *CommitGroupRequest, resp *Comm
 		return err
 	}
 	resp.Details = details
+	resp.ID = req.Spec.ID
 	return nil
 }
 
@@ -61,7 +62,7 @@ func (p *Group) FreeGroup(_ *http.Request, req *FreeGroupRequest, resp *FreeGrou
 	if err != nil {
 		return err
 	}
-	resp.OK = true
+	resp.ID = req.ID
 	return nil
 }
 
@@ -71,6 +72,7 @@ func (p *Group) DescribeGroup(_ *http.Request, req *DescribeGroupRequest, resp *
 	if err != nil {
 		return err
 	}
+	resp.ID = req.ID
 	resp.Description = desc
 	return nil
 }
@@ -81,7 +83,7 @@ func (p *Group) DestroyGroup(_ *http.Request, req *DestroyGroupRequest, resp *De
 	if err != nil {
 		return err
 	}
-	resp.OK = true
+	resp.ID = req.ID
 	return nil
 }
 
@@ -92,5 +94,36 @@ func (p *Group) InspectGroups(_ *http.Request, req *InspectGroupsRequest, resp *
 		return err
 	}
 	resp.Groups = groups
+	return nil
+}
+
+// DestroyInstances is the rpc method to destroy specific instances
+func (p *Group) DestroyInstances(_ *http.Request, req *DestroyInstancesRequest, resp *DestroyInstancesResponse) error {
+	err := p.plugin.DestroyInstances(req.ID, req.Instances)
+	if err != nil {
+		return err
+	}
+	resp.ID = req.ID
+	return nil
+}
+
+// Size is the rpc method to get the group target size
+func (p *Group) Size(_ *http.Request, req *SizeRequest, resp *SizeResponse) error {
+	size, err := p.plugin.Size(req.ID)
+	if err != nil {
+		return err
+	}
+	resp.ID = req.ID
+	resp.Size = size
+	return nil
+}
+
+// SetSize is the rpc method to set the group target size
+func (p *Group) SetSize(_ *http.Request, req *SetSizeRequest, resp *SetSizeResponse) error {
+	err := p.plugin.SetSize(req.ID, req.Size)
+	if err != nil {
+		return err
+	}
+	resp.ID = req.ID
 	return nil
 }

--- a/pkg/rpc/group/types.go
+++ b/pkg/rpc/group/types.go
@@ -2,6 +2,7 @@ package group
 
 import (
 	"github.com/docker/infrakit/pkg/spi/group"
+	"github.com/docker/infrakit/pkg/spi/instance"
 )
 
 // CommitGroupRequest is the rpc wrapper for input to commit a group
@@ -12,6 +13,7 @@ type CommitGroupRequest struct {
 
 // CommitGroupResponse is the rpc wrapper for the results to commit a group
 type CommitGroupResponse struct {
+	ID      group.ID
 	Details string
 }
 
@@ -22,7 +24,7 @@ type FreeGroupRequest struct {
 
 // FreeGroupResponse is the rpc wrapper for the results to free a group
 type FreeGroupResponse struct {
-	OK bool
+	ID group.ID
 }
 
 // DescribeGroupRequest is the rpc wrapper for the input to inspect a group
@@ -32,6 +34,7 @@ type DescribeGroupRequest struct {
 
 // DescribeGroupResponse is the rpc wrapper for the results from inspecting a group
 type DescribeGroupResponse struct {
+	ID          group.ID
 	Description group.Description
 }
 
@@ -42,14 +45,49 @@ type DestroyGroupRequest struct {
 
 // DestroyGroupResponse is the rpc wrapper for the output from destroying a group
 type DestroyGroupResponse struct {
-	OK bool
+	ID group.ID
 }
 
 // InspectGroupsRequest is the rpc wrapper for the input to inspect groups
 type InspectGroupsRequest struct {
+	ID group.ID
 }
 
 // InspectGroupsResponse is the rpc wrapper for the output from inspecting groups
 type InspectGroupsResponse struct {
+	ID     group.ID
 	Groups []group.Spec
+}
+
+// DestroyInstancesRequest is the rpc wrapper for the input to destroy instances
+type DestroyInstancesRequest struct {
+	ID        group.ID
+	Instances []instance.ID
+}
+
+// DestroyInstancesResponse is the rpc wrapper for the output from destroy instances
+type DestroyInstancesResponse struct {
+	ID group.ID
+}
+
+// SizeRequest is the rpc wrapper for the getting size
+type SizeRequest struct {
+	ID group.ID
+}
+
+// SizeResponse is the rpc wrapper for the output of sizefrom destroy instances
+type SizeResponse struct {
+	ID   group.ID
+	Size int
+}
+
+// SetSizeRequest is the rpc wrapper for the getting size
+type SetSizeRequest struct {
+	ID   group.ID
+	Size int
+}
+
+// SetSizeResponse is the rpc wrapper for the output of sizefrom destroy instances
+type SetSizeResponse struct {
+	ID group.ID
 }

--- a/pkg/rpc/handshake.go
+++ b/pkg/rpc/handshake.go
@@ -28,7 +28,7 @@ type TypesResponse struct {
 }
 
 // Handshake is a simple RPC object for doing handshake
-type Handshake map[spi.InterfaceSpec][]string
+type Handshake map[spi.InterfaceSpec]func() []string
 
 // Implements responds to a request for the supported plugin interfaces.
 func (h Handshake) Implements(_ *http.Request, req *ImplementsRequest, resp *ImplementsResponse) error {
@@ -44,7 +44,7 @@ func (h Handshake) Implements(_ *http.Request, req *ImplementsRequest, resp *Imp
 func (h Handshake) Types(_ *http.Request, req *TypesRequest, resp *TypesResponse) error {
 	m := map[InterfaceSpec][]string{}
 	for k, v := range h {
-		m[InterfaceSpec(k.Encode())] = v
+		m[InterfaceSpec(k.Encode())] = v()
 	}
 	resp.Types = m
 	return nil

--- a/pkg/rpc/loadbalancer/service.go
+++ b/pkg/rpc/loadbalancer/service.go
@@ -15,6 +15,13 @@ func PluginServer(l4 loadbalancer.L4) *L4 {
 // L4 is the exported type for json-rpc
 type L4 struct {
 	l4 loadbalancer.L4
+	tn string
+}
+
+// WithType adds a qualifier to the name
+func (l4 *L4) WithType(t string) *L4 {
+	l4.tn = t
+	return l4
 }
 
 // ImplementedInterface returns the interface implemented by this RPC service.
@@ -24,6 +31,9 @@ func (l4 *L4) ImplementedInterface() spi.InterfaceSpec {
 
 // Types returns the types exposed by this kind of RPC service
 func (l4 *L4) Types() []string {
+	if l4.tn != "" {
+		return []string{l4.tn}
+	}
 	return []string{"."} // no types
 }
 

--- a/pkg/rpc/server/server.go
+++ b/pkg/rpc/server/server.go
@@ -102,10 +102,10 @@ func startAtPath(listen []string, discoverPath string,
 
 	targets := append([]VersionedInterface{receiver}, more...)
 
-	interfaces := map[spi.InterfaceSpec][]string{}
+	interfaces := map[spi.InterfaceSpec]func() []string{}
 	for _, t := range targets {
 
-		interfaces[t.ImplementedInterface()] = t.Types()
+		interfaces[t.ImplementedInterface()] = t.Types
 
 		if err := server.RegisterService(t, ""); err != nil {
 			return nil, err

--- a/pkg/run/manager/manager.go
+++ b/pkg/run/manager/manager.go
@@ -212,7 +212,7 @@ func (m *Manager) WaitForAllShutdown() {
 			targets = append(targets, lookup)
 
 		case <-checkNow:
-			log.Debug("Checking on targets", "targets", targets, "V", logutil.V(100))
+			log.Debug("Checking on targets", "targets", targets, "V", logutil.V(400))
 			if m, err := m.plugins().List(); err == nil {
 				if countMatches(targets, m) == 0 {
 					log.Info("Scan found plugins not running now", "plugins", targets)
@@ -228,7 +228,7 @@ func countMatches(list []string, found map[string]*plugin.Endpoint) int {
 	c := 0
 	for _, l := range list {
 		if _, has := found[l]; has {
-			log.Debug("Scan found", "lookup", l, "V", logutil.V(100))
+			log.Debug("Scan found", "lookup", l, "V", logutil.V(400))
 			c++
 		}
 	}

--- a/pkg/run/v0/manager/manager.go
+++ b/pkg/run/v0/manager/manager.go
@@ -200,6 +200,7 @@ func Run(plugins func() discovery.Plugins, name plugin.Name,
 
 	impls = map[run.PluginCode]interface{}{
 		run.Manager:           mgr,
+		run.Controller:        mgr.GroupControllers,
 		run.Group:             mgr,
 		run.MetadataUpdatable: metadataUpdatable,
 		run.Metadata:          metadataUpdatable,

--- a/pkg/run/v0/simulator/instance.go
+++ b/pkg/run/v0/simulator/instance.go
@@ -1,0 +1,111 @@
+package simulator
+
+import (
+	"fmt"
+	"sync"
+
+	logutil "github.com/docker/infrakit/pkg/log"
+	"github.com/docker/infrakit/pkg/spi/instance"
+	"github.com/docker/infrakit/pkg/types"
+)
+
+var instanceLogger = logutil.New("module", "simulator/instance")
+
+type instanceSimulator struct {
+	name      string
+	instances map[instance.ID]instance.Description
+	lock      sync.Mutex
+}
+
+func (s *instanceSimulator) alloc() *instanceSimulator {
+	s.instances = map[instance.ID]instance.Description{}
+	return s
+}
+
+// Validate performs local validation on a provision request.
+func (s *instanceSimulator) Validate(req *types.Any) error {
+	return nil
+}
+
+// Provision creates a new instance based on the spec.
+func (s *instanceSimulator) Provision(spec instance.Spec) (*instance.ID, error) {
+	instanceLogger.Info("Provision", "name", s.name, "spec", spec)
+	s.lock.Lock()
+	defer s.lock.Unlock()
+	description := instance.Description{
+		ID:         instance.ID(fmt.Sprintf("i-%d", len(s.instances))),
+		Tags:       spec.Tags,
+		LogicalID:  spec.LogicalID,
+		Properties: types.AnyValueMust(spec),
+	}
+	s.instances[description.ID] = description
+	return &description.ID, nil
+}
+
+// Label labels the instance
+func (s *instanceSimulator) Label(instance instance.ID, labels map[string]string) error {
+	instanceLogger.Info("Label", "name", s.name, "instance", instance, "labels", labels)
+	s.lock.Lock()
+	defer s.lock.Unlock()
+
+	n, has := s.instances[instance]
+	if !has {
+		return fmt.Errorf("not found %v", instance)
+	}
+
+	if n.Tags == nil {
+		n.Tags = map[string]string{}
+	}
+
+	for k, v := range labels {
+		n.Tags[k] = v
+	}
+	return nil
+}
+
+// Destroy terminates an existing instance.
+func (s *instanceSimulator) Destroy(instance instance.ID, context instance.Context) error {
+	instanceLogger.Info("Destroy", "name", s.name, "instance", instance, "context", context)
+	s.lock.Lock()
+	defer s.lock.Unlock()
+
+	_, has := s.instances[instance]
+	if !has {
+		return fmt.Errorf("not found %v", instance)
+	}
+
+	delete(s.instances, instance)
+	return nil
+}
+
+// DescribeInstances returns descriptions of all instances matching all of the provided tags.
+// The properties flag indicates the client is interested in receiving details about each instance.
+func (s *instanceSimulator) DescribeInstances(labels map[string]string,
+	properties bool) ([]instance.Description, error) {
+	instanceLogger.Info("DescribeInstances", "name", s.name, "labels", labels)
+	s.lock.Lock()
+	defer s.lock.Unlock()
+
+	matches := []instance.Description{}
+	for _, v := range s.instances {
+
+		if hasDifferentTag(labels, v.Tags) {
+			continue
+		}
+		matches = append(matches, v)
+	}
+	return matches, nil
+}
+
+func hasDifferentTag(expected, actual map[string]string) bool {
+	if len(actual) == 0 {
+		return true
+	}
+	for k, v := range expected {
+		if a, ok := actual[k]; ok && a != v {
+			return true
+		}
+	}
+
+	return false
+}

--- a/pkg/run/v0/simulator/l4.go
+++ b/pkg/run/v0/simulator/l4.go
@@ -1,0 +1,138 @@
+package simulator
+
+import (
+	"fmt"
+	"sync"
+	"time"
+
+	logutil "github.com/docker/infrakit/pkg/log"
+	"github.com/docker/infrakit/pkg/spi/instance"
+	"github.com/docker/infrakit/pkg/spi/loadbalancer"
+)
+
+var l4Logger = logutil.New("module", "simulator/l4")
+
+type l4Simulator struct {
+	name     string
+	routes   map[uint32]loadbalancer.Route
+	backends map[instance.ID]instance.ID
+	lock     sync.Mutex
+}
+
+func (l *l4Simulator) alloc() *l4Simulator {
+	l.routes = map[uint32]loadbalancer.Route{}
+	l.backends = map[instance.ID]instance.ID{}
+
+	return l
+}
+
+// Name is the name of the load balancer
+func (l *l4Simulator) Name() string {
+	l4Logger.Info("Name")
+	return l.name
+}
+
+// Routes lists all known routes.
+func (l *l4Simulator) Routes() ([]loadbalancer.Route, error) {
+	l4Logger.Info("Routes")
+	l.lock.Lock()
+	defer l.lock.Unlock()
+
+	out := []loadbalancer.Route{}
+	for _, v := range l.routes {
+		out = append(out, v)
+	}
+	return out, nil
+}
+
+type result string
+
+func (r result) String() string {
+	return string(r)
+}
+
+// Publish publishes a route in the LB by adding a load balancing rule
+func (l *l4Simulator) Publish(route loadbalancer.Route) (loadbalancer.Result, error) {
+	l4Logger.Info("Public", "name", l.name, "route", route)
+	l.lock.Lock()
+	defer l.lock.Unlock()
+	_, has := l.routes[route.LoadBalancerPort]
+	if has {
+		return result(""), fmt.Errorf("duplicate port %v", route.LoadBalancerPort)
+	}
+	l.routes[route.LoadBalancerPort] = route
+	return result("ok"), nil
+}
+
+// Unpublish dissociates the load balancer from the backend service at the given port.
+func (l *l4Simulator) Unpublish(extPort uint32) (loadbalancer.Result, error) {
+	l4Logger.Info("Unpublish", "name", l.name, "extPort", extPort)
+	l.lock.Lock()
+	defer l.lock.Unlock()
+	_, has := l.routes[extPort]
+	if !has {
+		return result(""), fmt.Errorf("unknown port %v", extPort)
+	}
+	delete(l.routes, extPort)
+	return result("ok"), nil
+}
+
+// ConfigureHealthCheck configures the health checks for instance removal and reconfiguration
+// The parameters healthy and unhealthy indicate the number of consecutive success or fail pings required to
+// mark a backend instance as healthy or unhealthy.   The ping occurs on the backendPort parameter and
+// at the interval specified.
+func (l *l4Simulator) ConfigureHealthCheck(backendPort uint32, healthy,
+	unhealthy int, interval, timeout time.Duration) (loadbalancer.Result, error) {
+	l4Logger.Info("ConfigureHealthCheck",
+		"name", l.name,
+		"backendPort", backendPort,
+		"healthy", healthy,
+		"unhealthy", unhealthy,
+		"interval", interval,
+		"timeout", timeout)
+
+	return result("ok"), nil
+}
+
+// RegisterBackend registers instances identified by the IDs to the LB's backend pool
+func (l *l4Simulator) RegisterBackends(ids []instance.ID) (loadbalancer.Result, error) {
+	l4Logger.Info("RegisterBackends", "name", l.name, "ids", ids)
+	l.lock.Lock()
+	defer l.lock.Unlock()
+
+	for _, id := range ids {
+		_, has := l.backends[id]
+		if !has {
+			l.backends[id] = id
+		}
+	}
+	return result("ok"), nil
+}
+
+// DeregisterBackend removes the specified instances from the backend pool
+func (l *l4Simulator) DeregisterBackends(ids []instance.ID) (loadbalancer.Result, error) {
+	l4Logger.Info("DeregisterBackends", "name", l.name, "ids", ids)
+	l.lock.Lock()
+	defer l.lock.Unlock()
+
+	for _, id := range ids {
+		_, has := l.backends[id]
+		if has {
+			delete(l.backends, id)
+		}
+	}
+	return result("ok"), nil
+}
+
+// Backends returns a list of backends
+func (l *l4Simulator) Backends() ([]instance.ID, error) {
+	l4Logger.Info("Backends", "name", l.name)
+	l.lock.Lock()
+	defer l.lock.Unlock()
+
+	out := []instance.ID{}
+	for k := range l.backends {
+		out = append(out, k)
+	}
+	return out, nil
+}

--- a/pkg/run/v0/simulator/l4.go
+++ b/pkg/run/v0/simulator/l4.go
@@ -75,7 +75,7 @@ func (l *l4Simulator) Publish(route loadbalancer.Route) (loadbalancer.Result, er
 	if err != nil {
 		return result(""), err
 	}
-	if !exists {
+	if exists {
 		return result(""), fmt.Errorf("duplicate port %v", route.LoadBalancerPort)
 	}
 	return result("publish"), l.routes.Write(route.LoadBalancerPort, route)

--- a/pkg/run/v0/simulator/simulator.go
+++ b/pkg/run/v0/simulator/simulator.go
@@ -61,7 +61,7 @@ func Run(plugins func() discovery.Plugins, name plugin.Name,
 		return
 	}
 
-	os.MkdirAll(options.Dir, 0644)
+	os.MkdirAll(options.Dir, 0755)
 
 	impls = map[run.PluginCode]interface{}{}
 

--- a/pkg/run/v0/simulator/simulator.go
+++ b/pkg/run/v0/simulator/simulator.go
@@ -1,0 +1,73 @@
+package simulator
+
+import (
+	"strings"
+
+	"github.com/docker/infrakit/pkg/discovery"
+	"github.com/docker/infrakit/pkg/launch/inproc"
+	logutil "github.com/docker/infrakit/pkg/log"
+	"github.com/docker/infrakit/pkg/plugin"
+	"github.com/docker/infrakit/pkg/run"
+	"github.com/docker/infrakit/pkg/spi/instance"
+	"github.com/docker/infrakit/pkg/types"
+)
+
+const (
+	// Kind is the canonical name of the plugin for starting up, etc.
+	Kind = "simulator"
+
+	// EnvInstanceNames is the env var to set for the instance spi type names (comma-delimited)
+	EnvInstanceNames = "INFRAKIT_SIMULATOR_INSTANCE_NAMES"
+
+	// EnvL4Name is the env var to set for the L4 name
+	EnvL4Name = "INFRAKIT_SIMULATOR_L4_NAME"
+)
+
+var (
+	log = logutil.New("module", "run/v0/simulator")
+)
+
+func init() {
+	inproc.Register(Kind, Run, DefaultOptions)
+}
+
+// Options capture the options for starting up the plugin.
+type Options struct {
+	InstanceTypes []string
+	L4HostName    string
+}
+
+// DefaultOptions return an Options with default values filled in.
+var DefaultOptions = Options{
+	InstanceTypes: strings.Split(run.GetEnv(EnvInstanceNames, "compute,net,disk"), ","),
+	L4HostName:    "test.com",
+}
+
+// Run runs the plugin, blocking the current thread.  Error is returned immediately
+// if the plugin cannot be started.
+func Run(plugins func() discovery.Plugins, name plugin.Name,
+	config *types.Any) (transport plugin.Transport, impls map[run.PluginCode]interface{}, onStop func(), err error) {
+
+	options := Options{}
+	err = config.Decode(&options)
+	if err != nil {
+		return
+	}
+
+	impls = map[run.PluginCode]interface{}{}
+
+	instanceMap := map[string]instance.Plugin{}
+	if len(options.InstanceTypes) > 0 {
+		impls[run.Instance] = instanceMap
+	}
+	for _, n := range options.InstanceTypes {
+		instanceMap[n] = (&instanceSimulator{name: n}).alloc()
+	}
+
+	if options.L4HostName != "" {
+		impls[run.L4] = (&l4Simulator{name: options.L4HostName}).alloc()
+	}
+
+	transport.Name = name
+	return
+}

--- a/pkg/spi/group/spi.go
+++ b/pkg/spi/group/spi.go
@@ -16,13 +16,25 @@ var InterfaceSpec = spi.InterfaceSpec{
 type Plugin interface {
 	CommitGroup(grp Spec, pretend bool) (string, error)
 
-	FreeGroup(id ID) error
+	FreeGroup(ID) error
 
-	DescribeGroup(id ID) (Description, error)
+	DescribeGroup(ID) (Description, error)
 
-	DestroyGroup(id ID) error
+	DestroyGroup(ID) error
 
 	InspectGroups() ([]Spec, error)
+
+	// DestroyInstances deletes instances from this group. Error is returned either on
+	// failure or if any instances don't belong to the group. This function
+	// should wait until group size is updated.
+	DestroyInstances(ID, []instance.ID) error
+
+	// Size returns the current size of the group.
+	Size(ID) (int, error)
+
+	// SetSize sets the size.
+	// This function should block until completion.
+	SetSize(ID, int) error
 }
 
 // ID is the unique identifier for a Group.

--- a/pkg/spi/plugin.go
+++ b/pkg/spi/plugin.go
@@ -1,33 +1,20 @@
 package spi
 
 import (
-	"fmt"
-	"strings"
-
 	"github.com/docker/infrakit/pkg/types"
 )
 
 // InterfaceSpec is metadata about an API.
-type InterfaceSpec struct {
-	// Name of the interface.
-	Name string
+type InterfaceSpec types.InterfaceSpec
 
-	// Version is the identifier for the API version.
-	Version string
+// DecodeInterfaceSpec takes a string and returns the struct
+func DecodeInterfaceSpec(s string) InterfaceSpec {
+	return InterfaceSpec(types.DecodeInterfaceSpec(s))
 }
 
 // Encode encodes a struct form to string
 func (i InterfaceSpec) Encode() string {
-	return fmt.Sprintf("%s/%s", i.Name, i.Version)
-}
-
-// DecodeInterfaceSpec takes a string and returns the struct
-func DecodeInterfaceSpec(s string) InterfaceSpec {
-	p := strings.SplitN(s, "/", 2)
-	return InterfaceSpec{
-		Name:    p[0],
-		Version: p[1],
-	}
+	return types.InterfaceSpec(i).Encode()
 }
 
 // VendorInfo provides vendor-specific information

--- a/pkg/store/file/dir.go
+++ b/pkg/store/file/dir.go
@@ -107,7 +107,11 @@ func (s *Store) Exists(key interface{}) (bool, error) {
 	fp := filepath.Join(s.Dir, id)
 	_, err := s.fs.Stat(fp)
 	log.Debug("Exists", "id", id, "path", fp, "err", err)
-	return !os.IsNotExist(err), err
+	v := os.IsNotExist(err)
+	if v {
+		return false, nil
+	}
+	return !v, err
 }
 
 // Delete deletes the object by id

--- a/pkg/store/file/dir.go
+++ b/pkg/store/file/dir.go
@@ -1,0 +1,189 @@
+package file
+
+import (
+	"fmt"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	logutil "github.com/docker/infrakit/pkg/log"
+	"github.com/docker/infrakit/pkg/types"
+	"github.com/spf13/afero"
+	"math/rand"
+)
+
+func init() {
+	rand.Seed(time.Now().UTC().UnixNano())
+}
+
+var log = logutil.New("module", "store/file")
+
+const logV = logutil.V(300)
+
+// Store is an abstraction for writing and reading from entries in a file directory.
+type Store struct {
+	t    string
+	Dir  string
+	yaml bool
+	fs   afero.Fs
+
+	// IDFunc is the function that generates the id.
+	IDFunc func(interface{}) string
+}
+
+// NewStore creates a store of object with a typeName in the given directory.  Instances of the
+// type will be stored as files in this directory and named accordingly.
+func NewStore(typeName string, dir string, yaml bool) *Store {
+	log.Debug("Store", "type", typeName, "dir", dir, "yaml", yaml, "V", logV)
+	return &Store{
+		t:    typeName,
+		Dir:  dir,
+		yaml: yaml,
+		fs:   afero.NewOsFs(),
+	}
+}
+
+// Init initializes the store using defaults.
+func (s *Store) Init() *Store {
+	if s.IDFunc == nil {
+		s.IDFunc = func(key interface{}) string {
+			return fmt.Sprintf("%s-%v", s.t, key)
+		}
+	}
+	return s
+}
+
+// Write writes the object and returns an id or error.
+func (s *Store) Write(key interface{}, object interface{}) error {
+	if key == nil {
+		key = rand.Int63()
+	}
+	id := s.IDFunc(key)
+
+	var buff []byte
+	var err error
+	if s.yaml {
+		buff, err = types.AnyValueMust(object).MarshalYAML()
+		if err != nil {
+			return err
+		}
+	} else {
+		buff, err = types.AnyValueMust(object).MarshalJSON()
+		if err != nil {
+			return err
+		}
+	}
+	log.Debug("Write", "id", id, "object", object, "err", err, "V", logV)
+	if err != nil {
+		return err
+	}
+	return afero.WriteFile(s.fs, filepath.Join(s.Dir, string(id)), buff, 0644)
+}
+
+// Key returns an id given the key. The id contains type, etc.
+func (s *Store) Key(key interface{}) string {
+	return s.IDFunc(key)
+}
+
+// Read checks for existence
+func (s *Store) Read(key interface{}, decode func([]byte) (interface{}, error)) (interface{}, error) {
+	id := s.Key(key)
+	fp := filepath.Join(s.Dir, id)
+	f, err := s.fs.Open(fp)
+	log.Debug("Read", "id", id, "path", fp, "err", err)
+
+	buff, err := ioutil.ReadAll(f)
+	if err != nil {
+		return nil, err
+	}
+	return decode(buff)
+}
+
+// Exists checks for existence
+func (s *Store) Exists(key interface{}) (bool, error) {
+	id := s.Key(key)
+	fp := filepath.Join(s.Dir, id)
+	_, err := s.fs.Stat(fp)
+	log.Debug("Exists", "id", id, "path", fp, "err", err)
+	return !os.IsNotExist(err), err
+}
+
+// Delete deletes the object by id
+func (s *Store) Delete(key interface{}) error {
+	id := s.Key(key)
+	fp := filepath.Join(s.Dir, id)
+	log.Debug("Delete", "key", key, "file", fp, "V", logV)
+	return s.fs.Remove(fp)
+}
+
+// All iterates through all qualifying objects. tags is the function that gets the tags inside the object
+func (s *Store) All(tags map[string]string,
+	getTags func(interface{}) map[string]string,
+	decode func([]byte) (interface{}, error),
+	visit func(interface{}) (bool, error)) error {
+
+	log.Debug("Visit", "tags", tags, "visit", visit, "V", logV)
+	entries, err := afero.ReadDir(s.fs, s.Dir)
+	if err != nil {
+		return err
+	}
+
+	for _, entry := range entries {
+
+		if entry.IsDir() {
+			continue
+		}
+
+		if strings.Index(entry.Name(), s.t) != 0 {
+			continue
+		}
+
+		fp := filepath.Join(s.Dir, entry.Name())
+		file, err := s.fs.Open(fp)
+		if err != nil {
+			log.Warn("error opening", "path", fp, "err", err)
+			return err
+		}
+
+		buff, err := ioutil.ReadAll(file)
+		if err != nil {
+			log.Warn("error reading", "path", fp, "err", err)
+			return err
+		}
+
+		object, err := decode(buff)
+		if err != nil {
+			log.Warn("error decoding", "path", fp, "err", err)
+			return err
+		}
+
+		if getTags != nil && len(tags) > 0 {
+			found := getTags(object)
+			if hasDifferentTags(tags, found) {
+				continue
+			}
+		}
+
+		if continued, err := visit(object); err != nil {
+			log.Warn("error", "path", fp, "err", err)
+			return err
+		} else if !continued {
+			return nil
+		}
+	}
+	return nil
+}
+
+func hasDifferentTags(expected, actual map[string]string) bool {
+	if len(actual) == 0 {
+		return true
+	}
+	for k, v := range expected {
+		if a, ok := actual[k]; ok && a != v {
+			return true
+		}
+	}
+	return false
+}

--- a/pkg/store/file/dir_test.go
+++ b/pkg/store/file/dir_test.go
@@ -18,7 +18,7 @@ func TestUsage(t *testing.T) {
 	store := NewStore(typeName, dir, true).Init()
 
 	exists, err := store.Exists("hello")
-	require.Error(t, err)
+	require.NoError(t, err)
 	require.False(t, exists)
 
 	err = store.Write("hello", "world")

--- a/pkg/store/file/dir_test.go
+++ b/pkg/store/file/dir_test.go
@@ -1,0 +1,53 @@
+package file
+
+import (
+	"fmt"
+	"math/rand"
+	"os"
+	"testing"
+
+	"github.com/docker/infrakit/pkg/types"
+	"github.com/stretchr/testify/require"
+)
+
+func TestUsage(t *testing.T) {
+
+	dir := os.TempDir()
+	typeName := fmt.Sprintf("dirtest-%v", rand.Int63())
+
+	store := NewStore(typeName, dir, true).Init()
+
+	exists, err := store.Exists("hello")
+	require.Error(t, err)
+	require.False(t, exists)
+
+	err = store.Write("hello", "world")
+	require.NoError(t, err)
+
+	exists, err = store.Exists("hello")
+	require.NoError(t, err)
+	require.True(t, exists)
+
+	read := []string{}
+	err = store.All(nil, nil,
+		func(buff []byte) (interface{}, error) {
+			v := ""
+			err := types.AnyYAMLMust(buff).Decode(&v)
+			return v, err
+		},
+		func(v interface{}) (bool, error) {
+			read = append(read, v.(string))
+			return true, nil
+		})
+
+	require.NoError(t, err)
+	require.EqualValues(t, []string{"world"}, read)
+
+	object, err := store.Read("hello", func(buff []byte) (interface{}, error) {
+		v := ""
+		err := types.AnyYAMLMust(buff).Decode(&v)
+		return v, err
+	})
+	require.NoError(t, err)
+	require.EqualValues(t, "world", object)
+}

--- a/pkg/testing/controller/controller.go
+++ b/pkg/testing/controller/controller.go
@@ -28,18 +28,22 @@ type Controller struct {
 	DoFree func(metadata *types.Metadata) ([]types.Object, error)
 }
 
+// Plan implements pkg/controller/Controller.Plan
 func (t *Controller) Plan(operation controller.Operation, spec types.Spec) (types.Object, controller.Plan, error) {
 	return t.DoPlan(operation, spec)
 }
 
+// Commit implements pkg/controller/Controller.Commit
 func (t *Controller) Commit(operation controller.Operation, spec types.Spec) (types.Object, error) {
 	return t.DoCommit(operation, spec)
 }
 
+// Describe implements pkg/controller/Controller.Describe
 func (t *Controller) Describe(metadata *types.Metadata) ([]types.Object, error) {
 	return t.DoDescribe(metadata)
 }
 
+// Free implements pkg/controller/Controller.Free
 func (t *Controller) Free(metadata *types.Metadata) ([]types.Object, error) {
 	return t.DoFree(metadata)
 

--- a/pkg/testing/controller/controller.go
+++ b/pkg/testing/controller/controller.go
@@ -1,0 +1,46 @@
+package controller
+
+import (
+	"github.com/docker/infrakit/pkg/controller"
+	"github.com/docker/infrakit/pkg/types"
+)
+
+// Controller implements the controller.Controller interface and supports
+// testing by letting user assemble behavior dyanmically.
+type Controller struct {
+	// Plan is a commit without actually making the changes.  The controller returns a proposed object state
+	// after commit, with a Plan, or error.
+	DoPlan func(operation controller.Operation, spec types.Spec) (types.Object, controller.Plan, error)
+
+	// Commit commits the spec to the controller for management.  The controller's job is to ensure reality
+	// matches the specification.  The spec can be composed and references other controllers or plugins.
+	// When a spec is committed to a controller, the controller returns the object state corresponding to
+	// the spec.  When operation is Destroy, only Metadata portion of the spec is needed to identify
+	// the object to be destroyed.
+	DoCommit func(operation controller.Operation, spec types.Spec) (types.Object, error)
+
+	// Describe returns a list of objects matching the metadata provided. A list of objects are possible because
+	// metadata can be a tags search.  An object has state, and its original spec can be accessed as well.
+	// A nil Metadata will instruct the controller to return all objects under management.
+	DoDescribe func(metadata *types.Metadata) ([]types.Object, error)
+
+	// Free tells the controller to pause management of objects matching.  To resume, commit again.
+	DoFree func(metadata *types.Metadata) ([]types.Object, error)
+}
+
+func (t *Controller) Plan(operation controller.Operation, spec types.Spec) (types.Object, controller.Plan, error) {
+	return t.DoPlan(operation, spec)
+}
+
+func (t *Controller) Commit(operation controller.Operation, spec types.Spec) (types.Object, error) {
+	return t.DoCommit(operation, spec)
+}
+
+func (t *Controller) Describe(metadata *types.Metadata) ([]types.Object, error) {
+	return t.DoDescribe(metadata)
+}
+
+func (t *Controller) Free(metadata *types.Metadata) ([]types.Object, error) {
+	return t.DoFree(metadata)
+
+}

--- a/pkg/testing/group/plugin.go
+++ b/pkg/testing/group/plugin.go
@@ -63,12 +63,12 @@ func (t *Plugin) DestroyInstances(id group.ID, instances []instance.ID) error {
 	return t.DoDestroyInstances(id, instances)
 }
 
-// DestroyInstances destroys instances
+// Size returns the target size
 func (t *Plugin) Size(id group.ID) (int, error) {
 	return t.DoSize(id)
 }
 
-// DestroyInstances destroys instances
+// SetSize sets the target size
 func (t *Plugin) SetSize(id group.ID, size int) error {
 	return t.DoSetSize(id, size)
 }

--- a/pkg/testing/group/plugin.go
+++ b/pkg/testing/group/plugin.go
@@ -2,6 +2,7 @@ package group
 
 import (
 	"github.com/docker/infrakit/pkg/spi/group"
+	"github.com/docker/infrakit/pkg/spi/instance"
 )
 
 // Plugin implements group.Plugin
@@ -21,6 +22,15 @@ type Plugin struct {
 
 	// DoInspectGroups implements InspectGroups
 	DoInspectGroups func() ([]group.Spec, error)
+
+	// DoDestroyInstances implements DestroyInstances
+	DoDestroyInstances func(id group.ID, instances []instance.ID) error
+
+	// DoSize implements Size
+	DoSize func(id group.ID) (int, error)
+
+	// DoSetSize implements SetSize
+	DoSetSize func(id group.ID, size int) error
 }
 
 // CommitGroup commits spec for a group
@@ -46,4 +56,19 @@ func (t *Plugin) DestroyGroup(id group.ID) error {
 // InspectGroups returns the specs of all groups known
 func (t *Plugin) InspectGroups() ([]group.Spec, error) {
 	return t.DoInspectGroups()
+}
+
+// DestroyInstances destroys instances
+func (t *Plugin) DestroyInstances(id group.ID, instances []instance.ID) error {
+	return t.DoDestroyInstances(id, instances)
+}
+
+// DestroyInstances destroys instances
+func (t *Plugin) Size(id group.ID) (int, error) {
+	return t.DoSize(id)
+}
+
+// DestroyInstances destroys instances
+func (t *Plugin) SetSize(id group.ID, size int) error {
+	return t.DoSetSize(id, size)
 }

--- a/pkg/types/interface_spec.go
+++ b/pkg/types/interface_spec.go
@@ -1,0 +1,29 @@
+package types
+
+import (
+	"fmt"
+	"strings"
+)
+
+// InterfaceSpec is metadata about an API.
+type InterfaceSpec struct {
+	// Name of the interface.
+	Name string
+
+	// Version is the identifier for the API version.
+	Version string
+}
+
+// Encode encodes a struct form to string
+func (i InterfaceSpec) Encode() string {
+	return fmt.Sprintf("%s/%s", i.Name, i.Version)
+}
+
+// DecodeInterfaceSpec takes a string and returns the struct
+func DecodeInterfaceSpec(s string) InterfaceSpec {
+	p := strings.SplitN(s, "/", 2)
+	return InterfaceSpec{
+		Name:    p[0],
+		Version: p[1],
+	}
+}

--- a/pkg/types/object.go
+++ b/pkg/types/object.go
@@ -20,7 +20,7 @@ func (o Object) Validate() error {
 	if o.Metadata.Identity == nil {
 		return errMissingAttribute("metadata.identity")
 	}
-	if o.Metadata.Identity.UID == "" {
+	if o.Metadata.Identity.ID == "" {
 		return errMissingAttribute("metadata.identity.uid")
 	}
 	return nil

--- a/pkg/types/object_test.go
+++ b/pkg/types/object_test.go
@@ -28,13 +28,13 @@ func TestObject(t *testing.T) {
     - kind: instance-aws/ec2-volume
       name: disk1
       bind:
-         volume/id : metadata/UID
+         volume/id : metadata/ID
          volume/size: properties/sizeGb
 
 - kind:        instance-aws/ec2-volume
   version:   instance/v0.1.0
   metadata:
-    uid: disk1-1234
+    id: disk1-1234
     name: disk1
     tags:
       role:    worker

--- a/pkg/types/object_test.go
+++ b/pkg/types/object_test.go
@@ -10,7 +10,7 @@ func TestObject(t *testing.T) {
 
 	text := `
 - kind:        instance-aws/ec2-instance
-  spiVersion:   instance/v0.1.0
+  version:   instance/v0.1.0
   metadata:
     name: host1
     tags:
@@ -32,7 +32,7 @@ func TestObject(t *testing.T) {
          volume/size: properties/sizeGb
 
 - kind:        instance-aws/ec2-volume
-  spiVersion:   instance/v0.1.0
+  version:   instance/v0.1.0
   metadata:
     uid: disk1-1234
     name: disk1

--- a/pkg/types/pointer_test.go
+++ b/pkg/types/pointer_test.go
@@ -39,7 +39,7 @@ func TestPointer(t *testing.T) {
 }`, any.String())
 
 	text := `class:        instance-aws/ec2-instance
-spiVersion:   instance/v0.1.0
+version:   instance/v0.1.0
 metadata:
   uid : u-12134
   name: host1

--- a/pkg/types/pointer_test.go
+++ b/pkg/types/pointer_test.go
@@ -38,10 +38,11 @@ func TestPointer(t *testing.T) {
 "pointerPtr": "github.com/docker/infrakit/pkg/testing"
 }`, any.String())
 
-	text := `class:        instance-aws/ec2-instance
+	text := `
+class:        instance-aws/ec2-instance
 version:   instance/v0.1.0
 metadata:
-  uid : u-12134
+  id : u-12134
   name: host1
   tags:
     role:    worker
@@ -58,7 +59,7 @@ depends:
     - class: instance-aws/ebs-volume
       name: /var/lib/docker
       bind:
-         volume/id : Spec/Metadata/Identity/UID
+         volume/id : Spec/Metadata/Identity/ID
 
 state:
     instanceType: c2xlarge
@@ -88,4 +89,6 @@ state:
 	require.NoError(t, err)
 
 	require.Equal(t, object1, object2)
+
+	require.Equal(t, "u-12134", object1.Metadata.Identity.ID)
 }

--- a/pkg/types/spec.go
+++ b/pkg/types/spec.go
@@ -66,21 +66,34 @@ type Dependency struct {
 // Identity uniquely identifies an instance
 type Identity struct {
 
-	// UID is a unique identifier for the object instance.
-	UID string `json:"uid"`
+	// ID is a unique identifier for the object instance.
+	ID string `json:"id" yaml:"id"`
 }
 
 // Metadata captures label and descriptive information about the object
 type Metadata struct {
 
 	// Identity is an optional component that exists only in the case of a real object instance.
-	*Identity `json:",omitempty" yaml:",omitempty"`
+	*Identity `json:",inline,omitempty" yaml:",inline,omitempty"`
 
 	// Name is a user-friendly name.  It may or may not be unique.
 	Name string `json:"name"`
 
 	// Tags are a collection of labels, in key-value form, about the object
 	Tags map[string]string `json:"tags"`
+}
+
+// AddTagsFromStringSlice will parse any '=' delimited strings and set the Tags map. It overwrites on duplicate keys.
+func (m Metadata) AddTagsFromStringSlice(v []string) Metadata {
+	other := m
+	if other.Tags == nil {
+		other.Tags = map[string]string{}
+	}
+	for _, vv := range v {
+		p := strings.Split(vv, "=")
+		other.Tags[p[0]] = p[1]
+	}
+	return other
 }
 
 // URL is an alias of url

--- a/pkg/types/spec.go
+++ b/pkg/types/spec.go
@@ -12,8 +12,8 @@ type Spec struct {
 	// Kind is the category of the resources and kind can have types  -- e.g. instance-aws/ec2-instance
 	Kind string `json:"kind"`
 
-	// SpiVersion is the name of the interface and version - instance/v0.1.0
-	SpiVersion string `json:"spiVersion"`
+	// Version is the name of the interface and version - instance/v0.1.0
+	Version string `json:"version"`
 
 	// Metadata is metadata / useful information about object
 	Metadata Metadata `json:"metadata"`
@@ -39,8 +39,8 @@ func (s Spec) Validate() error {
 	if s.Kind == "" {
 		return errMissingAttribute("kind")
 	}
-	if s.SpiVersion == "" {
-		return errMissingAttribute("spiVersion")
+	if s.Version == "" {
+		return errMissingAttribute("version")
 	}
 	if s.Metadata.Name == "" {
 		return errMissingAttribute("metadata.name")

--- a/pkg/types/spec_test.go
+++ b/pkg/types/spec_test.go
@@ -11,7 +11,7 @@ func TestEncodeDecodeSpec(t *testing.T) {
 
 	spec := `
 kind:        instance-aws/ec2-instance
-spiVersion:   instance/v0.1.0
+version:   instance/v0.1.0
 metadata:
   name: host1
   tags:
@@ -29,8 +29,8 @@ options:
 	require.NoError(t, yaml.Unmarshal([]byte(spec), &s))
 
 	expected := Spec{
-		Kind:       "instance-aws/ec2-instance",
-		SpiVersion: "instance/v0.1.0",
+		Kind:    "instance-aws/ec2-instance",
+		Version: "instance/v0.1.0",
 		Metadata: Metadata{
 			Name: "host1",
 			Tags: map[string]string{
@@ -54,7 +54,7 @@ options:
 	s.Kind = ""
 	require.Error(t, s.Validate())
 
-	s.SpiVersion = ""
+	s.Version = ""
 	require.Error(t, s.Validate())
 }
 
@@ -62,7 +62,7 @@ func TestEncodeDecodeObject(t *testing.T) {
 
 	object := `
 kind:        instance-aws/ec2-instance
-spiVersion:   instance/v0.1.0
+version:   instance/v0.1.0
 metadata:
   uid : u-12134
   name: host1
@@ -95,8 +95,8 @@ state:
 
 	expected := Object{
 		Spec: Spec{
-			Kind:       "instance-aws/ec2-instance",
-			SpiVersion: "instance/v0.1.0",
+			Kind:    "instance-aws/ec2-instance",
+			Version: "instance/v0.1.0",
 			Metadata: Metadata{
 				Identity: &Identity{
 					UID: "u-12134",
@@ -136,7 +136,7 @@ state:
 
 	require.Equal(t, AnyValueMust(expected), AnyValueMust(o))
 	require.Equal(t, "u-12134", o.Spec.Metadata.Identity.UID)
-	require.Equal(t, "instance/v0.1.0", o.Spec.SpiVersion)
+	require.Equal(t, "instance/v0.1.0", o.Spec.Version)
 
 	require.NoError(t, o.Validate())
 

--- a/pkg/types/spec_test.go
+++ b/pkg/types/spec_test.go
@@ -64,7 +64,7 @@ func TestEncodeDecodeObject(t *testing.T) {
 kind:        instance-aws/ec2-instance
 version:   instance/v0.1.0
 metadata:
-  uid : u-12134
+  id : u-12134
   name: host1
   tags:
     role:    worker
@@ -81,7 +81,7 @@ depends:
     - kind: instance-aws/ebs-volume
       name: /var/lib/docker
       bind:
-         volume/id : Spec/Metadata/Identity/UID
+         volume/id : Spec/Metadata/Identity/ID
 
 state:
     instanceType: c2xlarge
@@ -99,7 +99,7 @@ state:
 			Version: "instance/v0.1.0",
 			Metadata: Metadata{
 				Identity: &Identity{
-					UID: "u-12134",
+					ID: "u-12134",
 				},
 				Name: "host1",
 				Tags: map[string]string{
@@ -122,7 +122,7 @@ state:
 					Kind: "instance-aws/ebs-volume",
 					Name: "/var/lib/docker",
 					Bind: map[string]*Pointer{
-						"volume/id": PointerFromString("Spec/Metadata/Identity/UID"),
+						"volume/id": PointerFromString("Spec/Metadata/Identity/ID"),
 					},
 				},
 			},
@@ -135,11 +135,11 @@ state:
 	}
 
 	require.Equal(t, AnyValueMust(expected), AnyValueMust(o))
-	require.Equal(t, "u-12134", o.Spec.Metadata.Identity.UID)
+	require.Equal(t, "u-12134", o.Spec.Metadata.Identity.ID)
 	require.Equal(t, "instance/v0.1.0", o.Spec.Version)
 
 	require.NoError(t, o.Validate())
 
-	o.Metadata.Identity.UID = ""
+	o.Metadata.Identity.ID = ""
 	require.Error(t, o.Validate())
 }


### PR DESCRIPTION
This PR adds new methods to the Group SPI:

  + DestroyInstances destroys a specific set of instances in a given group.
  + Size returns the target (desired) size of the group.  (*not* the current size)
  + SetSize sets the target size.

These changes are necessary give a more imperative style API for accessing the Group plugin.  This is in preparation of support for cluster autoscaler provider for k8s.

