### PR TITLE
Support template var "/self/logicalId" in tf plugin

### DIFF
--- a/pkg/provider/terraform/instance/plugin.go
+++ b/pkg/provider/terraform/instance/plugin.go
@@ -444,11 +444,17 @@ func mergeInitScript(spec instance.Spec, id instance.ID, vmType TResourceType, p
 	}
 }
 
-// renderInstIdVar applies the "/self/instId" as a global option and renders
-// the given string
-func renderInstIDVar(data string, id instance.ID) (string, error) {
+// renderInstVars applies the "/self/instId" and "/self/logicalId" variables as global options
+// on the input string
+func renderInstVars(data string, id instance.ID, logicalID *instance.LogicalID) (string, error) {
+	// Instance ID is always supplied
 	t, _ := template.NewTemplate("str://"+data, template.Options{})
-	return t.Global("/self/instId", id).Render(nil)
+	t = t.Global("/self/instId", id)
+	// LogicalID is optional
+	if logicalID != nil {
+		t = t.Global("/self/logicalId", string(*logicalID))
+	}
+	return t.Render(nil)
 }
 
 // handleProvisionTags sets the Infrakit-specific tags and merges with the user-defined in the instance spec
@@ -643,13 +649,13 @@ func (p *plugin) Provision(spec instance.Spec) (*instance.ID, error) {
 	}
 	id := instance.ID(name)
 
-	// Template the {{ var "/self/instId" }} var in both the Properties and the Init
-	rendered, err := renderInstIDVar(spec.Properties.String(), id)
+	// Template the "self" instance specific vars in both the Properties and the Init
+	rendered, err := renderInstVars(spec.Properties.String(), id, spec.LogicalID)
 	if err != nil {
 		return nil, err
 	}
 	spec.Properties = types.AnyBytes([]byte(rendered))
-	rendered, err = renderInstIDVar(spec.Init, id)
+	rendered, err = renderInstVars(spec.Init, id, spec.LogicalID)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/provider/terraform/instance/plugin_test.go
+++ b/pkg/provider/terraform/instance/plugin_test.go
@@ -1603,13 +1603,18 @@ func TestMergeTagsIntoVMProps(t *testing.T) {
 	}
 }
 
-func TestRenderInstIDVarNoReplace(t *testing.T) {
-	result, err := renderInstIDVar("{}", instance.ID("id"))
+func TestRenderInstVarsNoReplace(t *testing.T) {
+	result, err := renderInstVars("{}", instance.ID("id"), nil)
+	require.NoError(t, err)
+	require.Equal(t, "{}", result)
+
+	logicalID := instance.LogicalID("mgr1")
+	result, err = renderInstVars("{}", instance.ID("id"), &logicalID)
 	require.NoError(t, err)
 	require.Equal(t, "{}", result)
 }
 
-func TestRenderInstIDVar(t *testing.T) {
+func TestRenderInstVarsWithoutLogicalID(t *testing.T) {
 	input := `{
  "id": "{{ var "/self/instId" }}",
  "key": "val"
@@ -1618,7 +1623,29 @@ func TestRenderInstIDVar(t *testing.T) {
  "id": "id",
  "key": "val"
 }`
-	result, err := renderInstIDVar(input, instance.ID("id"))
+	result, err := renderInstVars(input, instance.ID("id"), nil)
+	require.NoError(t, err)
+	require.JSONEq(t, expected, result)
+
+	logicalID := instance.LogicalID("mgr1")
+	result, err = renderInstVars(input, instance.ID("id"), &logicalID)
+	require.NoError(t, err)
+	require.JSONEq(t, expected, result)
+}
+
+func TestRenderInstVarsWithLogicalID(t *testing.T) {
+	input := `{
+ "id": "{{ var "/self/instId" }}",
+ "logicalId": "{{ var "/self/logicalId" }}",
+ "key": "val"
+}`
+	expected := `{
+ "id": "id",
+ "logicalId": "mgr1",
+ "key": "val"
+}`
+	logicalID := instance.LogicalID("mgr1")
+	result, err := renderInstVars(input, instance.ID("id"), &logicalID)
 	require.NoError(t, err)
 	require.JSONEq(t, expected, result)
 }


### PR DESCRIPTION
This variable will be rendered (if the logical ID is supplied) on both the instance Spec properties and the instance Spec input script.

Signed-off-by: Steven Kaufer <kaufer@us.ibm.com>