### PR TITLE
Review infrakit docker instance and typos

### DIFF
--- a/cmd/infrakit/group/group.go
+++ b/cmd/infrakit/group/group.go
@@ -167,7 +167,7 @@ func Command(plugins func() discovery.Plugins) *cobra.Command {
 	// inspect
 	inspect := &cobra.Command{
 		Use:   "inspect <group ID>",
-		Short: "Insepct a group. Returns the raw configuration associated with a group",
+		Short: "Inspect a group. Returns the raw configuration associated with a group",
 		RunE: func(cmd *cobra.Command, args []string) error {
 
 			if len(args) != 1 {

--- a/examples/flavor/kubernetes/README.md
+++ b/examples/flavor/kubernetes/README.md
@@ -36,7 +36,7 @@ For workers
 Note `KubeJoinIP`, `KubeBindPort` that the Kubernetes connection information, as well as what IP in the Kubernetes managers and workers should use
 to advertise and join.
 
-`KubeAddOns` is list of (kubernetes addons)[https://kubernetes.io/docs/concepts/cluster-administration/addons/]. 
+`KubeAddOns` is list of [kubernetes addons](https://kubernetes.io/docs/concepts/cluster-administration/addons/). 
 You can set Type as network or visualise.
 `network` Type addon should be set as your cluster will not be Ready status until network addon is applyed.
 

--- a/examples/instance/docker/README.md
+++ b/examples/instance/docker/README.md
@@ -20,7 +20,7 @@ INFO[0000] Listening on: unix:///run/infrakit/plugins/group.sock
 INFO[0000] listener protocol= unix addr= /run/infrakit/plugins/group.sock err= <nil>
 ```
 
-and the [Vanilla](https://github.com/docker/infrakit/tree/master/examples/flavor/vanilla) Flavor plugin:
+the [Vanilla](https://github.com/docker/infrakit/tree/master/examples/flavor/vanilla) Flavor plugin:
 ```console
 $ build/infrakit-flavor-vanilla
 INFO[0000] Starting plugin
@@ -28,9 +28,17 @@ INFO[0000] Listening on: unix:///run/infrakit/plugins/flavor-vanilla.sock
 INFO[0000] listener protocol= unix addr= /run/infrakit/plugins/flavor-vanilla.sock err= <nil>
 ```
 
+and the Docker Instance plugin:
+
+```console
+$ build/infrakit-instance-docker
+INFO[0000] PID file at unix:///run/infrakit/plugins/instance-docker.pid
+INFO[0000] Server waiting at unix:///run/infrakit/plugins/instance-docker
+```
+
 We will use a basic configuration that creates a single instance:
 ```console
-$ cat << EOF > aws-vanilla.json
+$ cat << EOF > docker-vanilla.json
 {
   "ID": "docker-example",
   "Properties": {
@@ -41,7 +49,7 @@ $ cat << EOF > aws-vanilla.json
       "Plugin": "instance-docker",
       "Properties": {
         "Config": {
-          "Image": "alpine:3.5"
+          "Image": "httpd:2.2"
         },
         "HostConfig": {
           "AutoRemove": true
@@ -66,22 +74,15 @@ EOF
 
 For the structure of `Config` `HostConfig`, see the plugin properties definition below.
 
-Finally, instruct the Group plugin to start watching the group:
+Finally, instruct the Group plugin to `commit` the group:
 ```console
-$ build/infrakit group watch docker-vanilla.json
-watching docker-example
-```
-
-In the console running the Group plugin, we will see input like the following:
-```
-INFO[1208] Watching group 'docker-example'
-INFO[1219] Adding 1 instances to group to reach desired 1
-INFO[1219] Created instance i-ba0412a2 with tags map[infrakit.config_sha:dUBtWGmkptbGg29ecBgv1VJYzys= infrakit.group:aws-example]
+$ build/infrakit group commit docker-vanilla.json
+Committed docker-example: Managing 1 instances
 ```
 
 Additionally, the CLI will report the newly-created instance:
 ```console
-$ build/infrakit group inspect docker-example
+$ build/infrakit group describe docker-example
 ID                             	LOGICAL                        	TAGS
 90e6f3de4918                   	elusive_leaky                  	Name=infrakit-example,infrakit.config_sha=dUBtWGmkptbGg29ecBgv1VJYzys=,infrakit.group=docker-example
 ```

--- a/pkg/cli/v0/group/inspect.go
+++ b/pkg/cli/v0/group/inspect.go
@@ -15,7 +15,7 @@ func Inspect(name string, services *cli.Services) *cobra.Command {
 
 	inspect := &cobra.Command{
 		Use:   "inspect <group ID>",
-		Short: "Insepct a group. Returns the raw configuration associated with a group",
+		Short: "Inspect a group. Returns the raw configuration associated with a group",
 		RunE: func(cmd *cobra.Command, args []string) error {
 
 			pluginName := plugin.Name(name)


### PR DESCRIPTION
Was testing docker instance README.md, but I had to change some commands to make it work here. I updated with these changes. Also, changed some typos.

About the `alpine` to `httpd` change at docker-vanilla.json, the alpine was too ephemeral for me. When I was checking with `build/infrakit group describe docker-example` it was printing empty results. After the change, it keeps the container alive. I don't know if httpd is the best option, but was one of the [Official Image](https://github.com/docker-library/official-images/tree/master/library) that worked fine for me.