### PR TITLE
Adding AWS ELB ingress implementation

### DIFF
--- a/pkg/provider/aws/plugin/loadbalancer/auth.go
+++ b/pkg/provider/aws/plugin/loadbalancer/auth.go
@@ -1,0 +1,27 @@
+package aws
+
+import (
+	"github.com/aws/aws-sdk-go/aws/credentials"
+)
+
+// Credential defines static authentication details (as opposed to environment-based) for the AWS API.
+type Credential struct {
+	AccessKeyID     string `yaml:"access_key_id" json:"access_key_id"`
+	SecretAccessKey string `yaml:"secret_access_key" json:"secret_access_key"`
+	SessionToken    string `yaml:"session_token" json:"session_token"`
+}
+
+// Retrieve implements the AWS credentials.Provider interface method
+func (a *Credential) Retrieve() (credentials.Value, error) {
+	return credentials.Value{
+		AccessKeyID:     a.AccessKeyID,
+		SecretAccessKey: a.SecretAccessKey,
+		SessionToken:    a.SessionToken,
+		ProviderName:    "Machete",
+	}, nil
+}
+
+// IsExpired implements the AWS credentials.Provider interface method.  For static credentials this always returns false
+func (a *Credential) IsExpired() bool {
+	return false
+}

--- a/pkg/provider/aws/plugin/loadbalancer/elb.go
+++ b/pkg/provider/aws/plugin/loadbalancer/elb.go
@@ -98,9 +98,9 @@ func (p *elbPlugin) Routes() ([]loadbalancer.Route, error) {
 func (p *elbPlugin) RegisterBackends(ids []instance.ID) (loadbalancer.Result, error) {
 
 	addInstances := []*elb.Instance{}
-	for _, instanceId := range ids {
+	for _, instanceID := range ids {
 		addInstance := &elb.Instance{}
-		strID := string(instanceId)
+		strID := string(instanceID)
 		addInstance.InstanceId = &strID
 		addInstances = append(addInstances, addInstance)
 	}
@@ -114,9 +114,9 @@ func (p *elbPlugin) RegisterBackends(ids []instance.ID) (loadbalancer.Result, er
 func (p *elbPlugin) DeregisterBackends(ids []instance.ID) (loadbalancer.Result, error) {
 
 	rmInstances := []*elb.Instance{}
-	for _, instanceId := range ids {
+	for _, instanceID := range ids {
 		rmInstance := &elb.Instance{}
-		strID := string(instanceId)
+		strID := string(instanceID)
 		rmInstance.InstanceId = &strID
 		rmInstances = append(rmInstances, rmInstance)
 	}

--- a/pkg/provider/aws/plugin/loadbalancer/elb.go
+++ b/pkg/provider/aws/plugin/loadbalancer/elb.go
@@ -1,0 +1,201 @@
+package aws
+
+import (
+	"fmt"
+
+	log "github.com/Sirupsen/logrus"
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/credentials"
+	"github.com/aws/aws-sdk-go/aws/credentials/ec2rolecreds"
+	"github.com/aws/aws-sdk-go/aws/ec2metadata"
+	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/aws/aws-sdk-go/service/elb"
+	"github.com/aws/aws-sdk-go/service/elb/elbiface"
+	"github.com/docker/infrakit/pkg/spi/instance"
+	"github.com/docker/infrakit/pkg/spi/loadbalancer"
+)
+
+// ELBOptions are the configuration parameters for the ELB provisioner.
+type ELBOptions struct {
+	Region  string
+	Retries int
+}
+
+type elbPlugin struct {
+	client elbiface.ELBAPI
+	name   string
+}
+
+// NewELBPlugin creates an AWS-based ELB provisioner.
+func NewELBPlugin(client elbiface.ELBAPI, name string) (loadbalancer.L4, error) {
+	return &elbPlugin{
+		client: client,
+		name:   name,
+	}, nil
+}
+
+// Credentials allocates a credential object that has the access key and secret id.
+func Credentials(cred *Credential) *credentials.Credentials {
+	staticCred := new(Credential)
+	if cred != nil {
+		staticCred = cred
+	}
+
+	return credentials.NewChainCredentials([]credentials.Provider{
+		&ec2rolecreds.EC2RoleProvider{Client: ec2metadata.New(session.New())},
+		&credentials.EnvProvider{},
+		&credentials.SharedCredentialsProvider{},
+		staticCred,
+	})
+}
+
+// CreateELBClient creates an AWS ELB API client.
+func CreateELBClient(awsCredentials *credentials.Credentials, opt ELBOptions) elbiface.ELBAPI {
+	region := opt.Region
+	if region == "" {
+		region, _ = GetRegion()
+	}
+
+	log.Infoln("ELB Client in region", region)
+
+	return elb.New(session.New(aws.NewConfig().
+		WithRegion(region).
+		WithCredentials(awsCredentials).
+		WithLogger(getLogger()).
+		WithLogLevel(aws.LogDebugWithHTTPBody).
+		WithMaxRetries(opt.Retries)))
+}
+
+func (p *elbPlugin) Name() string {
+	return p.name
+}
+
+// Routes lists all registered routes.
+func (p *elbPlugin) Routes() ([]loadbalancer.Route, error) {
+	output, err := p.client.DescribeLoadBalancers(&elb.DescribeLoadBalancersInput{
+		LoadBalancerNames: []*string{aws.String(p.name)},
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	routes := []loadbalancer.Route{}
+
+	if len(output.LoadBalancerDescriptions) > 0 && output.LoadBalancerDescriptions[0].ListenerDescriptions != nil {
+		for _, listener := range output.LoadBalancerDescriptions[0].ListenerDescriptions {
+			routes = append(routes, loadbalancer.Route{
+				Port:             int(*listener.Listener.InstancePort),
+				Protocol:         loadbalancer.ProtocolFromString(*listener.Listener.Protocol),
+				LoadBalancerPort: int(*listener.Listener.LoadBalancerPort),
+				Certificate:      listener.Listener.SSLCertificateId,
+			})
+		}
+	}
+
+	return routes, nil
+}
+
+func (p *elbPlugin) RegisterBackends(ids []instance.ID) (loadbalancer.Result, error) {
+
+	addInstances := []*elb.Instance{}
+	for _, instanceId := range ids {
+		addInstance := &elb.Instance{}
+		strID := string(instanceId)
+		addInstance.InstanceId = &strID
+		addInstances = append(addInstances, addInstance)
+	}
+
+	return p.client.RegisterInstancesWithLoadBalancer(&elb.RegisterInstancesWithLoadBalancerInput{
+		Instances:        addInstances,
+		LoadBalancerName: aws.String(p.name),
+	})
+}
+
+func (p *elbPlugin) DeregisterBackends(ids []instance.ID) (loadbalancer.Result, error) {
+
+	rmInstances := []*elb.Instance{}
+	for _, instanceId := range ids {
+		rmInstance := &elb.Instance{}
+		strID := string(instanceId)
+		rmInstance.InstanceId = &strID
+		rmInstances = append(rmInstances, rmInstance)
+	}
+
+	return p.client.DeregisterInstancesFromLoadBalancer(&elb.DeregisterInstancesFromLoadBalancerInput{
+		Instances:        rmInstances,
+		LoadBalancerName: aws.String(p.name),
+	})
+}
+
+func (p *elbPlugin) Backends() ([]instance.ID, error) {
+	output, err := p.client.DescribeLoadBalancers(&elb.DescribeLoadBalancersInput{
+		LoadBalancerNames: []*string{
+			aws.String(p.name),
+		},
+	})
+	if err != nil {
+		return []instance.ID{}, err
+	}
+
+	instanceIDs := []instance.ID{}
+
+	if len(output.LoadBalancerDescriptions) == 0 {
+		return instanceIDs, nil
+	}
+
+	for _, loadBalancerDescription := range output.LoadBalancerDescriptions {
+		for _, lbInstance := range loadBalancerDescription.Instances {
+			instanceIDs = append(instanceIDs, instance.ID(*lbInstance.InstanceId))
+		}
+	}
+	return instanceIDs, nil
+}
+
+func (p *elbPlugin) Publish(route loadbalancer.Route) (loadbalancer.Result, error) {
+
+	if route.Protocol == loadbalancer.Invalid {
+		return nil, fmt.Errorf("Bad protocol")
+	}
+	instanceProtocol := aws.String(string(route.Protocol))
+	if route.Protocol == loadbalancer.SSL {
+		// SSL needs to point to TCP internally
+		instanceProtocol = aws.String(string(loadbalancer.TCP))
+	} else if route.Protocol == loadbalancer.HTTPS {
+		// HTTPS has to point to HTTP internally
+		instanceProtocol = aws.String(string(loadbalancer.HTTP))
+	}
+
+	listener := &elb.Listener{
+		InstancePort:     aws.Int64(int64(route.Port)),
+		LoadBalancerPort: aws.Int64(int64(route.LoadBalancerPort)),
+		Protocol:         aws.String(string(route.Protocol)),
+		InstanceProtocol: instanceProtocol,
+		SSLCertificateId: route.Certificate,
+	}
+
+	return p.client.CreateLoadBalancerListeners(&elb.CreateLoadBalancerListenersInput{
+		Listeners:        []*elb.Listener{listener},
+		LoadBalancerName: aws.String(p.name),
+	})
+}
+
+func (p *elbPlugin) Unpublish(extPort int) (loadbalancer.Result, error) {
+	return p.client.DeleteLoadBalancerListeners(&elb.DeleteLoadBalancerListenersInput{
+		LoadBalancerPorts: []*int64{aws.Int64(int64(extPort))},
+		LoadBalancerName:  aws.String(p.name),
+	})
+}
+
+func (p *elbPlugin) ConfigureHealthCheck(hc loadbalancer.HealthCheck) (loadbalancer.Result, error) {
+
+	return p.client.ConfigureHealthCheck(&elb.ConfigureHealthCheckInput{
+		HealthCheck: &elb.HealthCheck{
+			HealthyThreshold:   aws.Int64(int64(hc.Healthy)),
+			Interval:           aws.Int64(int64(hc.Interval.Seconds())),
+			Target:             aws.String(fmt.Sprintf("TCP:%d", hc.BackendPort)),
+			Timeout:            aws.Int64(int64(hc.Timeout.Seconds())),
+			UnhealthyThreshold: aws.Int64(int64(hc.Unhealthy)),
+		},
+		LoadBalancerName: aws.String(p.name),
+	})
+}

--- a/pkg/provider/aws/plugin/loadbalancer/logger.go
+++ b/pkg/provider/aws/plugin/loadbalancer/logger.go
@@ -1,0 +1,21 @@
+package aws
+
+import (
+	"github.com/aws/aws-sdk-go/aws"
+	"log"
+	"os"
+)
+
+type logger struct {
+	logger *log.Logger
+}
+
+func (l logger) Log(args ...interface{}) {
+	l.logger.Println(args...)
+}
+
+func getLogger() aws.Logger {
+	return &logger{
+		logger: log.New(os.Stderr, "", log.LstdFlags),
+	}
+}

--- a/pkg/provider/aws/plugin/loadbalancer/metadata.go
+++ b/pkg/provider/aws/plugin/loadbalancer/metadata.go
@@ -1,0 +1,55 @@
+package aws
+
+import (
+	"io/ioutil"
+	"net/http"
+)
+
+// MetadataKey is the identifier for a metadata entry.
+type MetadataKey string
+
+const (
+	// MetadataAmiID - AMI ID
+	MetadataAmiID = MetadataKey("http://169.254.169.254/latest/meta-data/ami-id")
+
+	// MetadataInstanceID - Instance ID
+	MetadataInstanceID = MetadataKey("http://169.254.169.254/latest/meta-data/instance-id")
+
+	// MetadataInstanceType - Instance type
+	MetadataInstanceType = MetadataKey("http://169.254.169.254/latest/meta-data/instance-type")
+
+	// MetadataHostname - Host name
+	MetadataHostname = MetadataKey("http://169.254.169.254/latest/meta-data/hostname")
+
+	// MetadataLocalIPv4 - Local IPv4 address
+	MetadataLocalIPv4 = MetadataKey("http://169.254.169.254/latest/meta-data/local-ipv4")
+
+	// MetadataPublicIPv4 - Public IPv4 address
+	MetadataPublicIPv4 = MetadataKey("http://169.254.169.254/latest/meta-data/public-ipv4")
+
+	// MetadataAvailabilityZone - Availability zone
+	MetadataAvailabilityZone = MetadataKey("http://169.254.169.254/latest/meta-data/placement/availability-zone")
+)
+
+// GetMetadata returns the value of the metadata by key
+func GetMetadata(key MetadataKey) (string, error) {
+	resp, err := http.Get(string(key))
+	if err != nil {
+		return "", err
+	}
+	buff, err := ioutil.ReadAll(resp.Body)
+	resp.Body.Close()
+	if err != nil {
+		return "", err
+	}
+	return string(buff), nil
+}
+
+// GetRegion returns the AWS region this instance is in.
+func GetRegion() (string, error) {
+	az, err := GetMetadata(MetadataAvailabilityZone)
+	if err != nil {
+		return "", err
+	}
+	return az[0 : len(az)-1], nil
+}

--- a/pkg/run/v0/aws/aws.go
+++ b/pkg/run/v0/aws/aws.go
@@ -15,10 +15,12 @@ import (
 	logutil "github.com/docker/infrakit/pkg/log"
 	"github.com/docker/infrakit/pkg/plugin"
 	aws_instance "github.com/docker/infrakit/pkg/provider/aws/plugin/instance"
+	aws_loadbalancer "github.com/docker/infrakit/pkg/provider/aws/plugin/loadbalancer"
 	aws_metadata "github.com/docker/infrakit/pkg/provider/aws/plugin/metadata"
 	"github.com/docker/infrakit/pkg/run"
 	"github.com/docker/infrakit/pkg/spi/event"
 	"github.com/docker/infrakit/pkg/spi/instance"
+	"github.com/docker/infrakit/pkg/spi/loadbalancer"
 	"github.com/docker/infrakit/pkg/spi/metadata"
 	"github.com/docker/infrakit/pkg/types"
 )
@@ -81,11 +83,18 @@ func Run(plugins func() discovery.Plugins, name plugin.Name,
 	if err != nil {
 		return
 	}
+
+	var elbPlugin loadbalancer.L4
+	elbClient := elb.New(builder.Config)
+	elbPlugin, err = aws_loadbalancer.NewELBPlugin(elbClient, "elb-lb")
+	if err != nil {
+		return
+	}
+
 	autoscalingClient := autoscaling.New(builder.Config)
 	cloudWatchLogsClient := cloudwatchlogs.New(builder.Config)
 	dynamodbClient := dynamodb.New(builder.Config)
 	ec2Client := ec2.New(builder.Config)
-	elbClient := elb.New(builder.Config)
 	iamClient := iam.New(builder.Config)
 	sqsClient := sqs.New(builder.Config)
 
@@ -95,6 +104,7 @@ func Run(plugins func() discovery.Plugins, name plugin.Name,
 			"ec2-instance": (&aws_instance.Monitor{Plugin: instancePlugin}).Init(),
 		},
 		run.Metadata: metadataPlugin,
+		run.L4:       elbPlugin,
 		run.Instance: map[string]instance.Plugin{
 			"autoscaling-autoscalinggroup":    aws_instance.NewAutoScalingGroupPlugin(autoscalingClient, options.Namespace),
 			"autoscaling-launchconfiguration": aws_instance.NewLaunchConfigurationPlugin(autoscalingClient, options.Namespace),

--- a/pkg/run/v0/aws/aws.go
+++ b/pkg/run/v0/aws/aws.go
@@ -28,7 +28,8 @@ import (
 
 const (
 	// Kind is the canonical name of the plugin for starting up, etc.
-	Kind       = "aws"
+	Kind = "aws"
+	// EnvELBName is the name of the ELB ENV variable name for the ELB plugin.
 	EnvELBName = "INFRAKIT_AWS_ELB_NAME"
 )
 


### PR DESCRIPTION
Here is the code for an AWS ELB ingress implementation. This code mostly comes from the docker for AWS code base, and refactored to work with infrakit's L4 loadbalancer implementation.

This does not include the code for handling ACM/TLS/SSL certificates, that will come in a follow up PR.

There might be some extra code that might not be needed in the future, we can remove that in a future PR, once it has been refactored.

This has been tested using a local plugin pointing to us-west-1. I was able to add, remove and list the backends, and routes via the CLI.