### PR TITLE
Plugin start JSON processing fixes

### DIFF
--- a/pkg/run/v0/group/group.go
+++ b/pkg/run/v0/group/group.go
@@ -37,7 +37,7 @@ func init() {
 // Options capture the options for starting up the group controller.
 type Options struct {
 	// PollInterval is the frequency for syncing the state
-	PollInterval time.Duration
+	PollInterval types.Duration
 
 	// MaxParallelNum is the max number of parallel instance operation. Default =0 (no limit)
 	MaxParallelNum uint
@@ -51,7 +51,7 @@ type Options struct {
 
 // DefaultOptions return an Options with default values filled in.
 var DefaultOptions = Options{
-	PollInterval:            10 * time.Second,
+	PollInterval:            types.FromDuration(10 * time.Second),
 	MaxParallelNum:          0,
 	PollIntervalGroupSpec:   1 * time.Second,
 	PollIntervalGroupDetail: 30 * time.Second,
@@ -87,7 +87,7 @@ func Run(plugins func() discovery.Plugins, name plugin.Name,
 	}
 
 	groupPlugin := group.NewGroupPlugin(instancePluginLookup, flavorPluginLookup,
-		options.PollInterval, options.MaxParallelNum)
+		options.PollInterval.Duration(), options.MaxParallelNum)
 
 	// Start a poller to load the snapshot and make that available as metadata
 	updateSnapshot := make(chan func(map[string]interface{}))

--- a/pkg/run/v0/terraform/terraform.go
+++ b/pkg/run/v0/terraform/terraform.go
@@ -43,7 +43,7 @@ type Options struct {
 	Dir string
 
 	// PollInterval is the Terraform polling interval
-	PollInterval time.Duration
+	PollInterval types.Duration
 
 	// Standalone - set if running standalone, disables manager leadership verification
 	Standalone bool
@@ -65,7 +65,7 @@ type Options struct {
 // simply get this struct and bind the fields to the flags.
 var DefaultOptions = Options{
 	Dir:          local.Getenv(EnvDir, filepath.Join(local.InfrakitHome(), "terraform")),
-	PollInterval: 30 * time.Second,
+	PollInterval: types.FromDuration(30 * time.Second),
 	Standalone:   false,
 }
 
@@ -99,7 +99,7 @@ func Run(plugins func() discovery.Plugins, name plugin.Name,
 	log.Info("NewOptions", "value", options.NewOption, "Dir", options.Dir)
 
 	impls = map[run.PluginCode]interface{}{
-		run.Instance: terraform.NewTerraformInstancePlugin(options.Dir, options.PollInterval,
+		run.Instance: terraform.NewTerraformInstancePlugin(options.Dir, options.PollInterval.Duration(),
 			options.Standalone, &terraform.ImportOptions{
 				InstanceSpec: importInstSpec,
 				InstanceID:   &options.ImportInstanceID,

--- a/pkg/util/docker/docker.go
+++ b/pkg/util/docker/docker.go
@@ -35,7 +35,7 @@ type APIClientCloser interface {
 // NewClient creates a new API client.
 func NewClient(host string, tls *tlsconfig.Options) (APIClientCloser, error) {
 	tlsOptions := tls
-	if tls.KeyFile == "" || tls.CAFile == "" || tls.CertFile == "" {
+	if tls == nil || tls.KeyFile == "" || tls.CAFile == "" || tls.CertFile == "" {
 		// The api doesn't like it when you pass in not nil but with zero field values...
 		tlsOptions = nil
 	}


### PR DESCRIPTION
- Updates the `group` and `terraform` plugin's `PollInterval` from `time.Duration` to `types.Duration` so that it can be unmarshalled
- Adds a `nil` check on the TLS options when creating a new Docker client