### PR TITLE
Change time.Duration to types.Duration for run/v0 Option parsing

### DIFF
--- a/pkg/run/v0/group/group.go
+++ b/pkg/run/v0/group/group.go
@@ -43,18 +43,18 @@ type Options struct {
 	MaxParallelNum uint
 
 	// PollIntervalGroupSpec polls for group spec at this interval to update the metadata paths
-	PollIntervalGroupSpec time.Duration
+	PollIntervalGroupSpec types.Duration
 
 	// PollIntervalGroupDetail polls for group details at this interval to update the metadata paths
-	PollIntervalGroupDetail time.Duration
+	PollIntervalGroupDetail types.Duration
 }
 
 // DefaultOptions return an Options with default values filled in.
 var DefaultOptions = Options{
 	PollInterval:            types.FromDuration(10 * time.Second),
 	MaxParallelNum:          0,
-	PollIntervalGroupSpec:   1 * time.Second,
-	PollIntervalGroupDetail: 30 * time.Second,
+	PollIntervalGroupSpec:   types.FromDuration(1 * time.Second),
+	PollIntervalGroupDetail: types.FromDuration(30 * time.Second),
 }
 
 // Run runs the plugin, blocking the current thread.  Error is returned immediately
@@ -93,8 +93,8 @@ func Run(plugins func() discovery.Plugins, name plugin.Name,
 	updateSnapshot := make(chan func(map[string]interface{}))
 	stopSnapshot := make(chan struct{})
 	go func() {
-		tick := time.Tick(options.PollIntervalGroupSpec)
-		tick2 := time.Tick(options.PollIntervalGroupDetail)
+		tick := time.Tick(options.PollIntervalGroupSpec.Duration())
+		tick2 := time.Tick(options.PollIntervalGroupDetail.Duration())
 		for {
 			select {
 			case <-tick:

--- a/pkg/run/v0/manager/etcd.go
+++ b/pkg/run/v0/manager/etcd.go
@@ -14,7 +14,7 @@ import (
 // BackendEtcdOptions contain the options for the etcd backend
 type BackendEtcdOptions struct {
 	// PollInterval is how often to check
-	PollInterval time.Duration
+	PollInterval types.Duration
 
 	etcd.Options `json:",inline" yaml:",inline"`
 
@@ -25,7 +25,7 @@ type BackendEtcdOptions struct {
 // DefaultBackendEtcdOptions contains the defaults for running etcd as backend
 var DefaultBackendEtcdOptions = types.AnyValueMust(
 	BackendEtcdOptions{
-		PollInterval: 5 * time.Second,
+		PollInterval: types.FromDuration(5 * time.Second),
 		Options: etcd.Options{
 			RequestTimeout: 1 * time.Second,
 			Config: clientv3.Config{
@@ -50,7 +50,7 @@ func configEtcdBackends(options BackendEtcdOptions, managerConfig *Options) erro
 		return err
 	}
 
-	leader := etcd_leader.NewDetector(options.PollInterval, etcdClient)
+	leader := etcd_leader.NewDetector(options.PollInterval.Duration(), etcdClient)
 	leaderStore := etcd_leader.NewStore(etcdClient)
 	snapshot, err := etcd_store.NewSnapshot(etcdClient)
 	if err != nil {

--- a/pkg/run/v0/manager/file.go
+++ b/pkg/run/v0/manager/file.go
@@ -24,7 +24,7 @@ const (
 // BackendFileOptions contain the options for the file backend
 type BackendFileOptions struct {
 	// PollInterval is how often to check
-	PollInterval time.Duration
+	PollInterval types.Duration
 
 	// LeaderFile is the location of the leader file
 	LeaderFile string
@@ -40,7 +40,7 @@ type BackendFileOptions struct {
 var DefaultBackendFileOptions = types.AnyValueMust(
 	BackendFileOptions{
 		ID:           local.Getenv(EnvID, "manager1"),
-		PollInterval: 5 * time.Second,
+		PollInterval: types.FromDuration(5 * time.Second),
 		LeaderFile:   local.Getenv(EnvLeaderFile, filepath.Join(local.InfrakitHome(), "leader")),
 		StoreDir:     local.Getenv(EnvStoreDir, filepath.Join(local.InfrakitHome(), "configs")),
 	},
@@ -48,7 +48,7 @@ var DefaultBackendFileOptions = types.AnyValueMust(
 
 func configFileBackends(options BackendFileOptions, managerConfig *Options) error {
 
-	leader, err := file_leader.NewDetector(options.PollInterval, options.LeaderFile, options.ID)
+	leader, err := file_leader.NewDetector(options.PollInterval.Duration(), options.LeaderFile, options.ID)
 	if err != nil {
 		return err
 	}

--- a/pkg/run/v0/manager/swarm.go
+++ b/pkg/run/v0/manager/swarm.go
@@ -14,7 +14,7 @@ import (
 // BackendSwarmOptions contain the options for the swarm backend
 type BackendSwarmOptions struct {
 	// PollInterval is how often to check
-	PollInterval time.Duration
+	PollInterval types.Duration
 	// Docker holds the connection params to the Docker engine for join tokens, etc.
 	Docker docker.ConnectInfo `json:",inline" yaml:",inline"`
 }
@@ -22,7 +22,7 @@ type BackendSwarmOptions struct {
 // DefaultBackendSwarmOptions is the Options for using the swarm backend.
 var DefaultBackendSwarmOptions = types.AnyValueMust(
 	BackendSwarmOptions{
-		PollInterval: 5 * time.Second,
+		PollInterval: types.FromDuration(5 * time.Second),
 		Docker: docker.ConnectInfo{
 			Host: "unix:///var/run/docker.sock",
 			TLS:  &tlsconfig.Options{},
@@ -43,7 +43,7 @@ func configSwarmBackends(options BackendSwarmOptions, managerConfig *Options) er
 		return err
 	}
 
-	leader := swarm_leader.NewDetector(options.PollInterval, dockerClient)
+	leader := swarm_leader.NewDetector(options.PollInterval.Duration(), dockerClient)
 	leaderStore := swarm_leader.NewStore(dockerClient)
 
 	if managerConfig != nil {


### PR DESCRIPTION
`time.Duration` does not implement the JSON marshall/unmarshall interfaces, the `Option` parsing in the `manager` plugin needs to be changed to use `types.Duration`.
    
See PR #688 for the same change to the `group` and `terraform` processing; this PR handles the other occurrences.