### PR TITLE
Honor default `Options` in the `run/v0` package

### DIFF
--- a/pkg/run/v0/enrollment/enrollment.go
+++ b/pkg/run/v0/enrollment/enrollment.go
@@ -58,7 +58,7 @@ func Run(plugins func() discovery.Plugins, name plugin.Name,
 		panic("no plugins()")
 	}
 
-	options := enrollment.Options{}
+	options := DefaultOptions
 	err = config.Decode(&options)
 	if err != nil {
 		return

--- a/pkg/run/v0/manager/etcd.go
+++ b/pkg/run/v0/manager/etcd.go
@@ -23,17 +23,15 @@ type BackendEtcdOptions struct {
 }
 
 // DefaultBackendEtcdOptions contains the defaults for running etcd as backend
-var DefaultBackendEtcdOptions = types.AnyValueMust(
-	BackendEtcdOptions{
-		PollInterval: types.FromDuration(5 * time.Second),
-		Options: etcd.Options{
-			RequestTimeout: 1 * time.Second,
-			Config: clientv3.Config{
-				Endpoints: []string{etcd.LocalIP() + ":2379"},
-			},
+var DefaultBackendEtcdOptions = BackendEtcdOptions{
+	PollInterval: types.FromDuration(5 * time.Second),
+	Options: etcd.Options{
+		RequestTimeout: 1 * time.Second,
+		Config: clientv3.Config{
+			Endpoints: []string{etcd.LocalIP() + ":2379"},
 		},
 	},
-)
+}
 
 func configEtcdBackends(options BackendEtcdOptions, managerConfig *Options) error {
 	if options.TLS != nil {

--- a/pkg/run/v0/manager/file.go
+++ b/pkg/run/v0/manager/file.go
@@ -37,14 +37,12 @@ type BackendFileOptions struct {
 }
 
 // DefaultBackendFileOptions is the default for the file backend
-var DefaultBackendFileOptions = types.AnyValueMust(
-	BackendFileOptions{
-		ID:           local.Getenv(EnvID, "manager1"),
-		PollInterval: types.FromDuration(5 * time.Second),
-		LeaderFile:   local.Getenv(EnvLeaderFile, filepath.Join(local.InfrakitHome(), "leader")),
-		StoreDir:     local.Getenv(EnvStoreDir, filepath.Join(local.InfrakitHome(), "configs")),
-	},
-)
+var DefaultBackendFileOptions = BackendFileOptions{
+	ID:           local.Getenv(EnvID, "manager1"),
+	PollInterval: types.FromDuration(5 * time.Second),
+	LeaderFile:   local.Getenv(EnvLeaderFile, filepath.Join(local.InfrakitHome(), "leader")),
+	StoreDir:     local.Getenv(EnvStoreDir, filepath.Join(local.InfrakitHome(), "configs")),
+}
 
 func configFileBackends(options BackendFileOptions, managerConfig *Options) error {
 

--- a/pkg/run/v0/manager/manager.go
+++ b/pkg/run/v0/manager/manager.go
@@ -94,16 +94,16 @@ func defaultOptions() (options Options) {
 	switch options.Backend {
 	case "swarm":
 		options.Backend = "swarm"
-		options.Settings = DefaultBackendSwarmOptions
+		options.Settings = types.AnyValueMust(DefaultBackendSwarmOptions)
 	case "etcd":
 		options.Backend = "etcd"
-		options.Settings = DefaultBackendEtcdOptions
+		options.Settings = types.AnyValueMust(DefaultBackendEtcdOptions)
 	case "file":
 		options.Backend = "file"
-		options.Settings = DefaultBackendFileOptions
+		options.Settings = types.AnyValueMust(DefaultBackendFileOptions)
 	default:
 		options.Backend = "file"
-		options.Settings = DefaultBackendFileOptions
+		options.Settings = types.AnyValueMust(DefaultBackendFileOptions)
 	}
 
 	return
@@ -118,7 +118,7 @@ func Run(plugins func() discovery.Plugins, name plugin.Name,
 		panic("no plugins()")
 	}
 
-	options := Options{}
+	options := defaultOptions()
 	err = config.Decode(&options)
 	if err != nil {
 		return
@@ -131,7 +131,7 @@ func Run(plugins func() discovery.Plugins, name plugin.Name,
 
 	switch strings.ToLower(options.Backend) {
 	case "etcd":
-		backendOptions := BackendEtcdOptions{}
+		backendOptions := DefaultBackendEtcdOptions
 		err = options.Settings.Decode(&backendOptions)
 		if err != nil {
 			return
@@ -143,7 +143,7 @@ func Run(plugins func() discovery.Plugins, name plugin.Name,
 		}
 		log.Info("etcd backend", "leader", options.leader, "store", options.store, "cleanup", options.cleanUpFunc)
 	case "file":
-		backendOptions := BackendFileOptions{}
+		backendOptions := DefaultBackendFileOptions
 		err = options.Settings.Decode(&backendOptions)
 		if err != nil {
 			return
@@ -155,7 +155,7 @@ func Run(plugins func() discovery.Plugins, name plugin.Name,
 		}
 		log.Info("file backend", "leader", options.leader, "store", options.store, "cleanup", options.cleanUpFunc)
 	case "swarm":
-		backendOptions := BackendSwarmOptions{}
+		backendOptions := DefaultBackendSwarmOptions
 		err = options.Settings.Decode(&backendOptions)
 		if err != nil {
 			return

--- a/pkg/run/v0/manager/swarm.go
+++ b/pkg/run/v0/manager/swarm.go
@@ -20,15 +20,13 @@ type BackendSwarmOptions struct {
 }
 
 // DefaultBackendSwarmOptions is the Options for using the swarm backend.
-var DefaultBackendSwarmOptions = types.AnyValueMust(
-	BackendSwarmOptions{
-		PollInterval: types.FromDuration(5 * time.Second),
-		Docker: docker.ConnectInfo{
-			Host: "unix:///var/run/docker.sock",
-			TLS:  &tlsconfig.Options{},
-		},
+var DefaultBackendSwarmOptions = BackendSwarmOptions{
+	PollInterval: types.FromDuration(5 * time.Second),
+	Docker: docker.ConnectInfo{
+		Host: "unix:///var/run/docker.sock",
+		TLS:  &tlsconfig.Options{},
 	},
-)
+}
 
 func configSwarmBackends(options BackendSwarmOptions, managerConfig *Options) error {
 	dockerClient, err := docker.NewClient(options.Docker.Host, options.Docker.TLS)

--- a/pkg/run/v0/simulator/simulator.go
+++ b/pkg/run/v0/simulator/simulator.go
@@ -67,7 +67,7 @@ var DefaultOptions = Options{
 func Run(plugins func() discovery.Plugins, name plugin.Name,
 	config *types.Any) (transport plugin.Transport, impls map[run.PluginCode]interface{}, onStop func(), err error) {
 
-	options := Options{}
+	options := DefaultOptions
 	err = config.Decode(&options)
 	if err != nil {
 		return

--- a/pkg/run/v0/tailer/tailer.go
+++ b/pkg/run/v0/tailer/tailer.go
@@ -43,7 +43,7 @@ var DefaultOptions = tailer.Options{
 func Run(plugins func() discovery.Plugins, name plugin.Name,
 	config *types.Any) (transport plugin.Transport, impls map[run.PluginCode]interface{}, onStop func(), err error) {
 
-	options := tailer.Options{}
+	options := DefaultOptions
 	err = config.Decode(&options)
 	if err != nil {
 		return

--- a/pkg/run/v0/terraform/terraform.go
+++ b/pkg/run/v0/terraform/terraform.go
@@ -74,7 +74,7 @@ var DefaultOptions = Options{
 func Run(plugins func() discovery.Plugins, name plugin.Name,
 	config *types.Any) (transport plugin.Transport, impls map[run.PluginCode]interface{}, onStop func(), err error) {
 
-	options := Options{}
+	options := DefaultOptions
 	err = config.Decode(&options)
 	if err != nil {
 		return


### PR DESCRIPTION
When parsing the `Options` we need to start with the defined defaults so that the default values are honored if the user does not specify a given property.

Currently, the values are defaulted to the type defaults (for example, empty stings, 0 for ints, etc.).

Signed-off-by: Steven Kaufer <kaufer@us.ibm.com>