### PR TITLE
Added support for getting CFN output values in aws metadata plugin

### DIFF
--- a/docs/controller/ingress/example.yml
+++ b/docs/controller/ingress/example.yml
@@ -26,7 +26,7 @@
 #m4fghruao79i        t2                  replicated          1/1                 nginx:latest        *:7777->80/tcp
 #
 # Remove the service
-# docker service rm test1
+# docker service rm t2
 #
 # infrakit simulator/lb1 routes ls  # should be empty
 #

--- a/pkg/provider/aws/plugin/metadata/funcs.go
+++ b/pkg/provider/aws/plugin/metadata/funcs.go
@@ -135,9 +135,19 @@ func cfn(clients AWSClients, name string) (interface{}, error) {
 		parameters[*p.ParameterKey] = p
 	}
 
+	// index outputs by name
+	outputs := map[string]interface{}{}
+	for _, p := range output.Stacks[0].Outputs {
+		if p.OutputKey == nil {
+			continue
+		}
+		outputs[*p.OutputKey] = p
+	}
+
 	// JMESPath package has trouble with fields that are pointers
 	return template.ToMap(map[string]interface{}{
 		"Resources":  resources,
 		"Parameters": parameters,
+		"Outputs":    outputs,
 	})
 }


### PR DESCRIPTION
This allows you to gather values from the cloudformation outputs for a stack. This is helpful when trying to get results from a stack and using it as inputs down stream.

in a template you could do something like this.

```
{{ var "/my/cfn/output" (metadata "var/export/cfn/config/Outputs/MyStackOutput/OutputValue" )}}
```


Signed-off-by: Ken Cochrane <kencochrane@gmail.com>