### PR TITLE
Enrollment controller updates to use instance Properties as key

### DIFF
--- a/pkg/controller/enrollment/enroller.go
+++ b/pkg/controller/enrollment/enroller.go
@@ -46,6 +46,8 @@ type enroller struct {
 
 	// template that we use to render with a source instance.Description to get the link Key
 	sourceKeySelectorTemplate *template.Template
+	// template that we use to render with an enrollment instance.Description to get the link Key
+	enrollmentKeySelectorTemplate *template.Template
 	// template used to render the enrollment's Provision propertiesx
 	enrollmentPropertiesTemplate *template.Template
 }

--- a/pkg/controller/enrollment/set.go
+++ b/pkg/controller/enrollment/set.go
@@ -16,7 +16,7 @@ func index(list instance.Descriptions, getKey keyFunc) (map[string]instance.Desc
 	for _, n := range list {
 		key, err := getKey(n)
 		if err != nil {
-			log.Error("cannot index entry", "instane.Description", n)
+			log.Error("cannot index entry", "instance.Description", n, "err", err)
 			continue
 		}
 		this.Add(key)

--- a/pkg/controller/enrollment/types/types.go
+++ b/pkg/controller/enrollment/types/types.go
@@ -101,6 +101,10 @@ type Options struct {
 	// SourceKeySelector: \{\{ .ID \}\}  # selects the ID field.
 	SourceKeySelector string
 
+	// SourceKeySelector is a string template for selecting the join key from
+	// a enrollment plugin's instance.Description.
+	EnrollmentKeySelector string
+
 	// SyncInterval is the time interval between reconciliation. Syntax
 	// is go's time.Duration string representation (e.g. 1m, 30s)
 	SyncInterval types.Duration

--- a/pkg/plugin/group/scaled.go
+++ b/pkg/plugin/group/scaled.go
@@ -133,7 +133,7 @@ func (s *scaledGroup) Destroy(inst instance.Description, ctx instance.Context) e
 func (s *scaledGroup) List() ([]instance.Description, error) {
 	settings := s.latestSettings()
 
-	return settings.instancePlugin.DescribeInstances(s.memberTags, false)
+	return settings.instancePlugin.DescribeInstances(s.memberTags, true)
 }
 
 func (s *scaledGroup) Label() error {


### PR DESCRIPTION
- Adds support to specify a go template to get the index key from the enrolled instances, this will be a new config `EnrollmentKeySelector` option
- Updates the `DescribeInstances` API call that the group controller invokes on the instance plugin to includes `properties=true` so that the backend instance properites are retrieved and populated.

Signed-off-by: Steven Kaufer <kaufer@us.ibm.com>