### PR TITLE
Ingress controller source key selection support

### DIFF
--- a/pkg/controller/ingress/managed.go
+++ b/pkg/controller/ingress/managed.go
@@ -18,6 +18,7 @@ import (
 	"github.com/docker/infrakit/pkg/spi/group"
 	"github.com/docker/infrakit/pkg/spi/instance"
 	"github.com/docker/infrakit/pkg/spi/loadbalancer"
+	"github.com/docker/infrakit/pkg/template"
 	"github.com/docker/infrakit/pkg/types"
 )
 
@@ -71,6 +72,9 @@ type managed struct {
 	groupClientsLock gsync.RWMutex
 
 	lock gsync.RWMutex
+
+	// template that we use to render with a source instance.Description to get the link Key
+	sourceKeySelectorTemplate *template.Template
 }
 
 func (c *managed) state() ingress.Properties {

--- a/pkg/controller/ingress/types/types.go
+++ b/pkg/controller/ingress/types/types.go
@@ -9,6 +9,7 @@ import (
 	"github.com/docker/infrakit/pkg/spi/group"
 	"github.com/docker/infrakit/pkg/spi/instance"
 	"github.com/docker/infrakit/pkg/spi/loadbalancer"
+	"github.com/docker/infrakit/pkg/template"
 	"github.com/docker/infrakit/pkg/types"
 )
 
@@ -112,4 +113,14 @@ type Options struct {
 	// SyncInterval is how often to run the sync. The syntax is the string form
 	// of Go time.Duration (e.g. 1min)
 	SyncInterval types.Duration
+
+	// SourceKeySelector is a string template for selecting the join key from
+	// a source instance.Description.
+	SourceKeySelector string
+}
+
+// TemplateFrom returns a template after it has un-escapes any escape sequences
+func TemplateFrom(source []byte) (*template.Template, error) {
+	buff := template.Unescape(source)
+	return template.NewTemplate("str://"+string(buff), template.Options{MultiPass: false})
 }


### PR DESCRIPTION
The L4 plugin `Backends` API returns a `[]instance.ID` slice; the values in this slice are indexed against the members of a group.

This commit adds support to use a go template when getting the key from the group members. For example, the L4 plugin `Backends` API could return the registered IP addresses. These IP addresses could then be indexed against the specific specifc IP address property in the `instance.Description` for the group memeber.

The new option on the ingress config yml file is `SourceKeySelector`, see PR #701 for a similar solution in the enrollment controller.
