### PR TITLE
Added an AWS template function that returns AZs

### DIFF
--- a/pkg/provider/aws/plugin/metadata/funcs.go
+++ b/pkg/provider/aws/plugin/metadata/funcs.go
@@ -2,12 +2,13 @@ package metadata
 
 import (
 	"fmt"
-	"reflect"
-
+	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/autoscaling"
 	"github.com/aws/aws-sdk-go/service/cloudformation"
 	"github.com/aws/aws-sdk-go/service/ec2"
 	"github.com/docker/infrakit/pkg/template"
+	"reflect"
+	"sort"
 )
 
 var (
@@ -85,6 +86,38 @@ func describe(clients AWSClients, r *cloudformation.StackResource) (interface{},
 		return f(clients, r)
 	}
 	return nil, ErrNotSupported
+}
+
+// return a list of availablityZones for this region
+func availabilityZones(clients AWSClients) (interface{}, error) {
+
+	// we only want the Azs that are available.
+	input := &ec2.DescribeAvailabilityZonesInput{
+		Filters: []*ec2.Filter{
+			{
+				Name:   aws.String("state"),
+				Values: []*string{aws.String("available")},
+			},
+		},
+	}
+
+	result, err := clients.Ec2.DescribeAvailabilityZones(input)
+	if err != nil {
+		return nil, err
+	}
+
+	zones := []string{}
+	for _, p := range result.AvailabilityZones {
+		if p.ZoneName == nil {
+			// skip if it is nil
+			continue
+		}
+		zones = append(zones, *p.ZoneName)
+	}
+
+	// sort the zones, so we always return in the same order.
+	sort.Strings(zones)
+	return zones, nil
 }
 
 func cfn(clients AWSClients, name string) (interface{}, error) {

--- a/pkg/provider/aws/plugin/metadata/template.go
+++ b/pkg/provider/aws/plugin/metadata/template.go
@@ -186,6 +186,15 @@ func (c *Context) Funcs() []template.Function {
 			},
 		},
 		{
+			Name: "availabilityZones",
+			Description: []string{
+				"returns a list of availablity zones for this region",
+			},
+			Func: func() (interface{}, error) {
+				return availabilityZones(c.clients)
+			},
+		},
+		{
 			Name: "cfn",
 			Description: []string{
 				"cfn takes a string that is the stack name and retrieves the cloudformation data of the stack.",


### PR DESCRIPTION
This PR adds an AWS template function that will return a list of availabilityZones in the current region for the given user.

This will be helpful when spreading out the ec2 instances across the different AZs in a region.


Signed-off-by: Ken Cochrane <kencochrane@gmail.com>