### PR TITLE
Fix CI issue with returned type

### DIFF
--- a/pkg/plugin/flavor/swarm/worker.go
+++ b/pkg/plugin/flavor/swarm/worker.go
@@ -86,6 +86,6 @@ func (s *WorkerFlavor) Drain(flavorProperties *types.Any, inst instance.Descript
 		return nil
 
 	default:
-		return fmt.Errorf("Expected at most one node with label %s, but found %s", link.Value(), nodes)
+		return fmt.Errorf("Expected at most one node with label %s, but found %v", link.Value(), nodes)
 	}
 }


### PR DESCRIPTION
`nodes` is outputting a `%s` when the `NodeList` returns `[]swarm.Node`
Changed the output type to be `%v` to get CI to pass