### PR TITLE
Remove incorrect environment variable for mac

### DIFF
--- a/docs/playbooks/README.md
+++ b/docs/playbooks/README.md
@@ -28,11 +28,6 @@ In your terminal, or add this to your `.bash_profile`:
 ```shell
 export INFRAKIT_HOME=~/.infrakit
 ```
-If you're on the Mac, also
-
-```shell
-export INFRAKIT_HOST=localhost
-```
 
 ## Add a Playbook
 


### PR DESCRIPTION
I've removed the section for mac users, because with setting ```INFRAKIT_HOST=localhost``` no entry in the host file could be found. The entry is named ```INFRAKIT_HOST=docker4mac``` but working without the ```INFRAKIT_HOST```also works perfectly on the mac.