### PR TITLE
Kube support + bootstrapping

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,10 @@
 InfraKit
 ========
 
+[![CircleCI](https://circleci.com/gh/docker/infrakit/tree/master.svg?style=svg&circle-token=50d2063f283f98b7d94746416c979af3102275b5)](https://circleci.com/gh/docker/infrakit/tree/master)
+<!--
 [![Circle CI](https://circleci.com/gh/docker/infrakit.png?style=shield&circle-token=50d2063f283f98b7d94746416c979af3102275b5)](https://circleci.com/gh/docker/infrakit)
+-->
 [![Go Report Card](https://goreportcard.com/badge/github.com/docker/infrakit)](https://goreportcard.com/report/github.com/docker/infrakit)
 <!--
 [![codecov.io](https://codecov.io/github/docker/infrakit/coverage.svg?branch=master&token=z08ZKeIJfA)](https://codecov.io/github/docker/infrakit?branch=master)

--- a/README.md
+++ b/README.md
@@ -1,7 +1,8 @@
 InfraKit
 ========
-
+<!--
 [![CircleCI](https://circleci.com/gh/docker/infrakit/tree/master.svg?style=svg&circle-token=50d2063f283f98b7d94746416c979af3102275b5)](https://circleci.com/gh/docker/infrakit/tree/master)
+-->
 <!--
 [![Circle CI](https://circleci.com/gh/docker/infrakit.png?style=shield&circle-token=50d2063f283f98b7d94746416c979af3102275b5)](https://circleci.com/gh/docker/infrakit)
 -->

--- a/README.md
+++ b/README.md
@@ -1,8 +1,6 @@
 InfraKit
 ========
-<!--
 [![CircleCI](https://circleci.com/gh/docker/infrakit/tree/master.svg?style=svg&circle-token=50d2063f283f98b7d94746416c979af3102275b5)](https://circleci.com/gh/docker/infrakit/tree/master)
--->
 <!--
 [![Circle CI](https://circleci.com/gh/docker/infrakit.png?style=shield&circle-token=50d2063f283f98b7d94746416c979af3102275b5)](https://circleci.com/gh/docker/infrakit)
 -->

--- a/cmd/infrakit/util/init/init.go
+++ b/cmd/infrakit/util/init/init.go
@@ -1,0 +1,198 @@
+package init
+
+import (
+	"fmt"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/docker/infrakit/pkg/cli"
+	"github.com/docker/infrakit/pkg/discovery"
+	"github.com/docker/infrakit/pkg/launch"
+	logutil "github.com/docker/infrakit/pkg/log"
+	"github.com/docker/infrakit/pkg/plugin"
+	group_types "github.com/docker/infrakit/pkg/plugin/group/types"
+	flavor_rpc "github.com/docker/infrakit/pkg/rpc/flavor"
+	run "github.com/docker/infrakit/pkg/run/manager"
+	group_kind "github.com/docker/infrakit/pkg/run/v0/group"
+	manager_kind "github.com/docker/infrakit/pkg/run/v0/manager"
+	"github.com/docker/infrakit/pkg/spi/group"
+	"github.com/docker/infrakit/pkg/spi/instance"
+	"github.com/docker/infrakit/pkg/types"
+	"github.com/spf13/cobra"
+)
+
+var log = logutil.New("module", "util/init")
+
+func startPlugins(plugins func() discovery.Plugins, services *cli.Services,
+	configURL string, starts []string) (*run.Manager, error) {
+
+	parsedRules := []launch.Rule{}
+
+	if configURL != "" {
+		buff, err := services.ProcessTemplate(configURL)
+		if err != nil {
+			return nil, err
+		}
+		view, err := services.ToJSON([]byte(buff))
+		if err != nil {
+			return nil, err
+		}
+		configs := types.AnyBytes(view)
+		err = configs.Decode(&parsedRules)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	pluginManager, err := run.ManagePlugins(parsedRules, plugins, true, 5*time.Second)
+	if err != nil {
+		return nil, err
+	}
+
+	for _, arg := range starts {
+
+		p := strings.Split(arg, "=")
+		execName := "inproc" // default is to use inprocess goroutine for running plugins
+		if len(p) > 1 {
+			execName = p[1]
+		}
+
+		// the format is kind[:{plugin_name}][={os|inproc}]
+		pp := strings.Split(p[0], ":")
+		kind := pp[0]
+		name := plugin.Name(kind)
+
+		// This is some special case for the legacy setup (pre v0.6)
+		switch kind {
+		case manager_kind.Kind:
+			name = plugin.Name(manager_kind.LookupName)
+		case group_kind.Kind:
+			name = plugin.Name(group_kind.LookupName)
+		}
+		// customized by user as override
+		if len(pp) > 1 {
+			name = plugin.Name(pp[1])
+		}
+
+		log.Info("Launching", "kind", kind, "name", name)
+		err = pluginManager.Launch(execName, kind, name, nil)
+		if err != nil {
+			log.Warn("failed to launch", "exec", execName, "kind", kind, "name", name)
+		}
+	}
+	return pluginManager, nil
+}
+
+// Command returns the cobra command
+func Command(plugins func() discovery.Plugins) *cobra.Command {
+
+	services := cli.NewServices(plugins)
+
+	cmd := &cobra.Command{
+		Use:   "init <groups template URL | - >",
+		Short: "Generates the init script",
+	}
+
+	cmd.Flags().AddFlagSet(services.ProcessTemplateFlags)
+	groupID := cmd.Flags().String("group-id", "", "Group ID")
+
+	configURL := cmd.Flags().String("config-url", "", "URL for the startup configs")
+	starts := cmd.Flags().StringSlice("start", []string{}, "start spec for plugin just like infrakit plugin start")
+
+	cmd.RunE = func(c *cobra.Command, args []string) error {
+
+		if len(args) != 1 {
+			cmd.Usage()
+			os.Exit(1)
+		}
+
+		logutil.Configure(&logutil.Options{
+			Level:    3,
+			Stdout:   false,
+			Format:   "term",
+			CallFunc: true,
+		})
+
+		pluginManager, err := startPlugins(plugins, services, *configURL, *starts)
+		if err != nil {
+			return err
+		}
+		defer func() {
+			pluginManager.TerminateAll()
+			pluginManager.WaitForAllShutdown()
+			pluginManager.Stop()
+		}()
+
+		pluginManager.WaitStarting()
+
+		input, err := services.ReadFromStdinIfElse(
+			func() bool { return args[0] == "-" },
+			func() (string, error) { return services.ProcessTemplate(args[0]) },
+			services.ToJSON,
+		)
+		if err != nil {
+			return err
+		}
+
+		// TODO - update the schema -- this matches the current Plugin/Properties schema
+		type spec struct {
+			Plugin     plugin.Name
+			Properties struct {
+				ID         group.ID
+				Properties group_types.Spec
+			}
+		}
+
+		specs := []spec{}
+		err = types.AnyString(input).Decode(&specs)
+		if err != nil {
+			return err
+		}
+
+		var groupSpec *group_types.Spec
+		for _, s := range specs {
+			if string(s.Properties.ID) == *groupID {
+				copy := s.Properties.Properties
+				groupSpec = &copy
+				break
+			}
+		}
+
+		if groupSpec == nil {
+			return fmt.Errorf("no such group: %v", *groupID)
+		}
+
+		// Get the flavor properties and use that to call the prepare of the Flavor to generate the init
+		endpoint, err := plugins().Find(groupSpec.Flavor.Plugin)
+		if err != nil {
+			return err
+		}
+
+		flavorPlugin, err := flavor_rpc.NewClient(groupSpec.Flavor.Plugin, endpoint.Address)
+		if err != nil {
+			return err
+		}
+
+		cli.MustNotNil(flavorPlugin, "flavor plugin not found", "name", groupSpec.Flavor.Plugin.String())
+
+		instanceSpec := instance.Spec{}
+		if len(groupSpec.Allocation.LogicalIDs) > 0 {
+			lid := instance.LogicalID(groupSpec.Allocation.LogicalIDs[0])
+			instanceSpec.LogicalID = &lid
+		}
+
+		instanceSpec, err = flavorPlugin.Prepare(groupSpec.Flavor.Properties, instanceSpec,
+			groupSpec.Allocation,
+			group_types.Index{Group: group.ID(*groupID), Sequence: 0})
+
+		if err != nil {
+			return err
+		}
+
+		fmt.Print(instanceSpec.Init)
+		return nil
+	}
+
+	return cmd
+}

--- a/cmd/infrakit/util/util.go
+++ b/cmd/infrakit/util/util.go
@@ -2,6 +2,7 @@ package util
 
 import (
 	"github.com/docker/infrakit/cmd/infrakit/base"
+	init_cmd "github.com/docker/infrakit/cmd/infrakit/util/init"
 	"github.com/docker/infrakit/cmd/infrakit/util/mux"
 	"github.com/docker/infrakit/pkg/discovery"
 	"github.com/docker/infrakit/pkg/log"
@@ -24,6 +25,7 @@ func Command(plugins func() discovery.Plugins) *cobra.Command {
 
 	util.AddCommand(
 		mux.Command(plugins),
+		init_cmd.Command(plugins),
 		fileServerCommand(plugins),
 		trackCommand(plugins),
 	)

--- a/dockerfiles/Dockerfile.bundle
+++ b/dockerfiles/Dockerfile.bundle
@@ -5,7 +5,7 @@ RUN apk add --update wget ca-certificates openssl libvirt-dev openssh
 RUN mkdir -p /infrakit/plugins /infrakit/configs /infrakit/logs /infrakit/cli /infrakit/instance/terraform
 
 VOLUME /infrakit
-
+WORKDIR /infrakit
 ENV INFRAKIT_HOME /infrakit
 
 # Defined in pkg/discovery

--- a/pkg/cli/services.go
+++ b/pkg/cli/services.go
@@ -57,7 +57,7 @@ func NewServices(plugins func() discovery.Plugins) *Services {
 }
 
 // ProcessTemplateFunc is the function that processes the template at url and returns view or error.
-type ProcessTemplateFunc func(url string) (rendered string, err error)
+type ProcessTemplateFunc func(url string, ctx ...interface{}) (rendered string, err error)
 
 // ToJSONFunc converts the input buffer to json format
 type ToJSONFunc func(in []byte) (json []byte, err error)
@@ -157,7 +157,7 @@ func templateProcessor(plugins func() discovery.Plugins) (*pflag.FlagSet, ToJSON
 
 		},
 		// ProcessTemplateFunc
-		func(url string) (view string, err error) {
+		func(url string, ctx ...interface{}) (view string, err error) {
 
 			if !strings.Contains(url, "://") {
 				p := url
@@ -199,7 +199,11 @@ func templateProcessor(plugins func() discovery.Plugins) (*pflag.FlagSet, ToJSON
 
 			configureTemplate(engine, plugins)
 
-			view, err = engine.Render(nil)
+			contextObject := (interface{})(nil)
+			if len(ctx) == 1 {
+				contextObject = ctx[0]
+			}
+			view, err = engine.Render(contextObject)
 			if err != nil {
 				return
 			}

--- a/pkg/plugin/flavor/kubernetes/flavor.go
+++ b/pkg/plugin/flavor/kubernetes/flavor.go
@@ -282,9 +282,8 @@ func (s *baseFlavor) prepare(role string, flavorProperties *types.Any, instanceS
 			if err := ioutil.WriteFile(tokenPath, []byte(token), 0666); err != nil {
 				log.Error("can't write token", "path", tokenPath, "err", err)
 				return instanceSpec, err
-			} else {
-				log.Info("written token", "path", tokenPath)
 			}
+			log.Info("written token", "path", tokenPath)
 
 		}
 

--- a/pkg/plugin/flavor/kubernetes/manager-init.sh
+++ b/pkg/plugin/flavor/kubernetes/manager-init.sh
@@ -9,7 +9,10 @@ set -o xtrace
 {{/* Install Kubeadm */}}
 {{ include "install-kubeadm.sh" }}
 
+{{ if BOOTSTRAP }}
+# Bootstrap node -- init cluster and install add-ons
 kubeadm init --token {{ KUBEADM_JOIN_TOKEN }}
+
 export KUBECONFIG=/etc/kubernetes/admin.conf
 {{ if ADDON "network" }}
     kubectl apply -f {{ ADDON "network" }}
@@ -18,4 +21,9 @@ export KUBECONFIG=/etc/kubernetes/admin.conf
 {{ if ADDON "visualise" }}
     kubectl apply -f {{ ADDON "visualise" }}
 {{ else }}
+{{ end }}
+
+{{ if WORKER }}
+# Manager node but because we are doing a single master control plane, we will just reuse the node as worker
+kubeadm join --token {{ KUBEADM_JOIN_TOKEN }} {{ KUBE_JOIN_IP }}:{{ BIND_PORT }}
 {{ end }}

--- a/pkg/plugin/flavor/kubernetes/templates.go
+++ b/pkg/plugin/flavor/kubernetes/templates.go
@@ -9,16 +9,23 @@ set -o errexit
 set -o nounset
 set -o xtrace
 
+{{ if BOOTSTRAP }}
+# Bootstrap
 kubeadm init --token {{ KUBEADM_JOIN_TOKEN }}
 export KUBECONFIG=/etc/kubernetes/admin.conf
 {{ if ADDON "network" }}
     kubectl apply -f {{ ADDON "network" }}
-{{ else }}
 {{ end }}
 {{ if ADDON "visualise" }}
     kubectl apply -f {{ ADDON "visualise" }}
-{{ else }}
 {{ end }}
+{{ end }}{{/* bootstrap */}}
+
+{{ if WORKER }}
+# Manager node but because we are doing a single master control plane, we will just reuse the node as worker
+kubeadm join --token {{ KUBEADM_JOIN_TOKEN }} {{ KUBE_JOIN_IP }}:{{ BIND_PORT }}
+{{ end }}{{/* worker */}}
+
 `
 
 	// DefaultWorkerInitScriptTemplate is the default template for the init script which

--- a/pkg/plugin/flavor/kubernetes/worker.go
+++ b/pkg/plugin/flavor/kubernetes/worker.go
@@ -4,19 +4,22 @@ import (
 	"github.com/docker/infrakit/pkg/discovery"
 	group_types "github.com/docker/infrakit/pkg/plugin/group/types"
 	"github.com/docker/infrakit/pkg/spi/instance"
-	"github.com/docker/infrakit/pkg/template"
 	"github.com/docker/infrakit/pkg/types"
 )
 
 // NewWorkerFlavor creates a flavor.Plugin that creates manager and worker nodes connected in a kubernetes.
-func NewWorkerFlavor(plugins func() discovery.Plugins,
-	templ *template.Template,
-	dir string,
-	stop <-chan struct{}) *WorkerFlavor {
+func NewWorkerFlavor(plugins func() discovery.Plugins, options Options, stop <-chan struct{}) (*WorkerFlavor, error) {
 
-	base := &baseFlavor{initScript: templ, plugins: plugins, kubeConfDir: dir}
+	wt, err := getTemplate(options.DefaultWorkerInitScriptTemplate,
+		DefaultWorkerInitScriptTemplate, DefaultTemplateOptions)
+
+	if err != nil {
+		return nil, err
+	}
+
+	base := &baseFlavor{initScript: wt, plugins: plugins, options: options}
 	//	base.metadataPlugin = metadata.NewPluginFromChannel(base.runMetadataSnapshot(stop))
-	return &WorkerFlavor{baseFlavor: base}
+	return &WorkerFlavor{baseFlavor: base}, nil
 }
 
 // WorkerFlavor is the flavor for kubernetes workers

--- a/pkg/plugin/flavor/swarm/flavor.go
+++ b/pkg/plugin/flavor/swarm/flavor.go
@@ -322,6 +322,10 @@ func (s *baseFlavor) prepare(role string, flavorProperties *types.Any, instanceS
 		}
 	}
 
+	if instanceSpec.Tags == nil {
+		instanceSpec.Tags = map[string]string{}
+	}
+
 	// TODO(wfarner): Use the cluster UUID to scope instances for this swarm separately from instances in another
 	// swarm.  This will require plumbing back to Scaled (membership tags).
 	instanceSpec.Tags["swarm-id"] = swarmID

--- a/pkg/rpc/client/client.go
+++ b/pkg/rpc/client/client.go
@@ -49,7 +49,6 @@ func New(address string, api spi.InterfaceSpec) (Client, error) {
 	cl := &handshakingClient{client: unvalidatedClient, iface: api, lock: &sync.Mutex{}}
 	// check handshake
 	if err := cl.handshake(); err != nil {
-		log.Error("handshaking", "err", err)
 		// Note - we still return the client with the possibility of doing a handshake later on
 		// if we provide an api for the plugin to recheck later.  This way, individual components
 		// can stay running and recalibrate themselves after the user has corrected the problems.


### PR DESCRIPTION
This PR:

  + Improved Kube support by allowing specification of the control plane nodes for the kube cluster via new `ControlPlane` field.  This is necessary for self-starting a kube cluster where all the nodes are part of the cluster (instead of the current N+1 configuration, where the 0th node is used to run just infrakit).  In this case, we allow specification of a set of nodes for a control plane (for HA infrakit) and the Kube control plane is a strict subset of those nodes (which are designated via the `ControlPlane` field).  If you want to use a single master kube, then specify the `ControlPlane` field with the logical ID (usually the IP address) of the kube master.  We will support multi-master HA set up for kube where each Infrakit node is also a kube master.  This PR support a single master.
  + Added a `infrakit util init` command.  This command takes a groups.json and renders the Init for a member of the group of your choice.  With this, you can get a Init script for the initial boot node.  With this, you can get the join tokens via the `kubeadm` inside the kubernetes flavor.  

Example:

On AWS if you have a single node.. you can then call `infrakit util init` as your cloud init or pipe to a shell:
```json
 "UserData" : {
  "Fn::Base64" : {
     "Fn::Join" : [ "", [
       "#!/bin/sh \n",
       {  "Fn::FindInMap": [ "AMISelector", { "Ref" : "PreinstalledDockerAMI" }, "userdata" ]  },
       "mkdir -p /infrakit\n",
       "docker swarm init\n",
       "docker run --rm -v /var/run/docker.sock:/var/run/docker.sock -v /infrakit:/infrakit ",
	"-e INFRAKIT_FLAVOR_KUBERNETES_CONFIG_DIR=/infrakit ",
	{"Ref":"Infrakit"},
        " infrakit util init --group-id kube-managers --start combo --start swarm --start kubernetes ",
            " --var /cluster/name=", {"Ref":"AWS::StackName"},
            " --var /cluster/size=", {"Ref":"ClusterSize"},
            " --var /infrakit/config/root=", {"Ref":"InfrakitConfigRoot"},
            " --var /infrakit/metadata/configURL=", {"Ref":"MetadataExportTemplate"},
            " --var /provider/image/hasDocker=", {
                      "Fn::FindInMap": ["AMISelector", { "Ref":"PreinstalledDockerAMI" }, "hasDocker"]
                   },
            " --var /infrakit/docker/image=", {"Ref":"Infrakit"}, " ",  {"Ref":"InfrakitConfigRoot"}, "/groups.json",    " | tee /var/lib/infrakit.boot | sh \n"
          ]]
         }
        },
```
In this example, in CloudFormation, the first node's init is generated by infrakit itself.  This ensures the first node has the same configurations as the second, and third nodes later.

The config looks like below.  Note the configuration of the manager is a combination of swarm mode and kubernetes, with kube control plane being a subset of the the swarm mode control plane / managers:
```
{
   "Plugin": "group",
    "Properties": {
       "ID": "kube-managers",
       "Properties": {
           "Allocation": {
               "LogicalIDs": {{ $managerIPs | jsonEncode }}
            },
           "Flavor": {
	       "Plugin" : "combo",
	       "Properties" : [
		    {
		       "Plugin": "swarm/manager",
		       "Properties": {
				"Attachments" : {
				    "{{index $managerIPs 0}}" : [
					{ "ID":"{{index $managerIPs 0}}", "Type":"ebs" }
				    ],
				    "{{index $managerIPs 1}}" : [
					{ "ID":"{{index $managerIPs 1}}", "Type":"ebs" }
				    ],
				    "{{index $managerIPs 2}}" : [
					{ "ID":"{{index $managerIPs 2}}", "Type":"ebs" }
				    ]
				},
				"InitScriptTemplateURL": "{{ $managerInit }}",
				"SwarmJoinIP": "{{ $swarmLeaderIP }}",
				"Docker" : {
				    "Host" : "{{ $dockerEngine }}"
				}
			    }
	            },
	            {
		        "Plugin": "kubernetes/manager",
			"Properties": {
			  "InitScriptTemplateURL": "{{ var `/infrakit/config/root` }}/kube-managers-init.sh",
			  "KubeAddOns": [
				    {
					"Name": "calico",
					"Path": "http://docs.projectcalico.org/v2.2/getting-started/kubernetes/installation/hosted/kubeadm/1.6/calico.yaml",
					"Type": "network"
				    },
				    {
					"Name": "kubedash",
					"Path": "https://raw.githubusercontent.com/kubernetes/dashboard/master/src/deploy/recommended/kubernetes-dashboard.yaml",
					"Type": "visualise"
				    }
				],
				"KubeBindPort": 6443,
				"KubeJoinIP": "{{ var `/cluster/kube/join/ip` }}",
				"KubeClusterID" : "{{ var `/cluster/name`}}",
				"SkipManagerValidation" : true,
				"ControlPlane" : [ "{{ index $managerIPs 0 }}" ]
			    }
			}
		    ]
                },
                "Instance": {{ $myGroups.Managers | jsonEncode }}
            }
        }
```
For an example of a self-bootstrapping Kube cluster... see [here](https://github.com/chungers/examples/tree/master/latest/kube)

TODO 
   + Implement node Taint / Drain for node terminations.  Apparently kube likes to keep the nodes hanging around even after they have been terminated.  Swarm mode seems to be much better at handling this.
   + Do health check of the node via api call.  Kublets take more time to join the cluster than Swarm nodes.  Some type of sanity check / health check would be nice.

@YujiOshima 