### PR TITLE
make libvirt optional

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,6 +14,9 @@ E2E_TESTS?=true
 #Source file target
 SRCS  := $(shell find . -type f -name '*.go')
 
+# Set the go build tags here.  By default we disable building of libvirt
+GO_BUILD_TAGS?=nolibvirt
+
 # Allow turning off function inlining and variable registerization
 ifeq (${DISABLE_OPTIMIZATION},true)
 	GO_GCFLAGS=-gcflags "-N -l"
@@ -88,7 +91,7 @@ clean:
 
 define binary_target_template
 build/$(1): $(SRCS)
-	go build -o build/$(1)$(EXE_EXT) \
+	go build -o build/$(1)$(EXE_EXT) -tags $(GO_BUILD_TAGS) \
 		-ldflags "-X github.com/docker/infrakit/pkg/cli.Version=$(VERSION) -X github.com/docker/infrakit/pkg/cli.Revision=$(REVISION) -X github.com/docker/infrakit/pkg/util/docker.ClientVersion=$(DOCKER_CLIENT_VERSION)" $(2)
 endef
 define define_binary_target

--- a/cmd/infrakit/libvirt.go
+++ b/cmd/infrakit/libvirt.go
@@ -1,0 +1,7 @@
+// +build libvirt
+
+package main
+
+import (
+	_ "github.com/docker/infrakit/pkg/run/v0/libvirt"
+)

--- a/cmd/infrakit/main.go
+++ b/cmd/infrakit/main.go
@@ -53,7 +53,6 @@ import (
 	_ "github.com/docker/infrakit/pkg/run/v0/image"
 	_ "github.com/docker/infrakit/pkg/run/v0/ingress"
 	_ "github.com/docker/infrakit/pkg/run/v0/kubernetes"
-	_ "github.com/docker/infrakit/pkg/run/v0/libvirt"
 	_ "github.com/docker/infrakit/pkg/run/v0/maas"
 	_ "github.com/docker/infrakit/pkg/run/v0/manager"
 	_ "github.com/docker/infrakit/pkg/run/v0/oracle"

--- a/cmd/infrakit/plugin/plugin.go
+++ b/cmd/infrakit/plugin/plugin.go
@@ -151,6 +151,8 @@ func Command(plugins func() discovery.Plugins) *cobra.Command {
 
 		parsedRules := []launch.Rule{}
 
+		log.Info("config", "url", *configURL)
+
 		if *configURL != "" {
 			buff, err := processTemplate(*configURL)
 			if err != nil {

--- a/dockerfiles/Dockerfile.installer
+++ b/dockerfiles/Dockerfile.installer
@@ -1,12 +1,11 @@
 FROM golang:1.8-alpine
 
-RUN apk add --update git make gcc musl-dev wget ca-certificates openssl libvirt-dev git openssh
+RUN apk add --update git make gcc musl-dev wget ca-certificates openssl libvirt-dev libvirt-lxc libvirt-qemu git openssh
 
 ENV GOPATH /go
 ENV PATH /go/bin:$PATH
 
 COPY dockerfiles/build-infrakit /usr/local/bin/
-COPY dockerfiles/build-hyperkit /usr/local/bin/
 
 # Add source code
 Add . /go/src/github.com/docker/infrakit/

--- a/docs/install
+++ b/docs/install
@@ -2,7 +2,7 @@
 
 # Installs infrakit by cross compiling locally inside a docker container.
 
-if [[ "$(which docker)" == "" ]]; then
+if [ "$(which docker)" = "" ]; then
     echo "You must have Docker locally."
     exit -1
 fi
@@ -22,5 +22,5 @@ case "$(uname)" in
 esac
 
 
-docker run --rm -v $dir:/build infrakit/installer build-infrakit $target
+docker run --rm -v $dir:/build infrakit/installer:latest build-infrakit $target
 sudo cp ./infrakit /usr/local/bin


### PR DESCRIPTION
This PR makes the inclusion of libvirt in the core binary optional.

To build with libvirt enabled: 
```
GO_BUILD_TAGS=libvirt make build/infrakit
```

This will include libvirt.  libvirt go binding used here isn't a pure Go binding so many users have run into problems with building locally.   Cross compilation and linking statically of `infrakit` with libvirt will be fixed in a future PR.  Currently there are some problems with `-extldflags '-static'` when cross compiling libvirt inside a container.

Signed-off-by: David Chung <david.chung@docker.com>