### PR TITLE
Optionally block and retry metadata reads

### DIFF
--- a/pkg/cli/v0/event/ls.go
+++ b/pkg/cli/v0/event/ls.go
@@ -69,13 +69,20 @@ func Ls(name string, services *cli.Services) *cobra.Command {
 				}
 			}
 
+			// list paths relative to this path
+			rel := types.PathFromString(p)
+			if gopath.Dir(name) != "." {
+				// the name has / in it. so the relative path is longer
+				// ex) timer/streams and streams/msec/
+				rel = types.PathFromString(name).Shift(1).Join(rel)
+			}
 			if p == "." && !*all {
 				// special case of showing the top level plugin namespaces
 				if i > 0 && !*quick {
 					fmt.Println()
 				}
 				for _, l := range nodes {
-					fmt.Println(l.Shift(1).Rel(types.PathFromString(p)))
+					fmt.Println(l.Rel(rel))
 				}
 				break
 			}
@@ -84,7 +91,7 @@ func Ls(name string, services *cli.Services) *cobra.Command {
 				fmt.Printf("total %d:\n", len(nodes))
 			}
 			for _, l := range nodes {
-				fmt.Println(l.Shift(1).Rel(types.PathFromString(p)))
+				fmt.Println(l.Rel(rel))
 			}
 
 		}

--- a/pkg/plugin/metadata/updatable.go
+++ b/pkg/plugin/metadata/updatable.go
@@ -9,7 +9,10 @@ import (
 	"github.com/imdario/mergo"
 )
 
-var log = logutil.New("module", "plugin/metadata/updatable")
+var (
+	log    = logutil.New("module", "plugin/metadata/updatable")
+	debugV = logutil.V(300)
+)
 
 // LoadFunc is the function for returning the original to modify
 type LoadFunc func() (original *types.Any, err error)
@@ -51,20 +54,20 @@ func (p updatable) Changes(changes []metadata.Change) (original, proposed *types
 	if err != nil {
 		return
 	}
-	log.Info("original", "original", original.String())
+	log.Debug("original", "original", original.String(), "V", debugV)
 
 	var current map[string]interface{}
 	if err = original.Decode(&current); err != nil {
 		return
 	}
-	log.Info("decoded", "current", current)
+	log.Debug("decoded", "current", current, "V", debugV)
 
 	changeSet, e := changeSet(changes)
 	if e != nil {
 		err = e
 		return
 	}
-	log.Info("changeset", "changeset", changeSet)
+	log.Debug("changeset", "changeset", changeSet, "V", debugV)
 
 	var applied map[string]interface{}
 	if err = changeSet.Decode(&applied); err != nil {
@@ -75,7 +78,7 @@ func (p updatable) Changes(changes []metadata.Change) (original, proposed *types
 		return
 	}
 
-	log.Info("decoded2", "applied", applied)
+	log.Debug("decoded2", "applied", applied, "V", debugV)
 
 	// encoded it back to bytes
 	proposed, err = types.AnyValue(applied)
@@ -83,7 +86,7 @@ func (p updatable) Changes(changes []metadata.Change) (original, proposed *types
 		return
 	}
 
-	log.Info("proposed", "proposed", proposed.String())
+	log.Debug("proposed", "proposed", proposed.String(), "V", debugV)
 
 	cas = types.Fingerprint(original, proposed)
 	return


### PR DESCRIPTION
This PR adds the ability to block and retry a read of metadata:

  + The `metadata cat` command verb has now new options that, when set, will cause 
retry and timeout if there is no value at the given path.  For example:

```
infrakit vars metadata cat not/there --retry 20s
```
will attempt to read from the `vars` plugin at the path `not/there`.  If there is no value, the read will be retried 20 seconds later.  You can add a timeout:

```
infrakit vars metadata cat not/there --retry 1s --timeout 30s
```
This will try every second, and times out after 30 seconds.  There's an option to return an error or simply return a `false` for nil value.

  + The `metadata` template function now has the following forms:

```
{{ metadata `vars/not/here` `1s` `20s` false | default `hi`}}
```
means render the template with the `not/here` variable from `vars` plugin, retry every second until the value returns or times out after 20 seconds.  On timeout, do not return error and instead allows us to pipe to another function that prints the default value `hi`.

You can test it with a literal template in the command line:

```
 infrakit template 'str://{{ metadata `vars/not/here` `1s` `20s` false | default `hi`}}'
```

Why this is interesting:

A metadata read is actually a RPC to an addressed object implementing the Metadata SPI.  The Updatable SPI is actually a server that allows multiple clients to read / write metadata values.  With this change, we can now have one template that is being rendered (aka a thread / process) block on presence of a value.  Another client, possibly via the CLI, can set the value.  Once the value is set, the blocked process can continue.   This can be used to implement special cases such as blocking on a user input (e.g. an oauth token) before rendering the templates to provision an instance.  All processes depending on that value will block, until the user updates the value via the CLI or some other means.

Signed-off-by: David Chung david.chung@docker.com