### PR TITLE
plugin start / catching panics / recover

### DIFF
--- a/cmd/infrakit/plugin/plugin.go
+++ b/cmd/infrakit/plugin/plugin.go
@@ -139,7 +139,7 @@ func Command(plugins func() discovery.Plugins) *cobra.Command {
 	}
 
 	configURL := start.Flags().String("config-url", "", "URL for the startup configs")
-	mustAll := start.Flags().Bool("all", true, "Panic if any plugin fails to start")
+	mustAll := start.Flags().Bool("all", false, "Panic if any plugin fails to start")
 	templateFlags, toJSON, _, processTemplate := base.TemplateProcessor(plugins)
 	start.Flags().AddFlagSet(templateFlags)
 
@@ -175,7 +175,15 @@ func Command(plugins func() discovery.Plugins) *cobra.Command {
 		if err != nil {
 			return err
 		}
-		defer pluginManager.Stop()
+		defer func() {
+			if r := recover(); r != nil {
+				log.Error("Error occurred. Recovered but exiting.", "err", r)
+				pluginManager.TerminateRunning()
+			}
+			pluginManager.WaitForAllShutdown()
+			log.Info("All plugins shutdown")
+			pluginManager.Stop()
+		}()
 
 		if len(args) == 0 {
 
@@ -227,9 +235,6 @@ func Command(plugins func() discovery.Plugins) *cobra.Command {
 		pluginManager.WaitStarting()
 
 		log.Info("Done waiting on plugin starts")
-
-		pluginManager.WaitForAllShutdown()
-		log.Info("All plugins shutdown")
 
 		return nil
 	}

--- a/pkg/cli/v0/event/cmd.go
+++ b/pkg/cli/v0/event/cmd.go
@@ -15,7 +15,8 @@ var log = logutil.New("module", "cli/v1/event")
 func init() {
 	cli.Register(event.InterfaceSpec,
 		[]cli.CmdBuilder{
-			Event,
+			Ls,
+			Tail,
 		})
 }
 

--- a/pkg/cli/v0/event/ls.go
+++ b/pkg/cli/v0/event/ls.go
@@ -14,8 +14,8 @@ import (
 func Ls(name string, services *cli.Services) *cobra.Command {
 
 	ls := &cobra.Command{
-		Use:   "ls",
-		Short: "List event",
+		Use:   "topics",
+		Short: "List event topics",
 	}
 
 	long := ls.Flags().BoolP("long", "l", false, "Print full path")

--- a/pkg/cli/v0/metadata/cmd.go
+++ b/pkg/cli/v0/metadata/cmd.go
@@ -13,13 +13,24 @@ import (
 var log = logutil.New("module", "cli/v1/metadata")
 
 func init() {
+	// cli.Register(metadata.InterfaceSpec,
+	// 	[]cli.CmdBuilder{
+	// 		Metadata,
+	// 	})
+	// cli.Register(metadata.UpdatableInterfaceSpec,
+	// 	[]cli.CmdBuilder{
+	// 		Updatable,
+	// 	})
 	cli.Register(metadata.InterfaceSpec,
 		[]cli.CmdBuilder{
-			Metadata,
+			Ls,
+			Cat,
 		})
 	cli.Register(metadata.UpdatableInterfaceSpec,
 		[]cli.CmdBuilder{
-			Updatable,
+			Ls,
+			Cat,
+			Change,
 		})
 }
 

--- a/pkg/cli/v0/metadata/ls.go
+++ b/pkg/cli/v0/metadata/ls.go
@@ -15,7 +15,7 @@ import (
 func Ls(name string, services *cli.Services) *cobra.Command {
 
 	ls := &cobra.Command{
-		Use:   "ls",
+		Use:   "vars",
 		Short: "List metadata",
 	}
 


### PR DESCRIPTION
Closes #696 

This PR adds some `recover` code to avoid crashing the process when a plugin panics.
It also simplifies the command line verbs for the metadata and events plugins.  Specifically:

```
infrakit vars metadata [ls | cat | change]
```
is now

```
infrakit vars [vars | cat | change ]
```
and for events, the `event` subcommand has been removed to reduce typing:

```
infrakit time/streams event [ls | tail]
```
is now

```
infrakit time/streams [topics | tail]
```

Signed-off-by: David Chung <david.chung@docker.com>