### PR TITLE
Handle errors when walking the fs in tf instance provider

### DIFF
--- a/pkg/provider/terraform/instance/apply.go
+++ b/pkg/provider/terraform/instance/apply.go
@@ -171,6 +171,10 @@ func (p *plugin) handleFiles(fns tfFuncs) error {
 	fs := &afero.Afero{Fs: p.fs}
 	err = fs.Walk(p.Dir,
 		func(path string, info os.FileInfo, err error) error {
+			if err != nil {
+				log.Debugf("Ignoring file %s due to error: %s", path, err)
+				return nil
+			}
 			// Only the VM files are valid for pruning; once pruned then the group controller polling will
 			// ensure that a replacement is created. There is no mechanism that ensures consistency for
 			// dedicated and global resources.

--- a/pkg/provider/terraform/instance/plugin.go
+++ b/pkg/provider/terraform/instance/plugin.go
@@ -380,8 +380,11 @@ func (p *plugin) scanLocalFiles() (map[TResourceType]map[TResourceName]TResource
 	fs := &afero.Afero{Fs: p.fs}
 	// just scan the directory for the instance-*.tf.json files
 	err := fs.Walk(p.Dir,
-
 		func(path string, info os.FileInfo, err error) error {
+			if err != nil {
+				log.Debugf("Ignoring file %s due to error: %s", path, err)
+				return nil
+			}
 			matches := instanceTfFileRegex.FindStringSubmatch(info.Name())
 
 			if len(matches) == 4 {
@@ -820,6 +823,10 @@ func (p *plugin) listCurrentTfFiles() (map[string]map[TResourceType]map[TResourc
 	fs := &afero.Afero{Fs: p.fs}
 	err := fs.Walk(p.Dir,
 		func(path string, info os.FileInfo, err error) error {
+			if err != nil {
+				log.Debugf("Ignoring file %s due to error: %s", path, err)
+				return nil
+			}
 			matches := tfFileRegex.FindStringSubmatch(info.Name())
 			if len(matches) == 3 {
 				buff, err := ioutil.ReadFile(filepath.Join(p.Dir, info.Name()))
@@ -1078,6 +1085,10 @@ func (p *plugin) doDestroy(inst instance.ID, processAttach, executeTfApply bool)
 			fs := &afero.Afero{Fs: p.fs}
 			err = fs.Walk(p.Dir,
 				func(path string, info os.FileInfo, err error) error {
+					if err != nil {
+						log.Debugf("Ignoring file %s due to error: %s", path, err)
+						return nil
+					}
 					matches := instanceTfFileRegex.FindStringSubmatch(info.Name())
 					// Note that the current instance (being destroyed) still exists; filter
 					// this file out.


### PR DESCRIPTION
When walking the directory we need to check if an error is passed in and, if so, not process that entry since the associated `os.FileInfo` is `nil`.

This appears to happen when a file has been removed after the directory listing has completed.

Signed-off-by: Steven Kaufer <kaufer@us.ibm.com>