### PR TITLE
Refactor to use a common template runtime package

### DIFF
--- a/docs/plugin/metadata/vars/README.md
+++ b/docs/plugin/metadata/vars/README.md
@@ -1,8 +1,7 @@
 Vars Plugin
 ===========
 
-Design
-======
+## Design
 
 The `vars` plugin implements the [`metadata.Updatable`](../pkg/spi/metadata) SPI.  It supports
 

--- a/pkg/cli/context.go
+++ b/pkg/cli/context.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 
 	"github.com/docker/infrakit/pkg/discovery"
+	runtime "github.com/docker/infrakit/pkg/run/template"
 	"github.com/docker/infrakit/pkg/template"
 	"github.com/spf13/cobra"
 )
@@ -461,7 +462,7 @@ func (c *Context) BuildFlags() (err error) {
 		return
 	}
 	t.SetOptions(c.options)
-	_, err = configureTemplate(t, c.plugins).Render(c)
+	_, err = runtime.StdFunctions(t, c.plugins).Render(c)
 	return
 }
 
@@ -484,7 +485,7 @@ func (c *Context) Execute() (err error) {
 	// Process the input, render the template
 	t.SetOptions(opt)
 
-	script, err := configureTemplate(t, c.plugins).Render(c)
+	script, err := runtime.StdFunctions(t, c.plugins).Render(c)
 	if err != nil {
 		return err
 	}

--- a/pkg/cli/services.go
+++ b/pkg/cli/services.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 
 	"github.com/docker/infrakit/pkg/discovery"
+	runtime "github.com/docker/infrakit/pkg/run/template"
 	"github.com/docker/infrakit/pkg/template"
 	"github.com/ghodss/yaml"
 	"github.com/spf13/pflag"
@@ -197,7 +198,7 @@ func templateProcessor(plugins func() discovery.Plugins) (*pflag.FlagSet, ToJSON
 				}
 			}
 
-			configureTemplate(engine, plugins)
+			runtime.StdFunctions(engine, plugins)
 
 			contextObject := (interface{})(nil)
 			if len(ctx) == 1 {

--- a/pkg/cli/v0/group/describe.go
+++ b/pkg/cli/v0/group/describe.go
@@ -30,13 +30,13 @@ func Describe(name string, services *cli.Services) *cobra.Command {
 			if len(args) < 1 {
 				cmd.Usage()
 				os.Exit(1)
-			} else {
-				gid = args[0]
 			}
+			gid = args[0]
+			args = args[1:]
 		}
 
 		// get renderers first before costly rpc
-		renderer, err := view.Renderer()
+		renderer, err := view.Renderer(view.DefaultMatcher(args))
 		if err != nil {
 			return err
 		}

--- a/pkg/cli/v0/instance/describe.go
+++ b/pkg/cli/v0/instance/describe.go
@@ -1,15 +1,9 @@
 package instance
 
 import (
-	"fmt"
-	"io"
 	"os"
-	"sort"
-	"strings"
 
 	"github.com/docker/infrakit/pkg/cli"
-	"github.com/docker/infrakit/pkg/template"
-	"github.com/docker/infrakit/pkg/types"
 	"github.com/spf13/cobra"
 )
 
@@ -19,19 +13,21 @@ func Describe(name string, services *cli.Services) *cobra.Command {
 		Use:   "describe",
 		Short: "Describe all managed instances across all groups, subject to filter",
 	}
+
+	view := View{}
 	describe.Flags().AddFlagSet(services.OutputFlags)
-
-	tags := describe.Flags().StringSlice("tags", []string{}, "Tags to filter")
-	properties := describe.Flags().BoolP("properties", "p", false, "Also returns current status/ properties")
-	tagsTemplate := describe.Flags().StringP("tags-view", "t", "*", "Template to render tags")
-	propertiesTemplate := describe.Flags().String("properties-view", "{{.}}", "Template to render properties")
-
-	quiet := describe.Flags().BoolP("quiet", "q", false, "Print rows without column headers")
+	describe.Flags().AddFlagSet(view.FlagSet())
 
 	describe.RunE = func(cmd *cobra.Command, args []string) error {
 		if len(args) != 0 {
 			cmd.Usage()
 			os.Exit(1)
+		}
+
+		// get renderers first before costly rpc
+		renderer, err := view.Renderer()
+		if err != nil {
+			return err
 		}
 
 		instancePlugin, err := LoadPlugin(services.Plugins(), name)
@@ -40,92 +36,12 @@ func Describe(name string, services *cli.Services) *cobra.Command {
 		}
 		cli.MustNotNil(instancePlugin, "instance plugin not found", "name", name)
 
-		options := template.Options{}
-		tagsView, err := template.NewTemplate(template.ValidURL(*tagsTemplate), options)
-		if err != nil {
-			return err
-		}
-		propertiesView, err := template.NewTemplate(template.ValidURL(*propertiesTemplate), options)
+		desc, err := instancePlugin.DescribeInstances(view.TagFilter(), view.ShowProperties())
 		if err != nil {
 			return err
 		}
 
-		filter := map[string]string{}
-		for _, t := range *tags {
-			p := strings.Split(t, "=")
-			if len(p) == 2 {
-				filter[p[0]] = p[1]
-			} else {
-				filter[p[0]] = ""
-			}
-		}
-
-		desc, err := instancePlugin.DescribeInstances(filter, *properties)
-		if err != nil {
-			return err
-		}
-
-		return services.Output(os.Stdout, desc,
-			func(w io.Writer, v interface{}) error {
-				if !*quiet {
-					if *properties {
-						fmt.Printf("%-30s\t%-30s\t%-30s\t%-s\n", "ID", "LOGICAL", "TAGS", "PROPERTIES")
-
-					} else {
-						fmt.Printf("%-30s\t%-30s\t%-s\n", "ID", "LOGICAL", "TAGS")
-					}
-				}
-				for _, d := range desc {
-
-					logical := "  -   "
-					if d.LogicalID != nil {
-						logical = string(*d.LogicalID)
-					}
-
-					tagViewBuff := ""
-					if *tagsTemplate == "*" {
-						// default -- this is a hack
-						printTags := []string{}
-						for k, v := range d.Tags {
-							printTags = append(printTags, fmt.Sprintf("%s=%s", k, v))
-						}
-						sort.Strings(printTags)
-						tagViewBuff = strings.Join(printTags, ",")
-					} else {
-						tagViewBuff = renderTags(d.Tags, tagsView)
-					}
-
-					if *properties {
-						fmt.Printf("%-30s\t%-30s\t%-30s\t%-s\n", d.ID, logical, tagViewBuff,
-							renderProperties(d.Properties, propertiesView))
-					} else {
-						fmt.Printf("%-30s\t%-30s\t%-s\n", d.ID, logical, tagViewBuff)
-					}
-				}
-				return nil
-			})
+		return services.Output(os.Stdout, desc, renderer)
 	}
 	return describe
-}
-
-func renderTags(m map[string]string, view *template.Template) string {
-	buff, err := view.Render(m)
-	if err != nil {
-		return err.Error()
-	}
-	return buff
-}
-
-func renderProperties(properties *types.Any, view *template.Template) string {
-	var v interface{}
-	err := properties.Decode(&v)
-	if err != nil {
-		return err.Error()
-	}
-
-	buff, err := view.Render(v)
-	if err != nil {
-		return err.Error()
-	}
-	return buff
 }

--- a/pkg/cli/v0/instance/describe.go
+++ b/pkg/cli/v0/instance/describe.go
@@ -19,13 +19,8 @@ func Describe(name string, services *cli.Services) *cobra.Command {
 	describe.Flags().AddFlagSet(view.FlagSet())
 
 	describe.RunE = func(cmd *cobra.Command, args []string) error {
-		if len(args) != 0 {
-			cmd.Usage()
-			os.Exit(1)
-		}
-
 		// get renderers first before costly rpc
-		renderer, err := view.Renderer()
+		renderer, err := view.Renderer(view.DefaultMatcher(args))
 		if err != nil {
 			return err
 		}

--- a/pkg/cli/v0/instance/view.go
+++ b/pkg/cli/v0/instance/view.go
@@ -1,0 +1,137 @@
+package instance
+
+import (
+	"fmt"
+	"io"
+	"sort"
+	"strings"
+
+	"github.com/docker/infrakit/pkg/spi/instance"
+	"github.com/docker/infrakit/pkg/template"
+	"github.com/docker/infrakit/pkg/types"
+	"github.com/spf13/pflag"
+)
+
+// View is a view of an Instance
+type View struct {
+	options            template.Options
+	quiet              bool
+	tags               []string // tags to filter
+	properties         bool
+	tagsTemplate       string
+	propertiesTemplate string
+}
+
+// FlagSet returns a flagset to bind
+func (v *View) FlagSet() *pflag.FlagSet {
+	// defaults
+	v.tags = []string{}
+	v.tagsTemplate = "*"
+	v.propertiesTemplate = "{{.}}"
+
+	fs := pflag.NewFlagSet("instance-view", pflag.ExitOnError)
+	fs.StringSliceVar(&v.tags, "tags", v.tags, "Tags to filter")
+	fs.BoolVarP(&v.properties, "properties", "p", v.properties, "True to show properties")
+	fs.StringVarP(&v.tagsTemplate, "tags-view", "t", v.tagsTemplate, "Template for rendering tags")
+	fs.StringVarP(&v.propertiesTemplate, "properties-view", "w", v.propertiesTemplate, "Template for rendering properties")
+	fs.BoolVarP(&v.quiet, "quiet", "q", v.quiet, "Print rows without column headers")
+	return fs
+}
+
+// ShowProperties returns true if showing properties
+func (v *View) ShowProperties() bool {
+	return v.properties
+}
+
+// TagFilter returns the tag filter for querying
+func (v *View) TagFilter() map[string]string {
+	filter := map[string]string{}
+	for _, t := range v.tags {
+		p := strings.Split(t, "=")
+		if len(p) == 2 {
+			filter[p[0]] = p[1]
+		} else {
+			filter[p[0]] = ""
+		}
+	}
+	return filter
+}
+
+// Renderer returns the renderer for the results
+func (v *View) Renderer() (func(w io.Writer, v interface{}) error, error) {
+	tagsView, err := template.NewTemplate(template.ValidURL(v.tagsTemplate), v.options)
+	if err != nil {
+		return nil, err
+	}
+	propertiesView, err := template.NewTemplate(template.ValidURL(v.propertiesTemplate), v.options)
+	if err != nil {
+		return nil, err
+	}
+
+	return func(w io.Writer, result interface{}) error {
+
+		instances, is := result.([]instance.Description)
+		if !is {
+			return fmt.Errorf("not []instance.Description")
+		}
+
+		if !v.quiet {
+			if v.properties {
+				fmt.Printf("%-30s\t%-30s\t%-30s\t%-s\n", "ID", "LOGICAL", "TAGS", "PROPERTIES")
+
+			} else {
+				fmt.Printf("%-30s\t%-30s\t%-s\n", "ID", "LOGICAL", "TAGS")
+			}
+		}
+		for _, d := range instances {
+
+			logical := "  -   "
+			if d.LogicalID != nil {
+				logical = string(*d.LogicalID)
+			}
+
+			tagViewBuff := ""
+			if v.tagsTemplate == "*" {
+				// default -- this is a hack
+				printTags := []string{}
+				for k, v := range d.Tags {
+					printTags = append(printTags, fmt.Sprintf("%s=%s", k, v))
+				}
+				sort.Strings(printTags)
+				tagViewBuff = strings.Join(printTags, ",")
+			} else {
+				tagViewBuff = renderTags(d.Tags, tagsView)
+			}
+
+			if v.properties {
+				fmt.Printf("%-30s\t%-30s\t%-30s\t%-s\n", d.ID, logical, tagViewBuff,
+					renderProperties(d.Properties, propertiesView))
+			} else {
+				fmt.Printf("%-30s\t%-30s\t%-s\n", d.ID, logical, tagViewBuff)
+			}
+		}
+		return nil
+	}, nil
+}
+
+func renderTags(m map[string]string, view *template.Template) string {
+	buff, err := view.Render(m)
+	if err != nil {
+		return err.Error()
+	}
+	return buff
+}
+
+func renderProperties(properties *types.Any, view *template.Template) string {
+	var v interface{}
+	err := properties.Decode(&v)
+	if err != nil {
+		return err.Error()
+	}
+
+	buff, err := view.Render(v)
+	if err != nil {
+		return err.Error()
+	}
+	return buff
+}

--- a/pkg/log/log.go
+++ b/pkg/log/log.go
@@ -4,9 +4,11 @@ import (
 	"flag"
 	"fmt"
 	"os"
+	"strconv"
 	"strings"
 
 	"github.com/Sirupsen/logrus"
+	"github.com/docker/infrakit/pkg/run/local"
 	"gopkg.in/inconshreveable/log15.v2"
 )
 
@@ -45,11 +47,18 @@ type Options struct {
 // (e.g. .Debug(msg, "key", log.V(100))
 type V int
 
+func mustFirst(v int, err error) int {
+	if err != nil {
+		panic(err)
+	}
+	return v
+}
+
 // DevDefaults is the default options for development
 var DevDefaults = Options{
-	Level:     5,
+	Level:     mustFirst(strconv.Atoi(local.Getenv("INFRAKIT_LOG_DEV_LEVEL", "4"))),
 	Stdout:    false,
-	Format:    "json",
+	Format:    local.Getenv("INFRAKIT_LOG_DEV_FORMAT", "term"),
 	CallStack: true,
 }
 

--- a/pkg/plugin/flavor/kubernetes/flavor.go
+++ b/pkg/plugin/flavor/kubernetes/flavor.go
@@ -12,7 +12,7 @@ import (
 	"github.com/docker/infrakit/pkg/discovery"
 	logutil "github.com/docker/infrakit/pkg/log"
 	group_types "github.com/docker/infrakit/pkg/plugin/group/types"
-	metadata_template "github.com/docker/infrakit/pkg/plugin/metadata/template"
+	runtime "github.com/docker/infrakit/pkg/run/template"
 	"github.com/docker/infrakit/pkg/spi/flavor"
 	"github.com/docker/infrakit/pkg/spi/instance"
 	"github.com/docker/infrakit/pkg/spi/metadata"
@@ -352,20 +352,7 @@ func (s *baseFlavor) prepare(role string, flavorProperties *types.Any, instanceS
 		worker:       worker,
 	}
 
-	initTemplate.WithFunctions(func() []template.Function {
-		return []template.Function{
-			{
-				Name: "metadata",
-				Description: []string{
-					"Metadata function takes a path of the form \"plugin_name/path/to/data\"",
-					"and calls GET on the plugin with the path \"path/to/data\".",
-					"It's identical to the CLI command infrakit metadata cat ...",
-				},
-				Func: metadata_template.MetadataFunc(s.plugins),
-			},
-		}
-	})
-	initScript, err = initTemplate.Render(context)
+	initScript, err = runtime.StdFunctions(initTemplate, s.plugins).Render(context)
 	instanceSpec.Init = initScript
 	log.Debug("Init script", "content", initScript)
 	return instanceSpec, nil

--- a/pkg/plugin/flavor/swarm/flavor.go
+++ b/pkg/plugin/flavor/swarm/flavor.go
@@ -11,7 +11,7 @@ import (
 	"github.com/docker/go-connections/tlsconfig"
 	"github.com/docker/infrakit/pkg/discovery"
 	group_types "github.com/docker/infrakit/pkg/plugin/group/types"
-	metadata_template "github.com/docker/infrakit/pkg/plugin/metadata/template"
+	runtime "github.com/docker/infrakit/pkg/run/template"
 	"github.com/docker/infrakit/pkg/spi/flavor"
 	"github.com/docker/infrakit/pkg/spi/instance"
 	"github.com/docker/infrakit/pkg/spi/metadata"
@@ -275,21 +275,7 @@ func (s *baseFlavor) prepare(role string, flavorProperties *types.Any, instanceS
 			link:         *link,
 		}
 
-		initTemplate.WithFunctions(func() []template.Function {
-			return []template.Function{
-				{
-					Name: "metadata",
-					Description: []string{
-						"Metadata function takes a path of the form \"plugin_name/path/to/data\"",
-						"and calls GET on the plugin with the path \"path/to/data\".",
-						"It's identical to the CLI command infrakit metadata cat ...",
-					},
-					Func: metadata_template.MetadataFunc(s.plugins),
-				},
-			}
-		})
-		initScript, err = initTemplate.Render(context)
-
+		initScript, err = runtime.StdFunctions(initTemplate, s.plugins).Render(context)
 		log.Debugln(role, ">>> context.retries =", context.retries, "err=", err, "i=", i)
 
 		if err == nil {

--- a/pkg/plugin/flavor/vanilla/flavor_test.go
+++ b/pkg/plugin/flavor/vanilla/flavor_test.go
@@ -5,14 +5,17 @@ import (
 
 	group_types "github.com/docker/infrakit/pkg/plugin/group/types"
 
+	"github.com/docker/infrakit/pkg/discovery"
 	"github.com/docker/infrakit/pkg/spi/group"
 	"github.com/docker/infrakit/pkg/spi/instance"
 	"github.com/docker/infrakit/pkg/types"
 	"github.com/stretchr/testify/require"
 )
 
+var nilPlugins = func() discovery.Plugins { return nil }
+
 func TestValidateValid(t *testing.T) {
-	plugin := NewPlugin(DefaultOptions)
+	plugin := NewPlugin(nilPlugins, DefaultOptions)
 	require.NotNil(t, plugin)
 	err := plugin.Validate(
 		types.AnyString(`{
@@ -35,7 +38,7 @@ func TestValidateValid(t *testing.T) {
 }
 
 func TestValidateInvalidJSON(t *testing.T) {
-	plugin := NewPlugin(DefaultOptions)
+	plugin := NewPlugin(nilPlugins, DefaultOptions)
 	require.NotNil(t, plugin)
 	err := plugin.Validate(
 		types.AnyString("not-json"),
@@ -44,7 +47,7 @@ func TestValidateInvalidJSON(t *testing.T) {
 }
 
 func TestValidateInitLinesWithInitScript(t *testing.T) {
-	plugin := NewPlugin(DefaultOptions)
+	plugin := NewPlugin(nilPlugins, DefaultOptions)
 	require.NotNil(t, plugin)
 	err := plugin.Validate(
 		types.AnyString(`{
@@ -59,7 +62,7 @@ func TestValidateInitLinesWithInitScript(t *testing.T) {
 }
 
 func TestValidateInitScriptRenderError(t *testing.T) {
-	plugin := NewPlugin(DefaultOptions)
+	plugin := NewPlugin(nilPlugins, DefaultOptions)
 	require.NotNil(t, plugin)
 	err := plugin.Validate(
 		types.AnyString(`{
@@ -70,7 +73,7 @@ func TestValidateInitScriptRenderError(t *testing.T) {
 }
 
 func TestPrepareEmptyVanillaData(t *testing.T) {
-	plugin := NewPlugin(DefaultOptions)
+	plugin := NewPlugin(nilPlugins, DefaultOptions)
 	require.NotNil(t, plugin)
 	spec, err := plugin.Prepare(
 		types.AnyString(""),
@@ -88,7 +91,7 @@ func TestPrepareEmptyVanillaData(t *testing.T) {
 }
 
 func TestPrepareWithAttachments(t *testing.T) {
-	plugin := NewPlugin(DefaultOptions)
+	plugin := NewPlugin(nilPlugins, DefaultOptions)
 	require.NotNil(t, plugin)
 	spec, err := plugin.Prepare(
 		types.AnyString(`{
@@ -104,7 +107,7 @@ func TestPrepareWithAttachments(t *testing.T) {
 }
 
 func TestPrepareWithAttachmentsAndInstanceSpecAttachments(t *testing.T) {
-	plugin := NewPlugin(DefaultOptions)
+	plugin := NewPlugin(nilPlugins, DefaultOptions)
 	require.NotNil(t, plugin)
 	spec, err := plugin.Prepare(
 		types.AnyString(`{
@@ -120,7 +123,7 @@ func TestPrepareWithAttachmentsAndInstanceSpecAttachments(t *testing.T) {
 }
 
 func TestPrepareWithTags(t *testing.T) {
-	plugin := NewPlugin(DefaultOptions)
+	plugin := NewPlugin(nilPlugins, DefaultOptions)
 	require.NotNil(t, plugin)
 	spec, err := plugin.Prepare(
 		types.AnyString(`{
@@ -135,7 +138,7 @@ func TestPrepareWithTags(t *testing.T) {
 }
 
 func TestPrepareWithTagsAndInstanceSpecTags(t *testing.T) {
-	plugin := NewPlugin(DefaultOptions)
+	plugin := NewPlugin(nilPlugins, DefaultOptions)
 	require.NotNil(t, plugin)
 	spec, err := plugin.Prepare(
 		types.AnyString(`{
@@ -154,7 +157,7 @@ func TestPrepareWithTagsAndInstanceSpecTags(t *testing.T) {
 }
 
 func TestPrepareWithInit(t *testing.T) {
-	plugin := NewPlugin(DefaultOptions)
+	plugin := NewPlugin(nilPlugins, DefaultOptions)
 	require.NotNil(t, plugin)
 	spec, err := plugin.Prepare(
 		types.AnyString(`{
@@ -169,7 +172,7 @@ func TestPrepareWithInit(t *testing.T) {
 }
 
 func TestPrepareWithInitAndInstanceSpecInit(t *testing.T) {
-	plugin := NewPlugin(DefaultOptions)
+	plugin := NewPlugin(nilPlugins, DefaultOptions)
 	require.NotNil(t, plugin)
 	spec, err := plugin.Prepare(
 		types.AnyString(`{
@@ -186,7 +189,7 @@ func TestPrepareWithInitAndInstanceSpecInit(t *testing.T) {
 }
 
 func TestPrepareWithInitScriptAndInstanceSpecInit(t *testing.T) {
-	plugin := NewPlugin(DefaultOptions)
+	plugin := NewPlugin(nilPlugins, DefaultOptions)
 	require.NotNil(t, plugin)
 	spec, err := plugin.Prepare(
 		types.AnyString(`{

--- a/pkg/run/template/std.go
+++ b/pkg/run/template/std.go
@@ -1,4 +1,4 @@
-package cli
+package template
 
 import (
 	"fmt"
@@ -8,7 +8,8 @@ import (
 	"github.com/docker/infrakit/pkg/template"
 )
 
-func configureTemplate(engine *template.Template, plugins func() discovery.Plugins) *template.Template {
+// StdFunctions adds a set of standard functions for access in templates
+func StdFunctions(engine *template.Template, plugins func() discovery.Plugins) *template.Template {
 	engine.WithFunctions(func() []template.Function {
 		return []template.Function{
 			{

--- a/pkg/run/template/std.go
+++ b/pkg/run/template/std.go
@@ -2,6 +2,7 @@ package template
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/docker/infrakit/pkg/discovery"
 	metadata_template "github.com/docker/infrakit/pkg/plugin/metadata/template"
@@ -21,10 +22,35 @@ func StdFunctions(engine *template.Template, plugins func() discovery.Plugins) *
 				},
 				Func: metadata_template.MetadataFunc(plugins),
 			},
+			// This is an override of the existing Var function
 			{
-				Name: "resource",
-				Func: func(s string) string {
-					return fmt.Sprintf("{{ resource `%s` }}", s)
+				Name: "var",
+				Func: func(name string, optional ...interface{}) (interface{}, error) {
+
+					// returns nil if it's a read and unresolved
+					// or if it's a write, returns a void value that is not nil (an empty string)
+					v := engine.Var(name, optional...)
+					switch {
+					case len(optional) > 0: // writing
+						return v, nil
+					case v != nil && !engine.Options().MultiPass: // reading, resolved
+						return v, nil
+					}
+					// Check to see if the value is resolved...  in the case of multipass, we can get `{{ var foo }}` back
+					if engine.Options().MultiPass {
+						delim := `{{`
+						if engine.Options().DelimLeft != "" {
+							delim = engine.Options().DelimLeft
+						}
+						if strings.Index(fmt.Sprintf("%v", v), delim) < 0 {
+							return v, nil
+						}
+						// If it's multipass and we have a template expression returned, then the value is not resolved.
+						// continue to look up as metadata
+					}
+
+					// If not resolved, try to interpret the path as a path for metadata...
+					return metadata_template.MetadataFunc(plugins)(name, optional...)
 				},
 			},
 		}

--- a/pkg/run/v0/vanilla/vanilla.go
+++ b/pkg/run/v0/vanilla/vanilla.go
@@ -47,7 +47,7 @@ func Run(plugins func() discovery.Plugins, name plugin.Name,
 
 	transport.Name = name
 	impls = map[run.PluginCode]interface{}{
-		run.Flavor: vanilla.NewPlugin(options.Options),
+		run.Flavor: vanilla.NewPlugin(plugins, options.Options),
 	}
 	return
 }

--- a/pkg/template/template.go
+++ b/pkg/template/template.go
@@ -95,6 +95,11 @@ type Template struct {
 	parent *Template
 }
 
+// Options returns the options used to initialize this template engine
+func (t *Template) Options() Options {
+	return t.options
+}
+
 // Void is used in the template functions return value type to indicate a void.
 // Golang template does not allow functions with no return types to be bound.
 type Void string


### PR DESCRIPTION
This PR is mostly moving some packages so that

  + The plugins (swarm, kubernetes) all use the same `{{ metadata }}` function implementation.  Previously they were creating their own templates and binding own functions.
  + The CLI template engine now use the same `{{ metadata }}` function implementation
  + Move the code from a `pkg/cli` package to `pkg/run/template` as a common place for template functions either rendered in command-line (hence was `pkg/cli`) or in plugins.

Signed-off-by: David Chung <david.chung@docker.com>