### PR TITLE
Misc bug fixes for CLI `remote` and `var` template function

### DIFF
--- a/cmd/infrakit/remote/remote.go
+++ b/cmd/infrakit/remote/remote.go
@@ -33,9 +33,9 @@ func Command(plugins func() discovery.Plugins) *cobra.Command {
 
 	bastionAddr := ""
 	user := ""
-	add := &cobra.Command{
-		Use:   "add <name> <url_list>",
-		Short: "Add a remote",
+	set := &cobra.Command{
+		Use:   "set <name> <url_list>",
+		Short: "Set a remote",
 		RunE: func(cmd *cobra.Command, args []string) error {
 
 			if len(args) != 2 {
@@ -60,28 +60,25 @@ func Command(plugins func() discovery.Plugins) *cobra.Command {
 			return hosts.Save()
 		},
 	}
-	add.Flags().StringVar(&bastionAddr, "ssh-addr", bastionAddr, "The public host to tunnel")
-	add.Flags().StringVar(&user, "ssh-user", user, "The ssh user")
+	set.Flags().StringVar(&bastionAddr, "ssh-addr", bastionAddr, "The public host to tunnel")
+	set.Flags().StringVar(&user, "ssh-user", user, "The ssh user")
 
 	remove := &cobra.Command{
 		Use:   "rm <name>",
 		Short: "Remove a remote",
 		RunE: func(cmd *cobra.Command, args []string) error {
 
-			if len(args) != 1 {
+			if len(args) == 0 {
 				cmd.Usage()
 				os.Exit(1)
 			}
-
-			name := args[0]
-
 			hosts, err := cli.LoadHosts()
 			if err != nil {
 				return err
 			}
-
-			delete(hosts, name)
-
+			for _, name := range args {
+				delete(hosts, name)
+			}
 			return hosts.Save()
 		},
 	}
@@ -134,6 +131,6 @@ func Command(plugins func() discovery.Plugins) *cobra.Command {
 	}
 	list.Flags().AddFlagSet(outputFlags)
 
-	cmd.AddCommand(add, remove, list, current)
+	cmd.AddCommand(set, remove, list, current)
 	return cmd
 }

--- a/pkg/run/template/std.go
+++ b/pkg/run/template/std.go
@@ -24,7 +24,7 @@ func StdFunctions(engine *template.Template, plugins func() discovery.Plugins) *
 			},
 			// This is an override of the existing Var function
 			{
-				Name: "var",
+				Name: "var2",
 				Func: func(name string, optional ...interface{}) (interface{}, error) {
 
 					// returns nil if it's a read and unresolved

--- a/pkg/run/template/std.go
+++ b/pkg/run/template/std.go
@@ -1,9 +1,6 @@
 package template
 
 import (
-	"fmt"
-	"strings"
-
 	"github.com/docker/infrakit/pkg/discovery"
 	metadata_template "github.com/docker/infrakit/pkg/plugin/metadata/template"
 	"github.com/docker/infrakit/pkg/template"
@@ -24,33 +21,17 @@ func StdFunctions(engine *template.Template, plugins func() discovery.Plugins) *
 			},
 			// This is an override of the existing Var function
 			{
-				Name: "var2",
+				Name: "var",
 				Func: func(name string, optional ...interface{}) (interface{}, error) {
 
 					// returns nil if it's a read and unresolved
 					// or if it's a write, returns a void value that is not nil (an empty string)
 					v := engine.Var(name, optional...)
-					switch {
-					case len(optional) > 0: // writing
-						return v, nil
-					case v != nil && !engine.Options().MultiPass: // reading, resolved
-						return v, nil
+					if v == nil {
+						// If not resolved, try to interpret the path as a path for metadata...
+						return metadata_template.MetadataFunc(plugins)(name, optional...)
 					}
-					// Check to see if the value is resolved...  in the case of multipass, we can get `{{ var foo }}` back
-					if engine.Options().MultiPass {
-						delim := `{{`
-						if engine.Options().DelimLeft != "" {
-							delim = engine.Options().DelimLeft
-						}
-						if strings.Index(fmt.Sprintf("%v", v), delim) < 0 {
-							return v, nil
-						}
-						// If it's multipass and we have a template expression returned, then the value is not resolved.
-						// continue to look up as metadata
-					}
-
-					// If not resolved, try to interpret the path as a path for metadata...
-					return metadata_template.MetadataFunc(plugins)(name, optional...)
+					return v, nil
 				},
 			},
 		}


### PR DESCRIPTION
This PR

  + Allows multiple args in `remote rm`
  + Changes the verb to `remote set`
  + Removes extra logic in `var` template function

Signed-off-by: David Chung <david.chung@docker.com>

