### PR TITLE
Persistent / replicated metadata, `util init` fixes, and documentation

### DIFF
--- a/cmd/infrakit/manager/schema/v0.go
+++ b/cmd/infrakit/manager/schema/v0.go
@@ -1,0 +1,34 @@
+package schema
+
+import (
+	"github.com/docker/infrakit/pkg/plugin"
+	group_types "github.com/docker/infrakit/pkg/plugin/group/types"
+	"github.com/docker/infrakit/pkg/spi/group"
+	"github.com/docker/infrakit/pkg/types"
+)
+
+// ParseInputSpecs parses the input bytes which is the groups.json, and calls
+// each time a group spec is found.
+func ParseInputSpecs(input []byte, foundGroupSpec func(plugin.Name, group.ID, group_types.Spec) error) error {
+	// TODO - update the schema soon. This is the Plugin/Properties schema
+	type spec struct {
+		Plugin     plugin.Name
+		Properties struct {
+			ID         group.ID
+			Properties group_types.Spec
+		}
+	}
+
+	specs := []spec{}
+	err := types.AnyBytes(input).Decode(&specs)
+	if err != nil {
+		return err
+	}
+	for _, s := range specs {
+		err = foundGroupSpec(s.Plugin, s.Properties.ID, s.Properties.Properties)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}

--- a/cmd/infrakit/util/init/init.go
+++ b/cmd/infrakit/util/init/init.go
@@ -3,7 +3,6 @@ package init
 import (
 	"fmt"
 	"os"
-	"strings"
 	"time"
 
 	"github.com/docker/infrakit/pkg/cli"
@@ -13,9 +12,9 @@ import (
 	"github.com/docker/infrakit/pkg/plugin"
 	group_types "github.com/docker/infrakit/pkg/plugin/group/types"
 	flavor_rpc "github.com/docker/infrakit/pkg/rpc/flavor"
-	run "github.com/docker/infrakit/pkg/run/manager"
-	group_kind "github.com/docker/infrakit/pkg/run/v0/group"
-	manager_kind "github.com/docker/infrakit/pkg/run/v0/manager"
+	"github.com/docker/infrakit/pkg/run/manager"
+	"github.com/docker/infrakit/pkg/run/scope"
+	"github.com/docker/infrakit/pkg/run/scope/local"
 	"github.com/docker/infrakit/pkg/spi/group"
 	"github.com/docker/infrakit/pkg/spi/instance"
 	"github.com/docker/infrakit/pkg/types"
@@ -24,8 +23,8 @@ import (
 
 var log = logutil.New("module", "util/init")
 
-func startPlugins(plugins func() discovery.Plugins, services *cli.Services,
-	configURL string, starts []string) (*run.Manager, error) {
+func getPluginManager(plugins func() discovery.Plugins, services *cli.Services,
+	configURL string, starts []string) (*manager.Manager, error) {
 
 	parsedRules := []launch.Rule{}
 
@@ -44,44 +43,7 @@ func startPlugins(plugins func() discovery.Plugins, services *cli.Services,
 			return nil, err
 		}
 	}
-
-	pluginManager, err := run.ManagePlugins(parsedRules, plugins, true, 5*time.Second)
-	if err != nil {
-		return nil, err
-	}
-
-	for _, arg := range starts {
-
-		p := strings.Split(arg, "=")
-		execName := "inproc" // default is to use inprocess goroutine for running plugins
-		if len(p) > 1 {
-			execName = p[1]
-		}
-
-		// the format is kind[:{plugin_name}][={os|inproc}]
-		pp := strings.Split(p[0], ":")
-		kind := pp[0]
-		name := plugin.Name(kind)
-
-		// This is some special case for the legacy setup (pre v0.6)
-		switch kind {
-		case manager_kind.Kind:
-			name = plugin.Name(manager_kind.LookupName)
-		case group_kind.Kind:
-			name = plugin.Name(group_kind.LookupName)
-		}
-		// customized by user as override
-		if len(pp) > 1 {
-			name = plugin.Name(pp[1])
-		}
-
-		log.Info("Launching", "kind", kind, "name", name)
-		err = pluginManager.Launch(execName, kind, name, nil)
-		if err != nil {
-			log.Warn("failed to launch", "exec", execName, "kind", kind, "name", name)
-		}
-	}
-	return pluginManager, nil
+	return manager.ManagePlugins(parsedRules, plugins, true, 5*time.Second)
 }
 
 // Command returns the cobra command
@@ -122,107 +84,116 @@ func Command(plugins func() discovery.Plugins) *cobra.Command {
 
 		wait := types.MustParseDuration(*waitDuration)
 
-		pluginManager, err := startPlugins(plugins, services, *configURL, *starts)
+		pluginManager, err := getPluginManager(plugins, services, *configURL, *starts)
 		if err != nil {
 			return err
 		}
-		defer func() {
-			<-time.After(wait.Duration())
-			pluginManager.TerminateAll()
-			pluginManager.WaitForAllShutdown()
-			pluginManager.Stop()
-		}()
 
-		pluginManager.WaitStarting()
-		<-time.After(wait.Duration())
+		buildInit := func(scope scope.Scope) error {
 
-		input, err := services.ReadFromStdinIfElse(
-			func() bool { return args[0] == "-" },
-			func() (string, error) { return services.ProcessTemplate(args[0]) },
-			services.ToJSON,
+			input, err := services.ReadFromStdinIfElse(
+				func() bool { return args[0] == "-" },
+				func() (string, error) { return services.ProcessTemplate(args[0]) },
+				services.ToJSON,
+			)
+			if err != nil {
+				log.Error("processing input", "err", err)
+				return err
+			}
+
+			// TODO - update the schema -- this matches the current Plugin/Properties schema
+			type spec struct {
+				Plugin     plugin.Name
+				Properties struct {
+					ID         group.ID
+					Properties group_types.Spec
+				}
+			}
+
+			specs := []spec{}
+			err = types.AnyString(input).Decode(&specs)
+			if err != nil {
+				return err
+			}
+
+			var groupSpec *group_types.Spec
+			for _, s := range specs {
+				if string(s.Properties.ID) == *groupID {
+					copy := s.Properties.Properties
+					groupSpec = &copy
+					break
+				}
+			}
+
+			if groupSpec == nil {
+				return fmt.Errorf("no such group: %v", *groupID)
+			}
+
+			// Get the flavor properties and use that to call the prepare of the Flavor to generate the init
+			endpoint, err := scope.Plugins().Find(groupSpec.Flavor.Plugin)
+			if err != nil {
+				log.Error("error looking up plugin", "plugin", groupSpec.Flavor.Plugin, "err", err)
+				return err
+			}
+
+			flavorPlugin, err := flavor_rpc.NewClient(groupSpec.Flavor.Plugin, endpoint.Address)
+			if err != nil {
+				return err
+			}
+
+			cli.MustNotNil(flavorPlugin, "flavor plugin not found", "name", groupSpec.Flavor.Plugin.String())
+
+			instanceSpec := instance.Spec{}
+			if lidLen := len(groupSpec.Allocation.LogicalIDs); lidLen > 0 {
+
+				if int(*sequence) >= lidLen {
+					return fmt.Errorf("out of bound sequence index: %v in %v", *sequence, groupSpec.Allocation.LogicalIDs)
+				}
+
+				lid := instance.LogicalID(groupSpec.Allocation.LogicalIDs[*sequence])
+				instanceSpec.LogicalID = &lid
+			}
+
+			instanceSpec, err = flavorPlugin.Prepare(groupSpec.Flavor.Properties, instanceSpec,
+				groupSpec.Allocation,
+				group_types.Index{Group: group.ID(*groupID), Sequence: *sequence})
+
+			if err != nil {
+				log.Error("error preparing", "err", err, "spec", instanceSpec)
+				return err
+			}
+
+			log.Info("apply init template", "init", instanceSpec.Init)
+
+			// Here the Init may contain template vars since in the evaluation of the manager / worker
+			// init templates, we do not propapage the vars set in the command line here.
+			// So we need to evaluate the entire Init as a template again.
+			// TODO - this is really better addressed via some formal globally available var store/section
+			// that is always available to the templates at the schema / document level.
+			applied, err := services.ProcessTemplate("str://" + instanceSpec.Init)
+			if err != nil {
+				return err
+			}
+
+			fmt.Print(applied)
+
+			return nil
+		}
+
+		return local.Execute(plugins, pluginManager,
+			func() (targets []local.StartPlugin, err error) {
+				for _, start := range *starts {
+					targets = append(targets, local.StartPlugin(start))
+				}
+				return
+			},
+			buildInit,
+			local.Options{
+				StartWait: wait,
+				StopWait:  wait,
+			},
 		)
-		if err != nil {
-			log.Error("processing input", "err", err)
-			return err
-		}
 
-		// TODO - update the schema -- this matches the current Plugin/Properties schema
-		type spec struct {
-			Plugin     plugin.Name
-			Properties struct {
-				ID         group.ID
-				Properties group_types.Spec
-			}
-		}
-
-		specs := []spec{}
-		err = types.AnyString(input).Decode(&specs)
-		if err != nil {
-			return err
-		}
-
-		var groupSpec *group_types.Spec
-		for _, s := range specs {
-			if string(s.Properties.ID) == *groupID {
-				copy := s.Properties.Properties
-				groupSpec = &copy
-				break
-			}
-		}
-
-		if groupSpec == nil {
-			return fmt.Errorf("no such group: %v", *groupID)
-		}
-
-		// Get the flavor properties and use that to call the prepare of the Flavor to generate the init
-		endpoint, err := plugins().Find(groupSpec.Flavor.Plugin)
-		if err != nil {
-			log.Error("error looking up plugin", "plugin", groupSpec.Flavor.Plugin, "err", err)
-			return err
-		}
-
-		flavorPlugin, err := flavor_rpc.NewClient(groupSpec.Flavor.Plugin, endpoint.Address)
-		if err != nil {
-			return err
-		}
-
-		cli.MustNotNil(flavorPlugin, "flavor plugin not found", "name", groupSpec.Flavor.Plugin.String())
-
-		instanceSpec := instance.Spec{}
-		if lidLen := len(groupSpec.Allocation.LogicalIDs); lidLen > 0 {
-
-			if int(*sequence) >= lidLen {
-				return fmt.Errorf("out of bound sequence index: %v in %v", *sequence, groupSpec.Allocation.LogicalIDs)
-			}
-
-			lid := instance.LogicalID(groupSpec.Allocation.LogicalIDs[*sequence])
-			instanceSpec.LogicalID = &lid
-		}
-
-		instanceSpec, err = flavorPlugin.Prepare(groupSpec.Flavor.Properties, instanceSpec,
-			groupSpec.Allocation,
-			group_types.Index{Group: group.ID(*groupID), Sequence: *sequence})
-
-		if err != nil {
-			log.Error("error preparing", "err", err, "spec", instanceSpec)
-			return err
-		}
-
-		log.Info("apply init template", "init", instanceSpec.Init)
-
-		// Here the Init may contain template vars since in the evaluation of the manager / worker
-		// init templates, we do not propapage the vars set in the command line here.
-		// So we need to evaluate the entire Init as a template again.
-		// TODO - this is really better addressed via some formal globally available var store/section
-		// that is always available to the templates at the schema / document level.
-		applied, err := services.ProcessTemplate("str://" + instanceSpec.Init)
-		if err != nil {
-			return err
-		}
-
-		fmt.Print(applied)
-
-		return nil
 	}
 
 	return cmd

--- a/cmd/infrakit/util/init/init.go
+++ b/cmd/infrakit/util/init/init.go
@@ -98,7 +98,7 @@ func Command(plugins func() discovery.Plugins) *cobra.Command {
 		log.Info("Starting up base plugins")
 		basePlugins := []string{"vars"}
 		if *persist {
-			basePlugins = []string{"vars:vars-stateless", "manager:vars", "group:group-stateless"} // manager aliased to vars
+			basePlugins = []string{"vars", "manager", "group"} // manager aliased to vars
 		}
 		for _, base := range basePlugins {
 			execName, kind, name, _ := local.StartPlugin(base).Parse()
@@ -213,7 +213,7 @@ func Command(plugins func() discovery.Plugins) *cobra.Command {
 			}
 
 			if *persist {
-				vars := plugin.Name("vars")
+				vars := plugin.Name("group/vars")
 				log.Info("Persisting data into the backend")
 				endpoint, err := scope.Plugins().Find(vars)
 				if err != nil {
@@ -232,6 +232,7 @@ func Command(plugins func() discovery.Plugins) *cobra.Command {
 					return err
 				}
 				err = u.Commit(proposed, cas)
+				log.Info("Committed to vars", "err", err)
 				if err != nil {
 					return err
 				}

--- a/cmd/infrakit/util/init/init.go
+++ b/cmd/infrakit/util/init/init.go
@@ -94,7 +94,7 @@ func Command(plugins func() discovery.Plugins) *cobra.Command {
 
 		wait := types.MustParseDuration(*waitDuration)
 
-		pluginManager, err := getPluginManager(plugins, services, *configURL)
+		pluginManager, err := cli.PluginManager(plugins, services, *configURL)
 		if err != nil {
 			return err
 		}

--- a/docs/cmd/infrakit/util/init/README.md
+++ b/docs/cmd/infrakit/util/init/README.md
@@ -1,0 +1,44 @@
+init
+====
+
+The `init` command takes a spec (`groups.json`) and starts
+the flavor plugin and generates the init script of the boot
+node as though it's provisioned by the group and instance plugins.
+This is used primarily as a way too bootstrap the first node of a
+cluster.
+
+The `init` command also implicitly starts a `vars` plugin for storing
+your varaibles so that through successive evaluations of templates, your
+configuration information is always accessible.
+
+This example here uses the `vars.json`, `groups.json`, `common.ikt`, and `init.sh`
+in this directory.
+
+To run
+
+```shell
+$ INFRAKIT_VARS_TEMPLATE=file://$(pwd)/vars.json infrakit util init --group-id managers groups.json --var vars/config/root=file://$(pwd)
+#!/bin/bash
+
+echo "This is the init script"
+echo "The config root is file:///Users/davidchung/project5/src/github.com/docker/infrakit/docs/cmd/infrakit/util/init"
+echo "The cluster size is 5"
+```
+
+The output will be the shell script that the first node of the group `managers` should
+execute.  You can pipe this to `sh` and the node that runs this script will become
+the first node of the cluster.  Note that there are other requirements on the first node
+in terms of its configuration and labels (must have a label `infrakit.config_sha=bootstrap`)
+such that it's not possible to run this on your mac and expect it to be the first node of
+a cluster in AWS.  This is meant to be for bootstrapping in the cloud environment where the
+cluster will be.
+
+Note that we have the `init.sh` like so:
+
+```
+#!/bin/bash
+
+echo "This is the init script"
+echo "The config root is {{ var `vars/config/root` }}"
+echo "The cluster size is {{ var `vars/cluster/size` }}"
+```

--- a/docs/cmd/infrakit/util/init/README.md
+++ b/docs/cmd/infrakit/util/init/README.md
@@ -146,8 +146,9 @@ data fully available.
 
 ### `--var` or `--metadata`?
 
-This is a matter of tasted as they serve different purposes.  If a parameter is only
-meant to be temporary, `--var` will avoid cluttering up the data store.  However,
+This is a matter of taste and requirements, as they serve different purposes.
+If a parameter is only meant to be temporary, `--var` will avoid cluttering up
+the data store.  However,
 `--metadata` is easier to reason about across time and location because that data
 is highly available.  For simplicity, `--metadata` may be the way to start off developing
 your custom templates.

--- a/docs/cmd/infrakit/util/init/README.md
+++ b/docs/cmd/infrakit/util/init/README.md
@@ -14,6 +14,45 @@ configuration information is always accessible.
 This example here uses the `vars.json`, `groups.json`, `common.ikt`, and `init.sh`
 in this directory.
 
+### Operation
+
+To render the init script from the groups specification is complex and involves
+multiple steps.  This is because bootstrapping from a single node requires a mix
+of user-provided data, as well as values that are available *after* some additional
+future step (e.g. getting a cluster master to provide a join token -- which is not
+available until the cluster is bootstrapping itself).  So while the configuration specs
+and scripts look like a set of point-in-time configurations, multiple evaluations
+of these as templates are performed as more data become available.  The sequence
+of `init` works as follows:
+
+  1. The user provides the spec's URL (the `groups.json` URL)
+  2. The CLI fetches this and evaluates it as a template.
+    + The engine uses the `INFRAKIT_VARS_TEMPLATE` env to determine a variables JSON to
+    initialize some variables.  These can be overridden by appropriately named `--var`
+    and `--metdata` flags in the command line.
+    + The engine uses the `--var` to set parameters in memory for the scope of *this*
+    evaluation.  These are ephemeral and can override the defaults set in above.
+    + The engine uses the `--metadata` to set parameters that will persist, as some
+    kind of cluster-state.  These values are persistent and are written to the backend
+    based on your configuration (eg. swarm, etcd, or file).
+  3. The CLI parses the spec, and locates the section for the group as specified by
+  the `group-id` flag.
+  4. The CLI now starts the plugins specified in the spec.  For example, the spec
+  here references the `swarm/managers` plugin, so the CLI starts up the `swarm` plugin.
+  5. The CLI invokes the flavor plugin's `Prepare` method.
+  6. The Flavor plugin performs the necessary work such as generating tokens, etc. and
+  renders a template.  Depending on the plugin implementation, values that are not known
+  at this time may be deferred (as multipass = true -- see `swarm/flavor.go#31).
+  7. The CLI renders the text blob from the `Init` field of the instance spec returned
+  by the `Prepare` method.  This will apply the same set of `--var` as varaibles.
+  8. The CLI prints out the rendered init script
+  9. If `--persist` is set, the CLI will commit the current state of the vars plugin
+  (which was started in the beginning of this process).
+
+** This is pretty complicated but the details here are presented for documentation.
+The end user only knows there are certain variables to set to bootstrap a cluster,
+and the values are set via the `--var` and `--metadata` flags (e.g. the size of the cluster).
+
 To run
 
 ```shell
@@ -42,3 +81,73 @@ echo "This is the init script"
 echo "The config root is {{ var `vars/config/root` }}"
 echo "The cluster size is {{ var `vars/cluster/size` }}"
 ```
+
+### Persist values via `--metadata`
+
+We don't always want every parameter used for templates to be stored as cluster state,
+but there are times, some parameters need to persist from node to node and through time.
+For those parameters, use `--metadata` followed by a `--persist` to ensure data is persisted
+into the the backend that's configured.
+
+```shell
+$INFRAKIT_VARS_TEMPLATE=file://$(pwd)/vars.json infrakit util init --group-id managers groups.json --metadata vars/config/root=file://$(pwd) --persist
+```
+
+This yields the same:
+
+```
+#!/bin/bash
+
+echo "This is the init script"
+echo "The config root is file:///Users/davidchung/project5/src/github.com/docker/infrakit/docs/cmd/infrakit/util/init"
+echo "The cluster size is 5"
+```
+
+However, the data has been snapshoted and persisted -- in this case as a file:
+
+```shell
+$ export INFRAKIT_HOME=~/.infrakit
+$ cat $INFRAKIT_HOME/configs/vars.vars
+{
+    "cluster": {
+      "name": "test",
+      "size": 5,
+      "swarm": {
+        "joinIP": "10.20.100.101",
+        "managerIPs": [
+          "10.20.100.101",
+          "10.20.100.102",
+          "10.20.100.103"
+        ]
+      },
+      "user": {
+        "name": "user"
+      }
+    },
+    "config": {
+      "root": "file:///Users/davidchung/project5/src/github.com/docker/infrakit/docs/cmd/infrakit/util/init"
+    },
+    "shell": "/bin/bash",
+    "zones": {
+      "east": {
+        "cidr": "10.20.100.100/24"
+      },
+      "west": {
+        "cidr": "10.20.100.200/24"
+      }
+    }
+  }
+```
+
+Next time if `manager` is started it will automatically load this state.  In case
+of failover, the manager on another node will load this as well as the cluster spec
+as part of failing over.  So we have the cluster specs as well as user-provided
+data fully available.
+
+### `--var` or `--metadata`?
+
+This is a matter of tasted as they serve different purposes.  If a parameter is only
+meant to be temporary, `--var` will avoid cluttering up the data store.  However,
+`--metadata` is easier to reason about across time and location because that data
+is highly available.  For simplicity, `--metadata` may be the way to start off developing
+your custom templates.

--- a/docs/cmd/infrakit/util/init/common.ikt
+++ b/docs/cmd/infrakit/util/init/common.ikt
@@ -1,0 +1,24 @@
+{{/* Var variables */}}
+
+{{ var `/cluster/swarm/join/ip` `172.31.16.101` }}
+{{ var `/cluster/swarm/manager/ips` (tuple `172.31.16.101` `172.31.16.102` `172.31.16.103`) }}
+{{ if empty (var `/local/docker/engine/labels`) }}{{ var `/local/docker/engine/labels` (jsonDecode `[]`) }}{{end}}
+
+{{/*
+Integration with the metadata plugin here.
+See infrakit.sh when booting up, we store the variables from cloudformation
+in the vars metadata plugin so that the user-entered values like cluster size can be
+queried later even after the bootstrapping (cloudformation) completes.
+*/}}
+{{ if metadata `vars` }}
+{{ var `/cluster/provider`            ( metadata `vars/cluster/provider` ) }}
+{{ var `/cluster/name`                ( metadata `vars/cluster/name` )}}
+{{ var `/cluster/size`                ( metadata `vars/cluster/size` )}}
+{{ var `/infrakit/config/root`        ( metadata `vars/infrakit/config/root` )}}
+{{ var `/infrakit/metadata/configURL` ( metadata `vars/infrakit/metadata/configURL` ) }}
+{{ var `/infrakit/docker/image`       ( metadata `vars/infrakit/docker/image` )}}
+{{ var `/provider/image/hasDocker`    ( metadata `vars/provider/image/hasDocker` )}}
+{{ end }}
+
+{{ var `/local/install/docker` (var `/provider/image/hasDocker` | default `no` | eq `no` ) }}
+{{ var `/local/docker/user` `ubuntu` }}

--- a/docs/cmd/infrakit/util/init/groups.json
+++ b/docs/cmd/infrakit/util/init/groups.json
@@ -1,0 +1,49 @@
+{{ source "common.ikt" }}{{/* source some variables */}}
+
+{{/* Local variables */}}
+{{ $swarmLeaderIP := var `vars/cluster/swarm/joinIP` }}
+{{ $managerIPs := var `vars/cluster/swarm/managerIPs` }}
+{{ $workerSize := sub (var `vars/cluster/size`) (len $managerIPs) }}
+{{ $managerInit := cat (var `vars/config/root`) `/init.sh` | nospace }}
+
+{{ $dockerEngine := `unix:///var/run/docker.sock` }} {{/* for this flavor to connect to */}}
+[
+    {
+        "Plugin": "group",
+        "Properties": {
+            "ID": "managers",
+            "Properties": {
+                "Allocation": {
+                    "LogicalIDs": {{ $managerIPs | jsonEncode }}
+                },
+                "Flavor": {
+                    "Plugin": "swarm/manager",
+                    "Properties": {
+                        "Attachments" : {
+                            "{{index $managerIPs 0}}" : [
+                                { "ID":"{{index $managerIPs 0}}", "Type":"ebs" }
+                            ],
+                            "{{index $managerIPs 1}}" : [
+                                { "ID":"{{index $managerIPs 1}}", "Type":"ebs" }
+                            ],
+                            "{{index $managerIPs 2}}" : [
+                                { "ID":"{{index $managerIPs 2}}", "Type":"ebs" }
+                            ]
+                        },
+                        "InitScriptTemplateURL": "{{ $managerInit }}",
+                        "SwarmJoinIP": "{{ $swarmLeaderIP }}",
+                        "Docker" : {
+                            "Host" : "{{ $dockerEngine }}"
+                        }
+                    }
+                },
+                "Instance": {
+                    "Plugin" : "simulator/compute",
+                    "Properties" : {
+                        "CustomNotes" : "This is custom for manager"
+                    }
+                }
+            }
+        }
+    }
+]

--- a/docs/cmd/infrakit/util/init/groups.json
+++ b/docs/cmd/infrakit/util/init/groups.json
@@ -17,25 +17,41 @@
                     "LogicalIDs": {{ $managerIPs | jsonEncode }}
                 },
                 "Flavor": {
-                    "Plugin": "swarm/manager",
-                    "Properties": {
-                        "Attachments" : {
-                            "{{index $managerIPs 0}}" : [
-                                { "ID":"{{index $managerIPs 0}}", "Type":"ebs" }
-                            ],
-                            "{{index $managerIPs 1}}" : [
-                                { "ID":"{{index $managerIPs 1}}", "Type":"ebs" }
-                            ],
-                            "{{index $managerIPs 2}}" : [
-                                { "ID":"{{index $managerIPs 2}}", "Type":"ebs" }
-                            ]
+                    "Plugin" : "combo",
+                    "Properties" : [
+                        {
+                            "Plugin": "swarm/manager",
+                            "Properties": {
+                                "Attachments" : {
+                                    "{{index $managerIPs 0}}" : [
+                                        { "ID":"{{index $managerIPs 0}}", "Type":"ebs" }
+                                    ],
+                                    "{{index $managerIPs 1}}" : [
+                                        { "ID":"{{index $managerIPs 1}}", "Type":"ebs" }
+                                    ],
+                                    "{{index $managerIPs 2}}" : [
+                                        { "ID":"{{index $managerIPs 2}}", "Type":"ebs" }
+                                    ]
+                                },
+                                "InitScriptTemplateURL": "{{ $managerInit }}",
+                                "SwarmJoinIP": "{{ $swarmLeaderIP }}",
+                                "Docker" : {
+                                    "Host" : "{{ $dockerEngine }}"
+                                }
+                            }
                         },
-                        "InitScriptTemplateURL": "{{ $managerInit }}",
-                        "SwarmJoinIP": "{{ $swarmLeaderIP }}",
-                        "Docker" : {
-                            "Host" : "{{ $dockerEngine }}"
+                        {
+                            "Plugin": "vanilla",
+                            "Properties": {
+                                "Init" : [
+                                    "sudo apt-get install -y something-else",
+                                    "./configure-something-else"
+                                ]
+                            }
                         }
-                    }
+                    ]
+
+
                 },
                 "Instance": {
                     "Plugin" : "simulator/compute",

--- a/docs/cmd/infrakit/util/init/init.sh
+++ b/docs/cmd/infrakit/util/init/init.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+echo "This is the init script"
+echo "The config root is {{ var `vars/config/root` }}"
+echo "The cluster size is {{ var `vars/cluster/size` }}"

--- a/docs/cmd/infrakit/util/init/vars.json
+++ b/docs/cmd/infrakit/util/init/vars.json
@@ -1,0 +1,19 @@
+{{/*
+The vars.json is itself a template.  You can embed template functions
+which will be evaluated when the engine renders itself to create the
+JSON used by the vars plugin.
+*/}}
+{{ var `cluster/user/name` `user` }}
+{{ var `zones/east/cidr` `10.20.100.100/24` }}
+{{ var `zones/west/cidr` `10.20.100.200/24` }}
+{
+    "cluster" : {
+        "size" : 5,
+        "name" : "test",
+        "swarm" : {
+            "joinIP" : "10.20.100.101",
+            "managerIPs" : [ "10.20.100.101", "10.20.100.102", "10.20.100.103" ]
+        }
+    },
+    "shell" : {{ env `SHELL` }}
+}

--- a/pkg/cli/plugins.go
+++ b/pkg/cli/plugins.go
@@ -1,0 +1,34 @@
+package cli
+
+import (
+	"time"
+
+	"github.com/docker/infrakit/pkg/discovery"
+	"github.com/docker/infrakit/pkg/launch"
+	"github.com/docker/infrakit/pkg/run/manager"
+	"github.com/docker/infrakit/pkg/types"
+)
+
+// PluginManager returns the plugin manager for running plugins locally.
+func PluginManager(plugins func() discovery.Plugins,
+	services *Services, configURL string) (*manager.Manager, error) {
+
+	parsedRules := []launch.Rule{}
+
+	if configURL != "" {
+		buff, err := services.ProcessTemplate(configURL)
+		if err != nil {
+			return nil, err
+		}
+		view, err := services.ToJSON([]byte(buff))
+		if err != nil {
+			return nil, err
+		}
+		configs := types.AnyBytes(view)
+		err = configs.Decode(&parsedRules)
+		if err != nil {
+			return nil, err
+		}
+	}
+	return manager.ManagePlugins(parsedRules, plugins, true, 5*time.Second)
+}

--- a/pkg/controller/enrollment/types/types.go
+++ b/pkg/controller/enrollment/types/types.go
@@ -21,7 +21,7 @@ func init() {
 }
 
 // ResolveDependencies returns a list of dependencies by parsing the opaque Properties blob.
-func ResolveDependencies(spec types.Spec) ([]plugin.Name, error) {
+func ResolveDependencies(spec types.Spec) (depends.Runnables, error) {
 	if spec.Properties == nil {
 		return nil, nil
 	}
@@ -32,7 +32,14 @@ func ResolveDependencies(spec types.Spec) ([]plugin.Name, error) {
 		return nil, err
 	}
 
-	return []plugin.Name{properties.Instance.Plugin}, nil
+	return depends.Runnables{
+		depends.AsRunnable(types.Spec{
+			Kind: properties.Instance.Plugin.Lookup(),
+			Metadata: types.Metadata{
+				Name: properties.Instance.Plugin.String(),
+			},
+		}),
+	}, nil
 }
 
 // ListSourceUnion is a union type of possible values:

--- a/pkg/controller/ingress/types/types.go
+++ b/pkg/controller/ingress/types/types.go
@@ -18,7 +18,7 @@ func init() {
 }
 
 // ResolveDependencies returns a list of dependencies by parsing the opaque Properties blob.
-func ResolveDependencies(spec types.Spec) ([]plugin.Name, error) {
+func ResolveDependencies(spec types.Spec) (depends.Runnables, error) {
 	if spec.Properties == nil {
 		return nil, nil
 	}
@@ -29,9 +29,9 @@ func ResolveDependencies(spec types.Spec) ([]plugin.Name, error) {
 		return nil, err
 	}
 
-	out := []plugin.Name{}
+	out := depends.Runnables{}
 	for _, p := range properties {
-		out = append(out, p.L4Plugin)
+		out = append(out, depends.RunnableFrom(p.L4Plugin))
 	}
 	return out, nil
 }

--- a/pkg/core/addressable.go
+++ b/pkg/core/addressable.go
@@ -49,9 +49,9 @@ func NewAddressableFromMetadata(kind string, metadata types.Metadata) Addressabl
 	return NewAddressable(kind, plugin.Name(metadata.Name), instance)
 }
 
-// NewAddressable returns a generic addressable object from just the plugin name.
+// NewAddressableFromPluginName returns a generic addressable object from just the plugin name.
 // The kind is assume to be the same as the lookup.
-func AddressableFromPluginName(pn plugin.Name) Addressable {
+func NewAddressableFromPluginName(pn plugin.Name) Addressable {
 	return NewAddressable(pn.Lookup(), pn, "")
 }
 

--- a/pkg/core/addressable.go
+++ b/pkg/core/addressable.go
@@ -49,6 +49,12 @@ func NewAddressableFromMetadata(kind string, metadata types.Metadata) Addressabl
 	return NewAddressable(kind, plugin.Name(metadata.Name), instance)
 }
 
+// NewAddressable returns a generic addressable object from just the plugin name.
+// The kind is assume to be the same as the lookup.
+func AddressableFromPluginName(pn plugin.Name) Addressable {
+	return NewAddressable(pn.Lookup(), pn, "")
+}
+
 // NewAddressable returns a generic addressable object
 func NewAddressable(kind string, pn plugin.Name, instance string) Addressable {
 	n := string(pn)

--- a/pkg/core/addressable_test.go
+++ b/pkg/core/addressable_test.go
@@ -54,7 +54,7 @@ metadata:
 	require.Equal(t, "group-stateless/mygroup", string(c.Plugin()))
 	require.Equal(t, "mygroup", c.Instance())
 
-	c = AddressableFromPluginName(plugin.Name("swarm/manager"))
+	c = NewAddressableFromPluginName(plugin.Name("swarm/manager"))
 	require.Equal(t, "swarm", c.Kind())
 	require.Equal(t, "swarm/manager", string(c.Plugin()))
 	require.Equal(t, "swarm", c.Plugin().Lookup())

--- a/pkg/core/addressable_test.go
+++ b/pkg/core/addressable_test.go
@@ -53,6 +53,11 @@ metadata:
 	require.Equal(t, "group", c.Kind())
 	require.Equal(t, "group-stateless/mygroup", string(c.Plugin()))
 	require.Equal(t, "mygroup", c.Instance())
+
+	c = AddressableFromPluginName(plugin.Name("swarm/manager"))
+	require.Equal(t, "swarm", c.Kind())
+	require.Equal(t, "swarm/manager", string(c.Plugin()))
+	require.Equal(t, "swarm", c.Plugin().Lookup())
 }
 
 func TestDerivePluginNames(t *testing.T) {

--- a/pkg/manager/manager.go
+++ b/pkg/manager/manager.go
@@ -212,7 +212,7 @@ func (m *manager) Start() (<-chan struct{}, error) {
 				// same leader node.
 				err := m.loadMetadata()
 				if err != nil {
-					log.Error("error loading metadata", "err", err)
+					log.Debug("error loading metadata", "err", err)
 				}
 
 				<-metadataRefresh
@@ -385,7 +385,7 @@ func (m *manager) loadMetadata() (err error) {
 		return nil
 	}
 
-	log.Info("loading metadata and committing")
+	log.Debug("loading metadata and committing")
 
 	var saved interface{}
 	err = m.Options.MetadataStore.Load(&saved)
@@ -400,7 +400,7 @@ func (m *manager) loadMetadata() (err error) {
 	}
 
 	if any == nil {
-		log.Info("no metadata stored")
+		log.Debug("no metadata stored")
 		return
 	}
 

--- a/pkg/plugin/flavor/combo/depends.go
+++ b/pkg/plugin/flavor/combo/depends.go
@@ -1,0 +1,32 @@
+package combo
+
+import (
+	"github.com/docker/infrakit/pkg/run/depends"
+	"github.com/docker/infrakit/pkg/spi/flavor"
+	"github.com/docker/infrakit/pkg/types"
+)
+
+func init() {
+	depends.Register("combo", types.InterfaceSpec(flavor.InterfaceSpec), ResolveDependencies)
+}
+
+// ResolveDependencies returns a list of dependencies by parsing the opaque Properties blob.
+// Do not include self -- only the children / dependent components.
+func ResolveDependencies(spec types.Spec) (depends.Runnables, error) {
+	if spec.Properties == nil {
+		return nil, nil
+	}
+
+	flavorSpecs := Spec{}
+	err := spec.Properties.Decode(&flavorSpecs)
+	if err != nil {
+		return nil, err
+	}
+
+	runnables := depends.Runnables{}
+	for _, flavorSpec := range flavorSpecs {
+		included := depends.RunnableFrom(flavorSpec.Plugin)
+		runnables = append(runnables, included)
+	}
+	return runnables, nil
+}

--- a/pkg/plugin/flavor/combo/depends_test.go
+++ b/pkg/plugin/flavor/combo/depends_test.go
@@ -1,0 +1,44 @@
+package combo
+
+import (
+	"testing"
+
+	"github.com/docker/infrakit/pkg/plugin"
+	"github.com/docker/infrakit/pkg/types"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDependencies(t *testing.T) {
+
+	spec := types.Spec{
+		Kind: "combo",
+		Metadata: types.Metadata{
+			Name: "managers",
+		},
+		Properties: types.AnyValueMust(
+			Spec{
+				{
+					Plugin: plugin.Name("swarm/manager"),
+					Properties: types.AnyValueMust(
+						map[string]interface{}{
+							"docker": "unix:///var/run/docker.sock",
+						},
+					),
+				},
+				{
+					Plugin: plugin.Name("kubernetes/manager"),
+					Properties: types.AnyValueMust(
+						map[string]interface{}{
+							"addOns": "weave",
+						},
+					),
+				},
+			},
+		),
+	}
+
+	runnables, err := ResolveDependencies(spec)
+	require.NoError(t, err)
+	require.Equal(t, "swarm", runnables[0].Plugin().Lookup())
+	require.Equal(t, "kubernetes", runnables[1].Plugin().Lookup())
+}

--- a/pkg/rpc/client/handshake.go
+++ b/pkg/rpc/client/handshake.go
@@ -49,7 +49,7 @@ func (c *handshakingClient) handshake() error {
 			return err
 		}
 
-		err = fmt.Errorf("Plugin does not support interface %v", c.iface)
+		err = fmt.Errorf("Plugin does not support interface %v", c.iface.Encode())
 		for _, iface := range apis {
 			if iface.Name == c.iface.Name {
 				if iface.Version == c.iface.Version {

--- a/pkg/rpc/client/handshake_test.go
+++ b/pkg/rpc/client/handshake_test.go
@@ -72,7 +72,7 @@ func TestHandshakeFailWrongAPI(t *testing.T) {
 	client := rpcClient{client: r}
 	err = client.DoSomething()
 	require.Error(t, err)
-	require.Equal(t, "Plugin does not support interface {OtherPlugin 0.1.0}", err.Error())
+	require.Equal(t, "Plugin does not support interface OtherPlugin/0.1.0", err.Error())
 }
 
 type rpcClient struct {

--- a/pkg/run/depends/depends.go
+++ b/pkg/run/depends/depends.go
@@ -5,14 +5,13 @@ import (
 	"sync"
 
 	logutil "github.com/docker/infrakit/pkg/log"
-	"github.com/docker/infrakit/pkg/plugin"
 	"github.com/docker/infrakit/pkg/types"
 )
 
 var log = logutil.New("module", "run/depends")
 
 // ParseDependsFunc returns a list of dependencies of this spec.
-type ParseDependsFunc func(types.Spec) ([]plugin.Name, error)
+type ParseDependsFunc func(types.Spec) (Runnables, error)
 
 var (
 	parsers = map[string]map[types.InterfaceSpec]ParseDependsFunc{}
@@ -38,7 +37,7 @@ func Register(key string, interfaceSpec types.InterfaceSpec, f ParseDependsFunc)
 // Resolve returns the dependencies listed in the spec as well as inside the properties.
 // InterfaceSpec is optional.  If nil, the first match by key (kind) is used.  If nothing is registered, returns nil
 // and no error.  Error is returned for exceptions (eg. parsing, etc.)
-func Resolve(spec types.Spec, key string, interfaceSpec *types.InterfaceSpec) ([]plugin.Name, error) {
+func Resolve(spec types.Spec, key string, interfaceSpec *types.InterfaceSpec) (Runnables, error) {
 	lock.RLock()
 	defer lock.RUnlock()
 

--- a/pkg/run/depends/depends_test.go
+++ b/pkg/run/depends/depends_test.go
@@ -1,0 +1,59 @@
+package depends
+
+import (
+	"testing"
+
+	"github.com/docker/infrakit/pkg/types"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDepends(t *testing.T) {
+
+	v := types.DecodeInterfaceSpec("Test/0.1")
+	Register("test", v, func(spec types.Spec) (Runnables, error) {
+		return Runnables{
+			AsRunnable(mustSpec(types.SpecFromString(`
+kind: simulator/compute
+version: Instance/0.1
+metadata:
+  name: us-east1
+options:
+  poll: 10
+`))),
+			AsRunnable(mustSpec(types.SpecFromString(`
+kind: swarm/manager
+version: Flavor/0.1
+metadata:
+  name: swarm
+options:
+  docker: /var/run/docker.sock
+`))),
+		}, nil
+	})
+
+	found, err := Resolve(mustSpec(types.SpecFromString(``)), "test", &v)
+	require.NoError(t, err)
+	// in this case, the resolver always returns 2
+	require.Equal(t, Runnables{
+		AsRunnable(mustSpec(types.SpecFromString(`
+kind: simulator/compute
+version: Instance/0.1
+metadata:
+  name: us-east1
+options:
+  poll: 10
+`))),
+		AsRunnable(mustSpec(types.SpecFromString(`
+kind: swarm/manager
+version: Flavor/0.1
+metadata:
+  name: swarm
+options:
+  docker: /var/run/docker.sock
+`))),
+	}, found)
+
+	found, err = Resolve(mustSpec(types.SpecFromString(``)), "nope", &v)
+	require.NoError(t, err)
+	require.Equal(t, 0, len(found))
+}

--- a/pkg/run/depends/runnable.go
+++ b/pkg/run/depends/runnable.go
@@ -1,0 +1,116 @@
+package depends
+
+import (
+	"fmt"
+	"sort"
+
+	"github.com/docker/infrakit/pkg/core"
+	"github.com/docker/infrakit/pkg/plugin"
+	"github.com/docker/infrakit/pkg/types"
+)
+
+// Runnable models an addressable object that can also be started.
+type Runnable interface {
+	core.Addressable
+	// Options returns the options needed to start the plugin
+	Options() *types.Any
+	// Dependents return all the plugins this runnable depends on
+	Dependents() (Runnables, error)
+}
+
+// Runnables represent a collection of Runnables
+type Runnables []Runnable
+
+// RunnableFrom creates a runnable from input name.  This is a simplification
+// for cases where only a plugin name is used to reference another plugin.
+func RunnableFrom(name plugin.Name) Runnable {
+	kind := name.Lookup()
+	return specQuery{
+		Addressable: core.NewAddressable(kind, name, ""),
+		spec: types.Spec{
+			Kind: kind,
+			Metadata: types.Metadata{
+				Name: string(name),
+			},
+		},
+	}
+}
+
+// AsRunnable returns the Runnable from a spec.
+func AsRunnable(spec types.Spec) Runnable {
+	return &specQuery{
+		Addressable: core.AsAddressable(spec),
+		spec:        spec,
+	}
+}
+
+type specQuery struct {
+	core.Addressable
+	spec types.Spec
+}
+
+// Options returns the options
+func (ps specQuery) Options() *types.Any {
+	return ps.spec.Options
+}
+
+// Dependents returns the plugins depended on by this unit
+func (ps specQuery) Dependents() (Runnables, error) {
+
+	var interfaceSpec *types.InterfaceSpec
+	if ps.spec.Version != "" {
+		decoded := types.DecodeInterfaceSpec(ps.spec.Version)
+		interfaceSpec = &decoded
+	}
+	dependentPlugins, err := Resolve(ps.spec, ps.Kind(), interfaceSpec)
+	if err != nil {
+		return nil, err
+	}
+	log.Debug("dependentPlugins", "depends", dependentPlugins, "spec", ps.spec, "kind", ps.Kind(), "intf", interfaceSpec)
+
+	// join this with the dependencies already in the spec
+	out := Runnables{}
+	out = append(out, dependentPlugins...)
+
+	for _, d := range ps.spec.Depends {
+		out = append(out, AsRunnable(types.Spec{Kind: d.Kind, Metadata: types.Metadata{Name: d.Name}}))
+	}
+
+	log.Debug("dependents", "specQuery", ps, "result", out)
+	return out, nil
+}
+
+// RunnablesFrom returns the Runnables from given slice of specs
+func RunnablesFrom(specs []types.Spec) (Runnables, error) {
+
+	key := func(addr core.Addressable) string {
+		return fmt.Sprintf("%v::%v", addr.Kind(), addr.Plugin().Lookup())
+	}
+
+	keys := []string{}
+	// keyed by kind and the specQuery
+	all := map[string]Runnable{}
+	for _, s := range specs {
+
+		q := AsRunnable(s)
+		all[key(q)] = q
+		keys = append(keys, key(q))
+
+		deps, err := q.Dependents()
+		if err != nil {
+			return nil, err
+		}
+
+		for _, d := range deps {
+			all[key(d)] = d
+			keys = append(keys, key(d))
+		}
+	}
+
+	sort.Strings(keys)
+	out := Runnables{}
+	for _, k := range keys {
+		out = append(out, all[k])
+	}
+	return out, nil
+}

--- a/pkg/run/depends/runnable_test.go
+++ b/pkg/run/depends/runnable_test.go
@@ -1,0 +1,252 @@
+package depends
+
+import (
+	"testing"
+
+	"github.com/docker/infrakit/pkg/plugin"
+	"github.com/docker/infrakit/pkg/types"
+	"github.com/stretchr/testify/require"
+)
+
+func mustSpec(s types.Spec, err error) types.Spec {
+	if err != nil {
+		panic(err)
+	}
+	return s
+}
+
+func mustSpecs(s []types.Spec, err error) []types.Spec {
+	if err != nil {
+		panic(err)
+	}
+	return s
+}
+
+func TestRunnable(t *testing.T) {
+	v := types.DecodeInterfaceSpec("Test/0.1")
+	Register("TestRunnable", v, func(spec types.Spec) (Runnables, error) {
+		return Runnables{AsRunnable(spec)}, nil
+	})
+
+	runnable := AsRunnable(mustSpec(types.SpecFromString(`
+kind: group
+metadata:
+  name: workers
+properties:
+  max: 100
+  min: 10
+options:
+  poll: 10
+`)))
+
+	require.Equal(t, "group", runnable.Kind())
+	require.Equal(t, plugin.Name("group/workers"), runnable.Plugin())
+	require.Equal(t, "workers", runnable.Instance())
+	options := map[string]int{}
+	require.NoError(t, runnable.Options().Decode(&options))
+	require.Equal(t, map[string]int{"poll": 10}, options)
+
+	deps, err := runnable.Dependents()
+	require.NoError(t, err)
+	require.Equal(t, Runnables{}, deps)
+}
+
+func TestRunnableWithDepends(t *testing.T) {
+	v := types.DecodeInterfaceSpec("group/0.1")
+	Register("group", v, func(spec types.Spec) (Runnables, error) {
+		// This just echos back whatever comes in
+		return Runnables{AsRunnable(spec)}, nil
+	})
+
+	runnable := AsRunnable(mustSpec(types.SpecFromString(`
+kind: group
+version: group/0.1
+metadata:
+  name: workers
+properties:
+  max: 100
+  min: 10
+options:
+  poll: 10
+`)))
+
+	require.Equal(t, "group", runnable.Kind())
+	require.Equal(t, plugin.Name("group/workers"), runnable.Plugin())
+	require.Equal(t, "workers", runnable.Instance())
+	options := map[string]int{}
+	require.NoError(t, runnable.Options().Decode(&options))
+	require.Equal(t, map[string]int{"poll": 10}, options)
+
+	deps, err := runnable.Dependents()
+	require.NoError(t, err)
+	require.Equal(t, Runnables{runnable}, deps)
+}
+
+func TestRunnablesFromSpec(t *testing.T) {
+
+	Register("group", types.InterfaceSpec{Name: "Group"}, func(spec types.Spec) (Runnables, error) {
+		if spec.Properties == nil {
+			return nil, nil
+		}
+
+		type t struct {
+			Instance struct {
+				Plugin     plugin.Name
+				Properties *types.Any
+				Options    *types.Any
+			}
+			Flavor struct {
+				Plugin     plugin.Name
+				Properties *types.Any
+				Options    *types.Any
+			}
+		}
+
+		groupSpec := t{}
+		err := spec.Properties.Decode(&groupSpec)
+		if err != nil {
+			return nil, err
+		}
+
+		return Runnables{
+			AsRunnable(types.Spec{
+				Kind: groupSpec.Instance.Plugin.Lookup(),
+				Metadata: types.Metadata{
+					Name: groupSpec.Instance.Plugin.String(),
+				},
+				Properties: groupSpec.Instance.Properties,
+				Options:    groupSpec.Instance.Options,
+			}),
+			AsRunnable(types.Spec{
+				Kind: groupSpec.Flavor.Plugin.Lookup(),
+				Metadata: types.Metadata{
+					Name: groupSpec.Flavor.Plugin.String(),
+				},
+				Properties: groupSpec.Flavor.Properties,
+				Options:    groupSpec.Flavor.Options,
+			}),
+		}, nil
+	})
+
+	runnables, err := RunnablesFrom(mustSpecs(types.SpecsFromString(`
+- kind: group
+  version: Group
+  metadata:
+    name: us-east-compute/workers
+  properties:
+    Allocation:
+      Size: 2
+    Flavor:
+      Plugin: vanilla
+      Properties:
+        Attachments:
+          - ID: attachid
+            Type: attachtype
+        Init:
+          - docker pull nginx:alpine
+          - docker run -d -p 80:80 nginx-alpine
+        Tags:
+          project: infrakit
+          tier: web
+    Instance:
+      Plugin: simulator/compute
+      Properties:
+        Note: Instance properties version 1.0
+  options:
+    poll: 10
+`)))
+
+	require.NoError(t, err)
+	require.Equal(t, "group", runnables[0].Kind())
+	require.Equal(t, "us-east-compute", runnables[0].Plugin().Lookup())
+	require.Equal(t, "simulator", runnables[1].Kind())
+	require.Equal(t, "simulator", runnables[1].Plugin().Lookup())
+	require.Equal(t, "vanilla", runnables[2].Kind())
+	require.Equal(t, "vanilla", runnables[2].Plugin().Lookup())
+
+	runnables, err = RunnablesFrom(mustSpecs(types.SpecsFromString(`
+- kind: group
+  version: Group
+  metadata:
+    name: us-east-compute/workers
+  properties:
+    Allocation:
+      Size: 2
+    Flavor:
+      Plugin: vanilla
+      Properties:
+        Attachments:
+          - ID: attachid
+            Type: attachtype
+        Init:
+          - docker pull nginx:alpine
+          - docker run -d -p 80:80 nginx-alpine
+        Tags:
+          project: infrakit
+          tier: web
+    Instance:
+      Plugin: simulator/compute
+      Properties:
+        Note: Instance properties version 1.0
+  options:
+    poll: 10
+
+- kind: ingress
+  metadata:
+    name: us-east-net/workers.com
+  properties:
+    routes: 10
+  options:
+    poll: 20
+`)))
+
+	require.NoError(t, err)
+	require.Equal(t, "group", runnables[0].Kind())
+	require.Equal(t, "us-east-compute", runnables[0].Plugin().Lookup())
+	require.Equal(t, "ingress", runnables[1].Kind())
+	require.Equal(t, "us-east-net", runnables[1].Plugin().Lookup())
+	require.Equal(t, "simulator", runnables[2].Kind())
+	require.Equal(t, "simulator", runnables[2].Plugin().Lookup())
+	require.Equal(t, "vanilla", runnables[3].Kind())
+	require.Equal(t, "vanilla", runnables[3].Plugin().Lookup())
+
+	require.Equal(t, "{\"poll\":10}", runnables[0].Options().String())
+	options := map[string]interface{}{}
+	require.NoError(t, runnables[1].Options().Decode(&options))
+	require.Equal(t, float64(20), options["poll"])
+
+	runnables, err = RunnablesFrom(mustSpecs(types.SpecsFromString(`
+- kind: ingress
+  metadata:
+    name: us-east-net/workers.com
+  properties:
+    routes: 10
+  options:
+    poll: 20
+
+# The lookup will be nfs (a plugin endpoint)
+- kind: simulator/disk
+  metadata:
+    name: nfs/disk1
+  properties:
+    cidr: 10.20.100.100/16
+
+# The lookup will default to simulator because it's not in the metadata/name
+- kind: simulator/net
+  metadata:
+    name: subnet1
+  properties:
+    cidr: 10.20.100.100/16
+
+
+`)))
+
+	require.NoError(t, err)
+	require.Equal(t, "ingress", runnables[0].Kind())
+	require.Equal(t, "us-east-net", runnables[0].Plugin().Lookup())
+	require.Equal(t, "simulator", runnables[1].Kind())
+	require.Equal(t, "nfs", runnables[1].Plugin().Lookup())
+	require.Equal(t, "simulator", runnables[2].Kind())
+	require.Equal(t, "simulator", runnables[2].Plugin().Lookup())
+
+}

--- a/pkg/run/manager/manager.go
+++ b/pkg/run/manager/manager.go
@@ -190,6 +190,7 @@ func (m *Manager) Launch(exec string, key string, name plugin.Name, options *typ
 
 	lookup, _ := name.GetLookupAndType()
 	if countMatches([]string{lookup}, running) > 0 {
+		log.Debug("already running", "lookup", lookup, "name", name)
 		m.started <- name
 		return nil
 	}

--- a/pkg/run/scope/local/depends.go
+++ b/pkg/run/scope/local/depends.go
@@ -1,0 +1,75 @@
+package local
+
+import (
+	"github.com/docker/infrakit/pkg/plugin"
+	group_types "github.com/docker/infrakit/pkg/plugin/group/types"
+	"github.com/docker/infrakit/pkg/run/depends"
+	group_kind "github.com/docker/infrakit/pkg/run/v0/group"
+	"github.com/docker/infrakit/pkg/spi/group"
+	"github.com/docker/infrakit/pkg/types"
+)
+
+// ParseInputSpecs parses the input bytes which is the groups.json, and calls
+// each time a group spec is found.
+func ParseInputSpecs(input []byte, foundGroupSpec func(group.ID, group_types.Spec)) error {
+	// TODO - update the schema soon. This is the Plugin/Properties schema
+	type spec struct {
+		Plugin     plugin.Name
+		Properties struct {
+			ID         group.ID
+			Properties group_types.Spec
+		}
+	}
+
+	specs := []spec{}
+	err := types.AnyBytes(input).Decode(&specs)
+	if err != nil {
+		return err
+	}
+	for _, s := range specs {
+		foundGroupSpec(s.Properties.ID, s.Properties.Properties)
+	}
+	return nil
+}
+
+// Plugins returns a list of startPlugin directives from the input.
+// This will recurse into any composable plugins.
+func Plugins(gid group.ID, gspec group_types.Spec) ([]StartPlugin, error) {
+	targets := []StartPlugin{}
+
+	spec, err := toSpec(gid, gspec)
+	if err != nil {
+		return nil, err
+	}
+
+	log.Debug("resolving", "groupID", gid, "spec", spec)
+	other, err := depends.Resolve(spec, spec.Kind, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	for _, r := range other {
+		targets = append(targets, FromAddressable(r))
+	}
+
+	return targets, nil
+}
+
+func toSpec(gid group.ID, g group_types.Spec) (spec types.Spec, err error) {
+	any, e := types.AnyValue(g)
+	if e != nil {
+		err = e
+		return
+	}
+	spec = types.Spec{
+		Kind:    group_kind.Kind,
+		Version: group.InterfaceSpec.Encode(),
+		Metadata: types.Metadata{
+			Identity: &types.Identity{ID: string(gid)},
+			Name:     plugin.NameFrom(group_kind.Kind, string(gid)).String(),
+		},
+		Properties: any,
+		Options:    nil, // TOOD -- the old format doesn't have this information.
+	}
+	return
+}

--- a/pkg/run/scope/local/depends.go
+++ b/pkg/run/scope/local/depends.go
@@ -9,28 +9,28 @@ import (
 	"github.com/docker/infrakit/pkg/types"
 )
 
-// ParseInputSpecs parses the input bytes which is the groups.json, and calls
-// each time a group spec is found.
-func ParseInputSpecs(input []byte, foundGroupSpec func(group.ID, group_types.Spec)) error {
-	// TODO - update the schema soon. This is the Plugin/Properties schema
-	type spec struct {
-		Plugin     plugin.Name
-		Properties struct {
-			ID         group.ID
-			Properties group_types.Spec
-		}
-	}
+// // ParseInputSpecs parses the input bytes which is the groups.json, and calls
+// // each time a group spec is found.
+// func ParseInputSpecs(input []byte, foundGroupSpec func(group.ID, group_types.Spec)) error {
+// 	// TODO - update the schema soon. This is the Plugin/Properties schema
+// 	type spec struct {
+// 		Plugin     plugin.Name
+// 		Properties struct {
+// 			ID         group.ID
+// 			Properties group_types.Spec
+// 		}
+// 	}
 
-	specs := []spec{}
-	err := types.AnyBytes(input).Decode(&specs)
-	if err != nil {
-		return err
-	}
-	for _, s := range specs {
-		foundGroupSpec(s.Properties.ID, s.Properties.Properties)
-	}
-	return nil
-}
+// 	specs := []spec{}
+// 	err := types.AnyBytes(input).Decode(&specs)
+// 	if err != nil {
+// 		return err
+// 	}
+// 	for _, s := range specs {
+// 		foundGroupSpec(s.Properties.ID, s.Properties.Properties)
+// 	}
+// 	return nil
+// }
 
 // Plugins returns a list of startPlugin directives from the input.
 // This will recurse into any composable plugins.

--- a/pkg/run/scope/local/local.go
+++ b/pkg/run/scope/local/local.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/docker/infrakit/pkg/core"
 	"github.com/docker/infrakit/pkg/discovery"
 	logutil "github.com/docker/infrakit/pkg/log"
 	"github.com/docker/infrakit/pkg/plugin"
@@ -24,6 +25,11 @@ var (
 // to use, etc.
 // The format is kind[:{plugin_name}][={os|inproc}]
 type StartPlugin string
+
+// FromAddressable returns a StartPlugin encoded string
+func FromAddressable(addr core.Addressable) StartPlugin {
+	return StartPlugin(fmt.Sprintf("%v:%v", addr.Kind(), addr.Plugin().Lookup()))
+}
 
 // Parse parses the specification into parts that the manager can use to launch plugins
 func (arg StartPlugin) Parse() (execName string, kind string, name plugin.Name, err error) {
@@ -83,12 +89,11 @@ func Execute(plugins func() discovery.Plugins,
 		if err != nil {
 			return err
 		}
-
 		err = pluginManager.Launch(execName, kind, name, nil)
 		if err != nil {
 			log.Warn("failed to launch", "exec", execName, "kind", kind, "name", name)
+			return err
 		}
-		return err
 	}
 
 	defer func() {

--- a/pkg/run/scope/local/local.go
+++ b/pkg/run/scope/local/local.go
@@ -1,0 +1,112 @@
+package local
+
+import (
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/docker/infrakit/pkg/discovery"
+	logutil "github.com/docker/infrakit/pkg/log"
+	"github.com/docker/infrakit/pkg/plugin"
+	"github.com/docker/infrakit/pkg/run/manager"
+	"github.com/docker/infrakit/pkg/run/scope"
+	group_kind "github.com/docker/infrakit/pkg/run/v0/group"
+	manager_kind "github.com/docker/infrakit/pkg/run/v0/manager"
+	"github.com/docker/infrakit/pkg/types"
+)
+
+var (
+	log    = logutil.New("module", "run/scope/local")
+	debugV = logutil.V(300)
+)
+
+// StartPlugin is a specification of what plugin to run and what socket name
+// to use, etc.
+// The format is kind[:{plugin_name}][={os|inproc}]
+type StartPlugin string
+
+// Parse parses the specification into parts that the manager can use to launch plugins
+func (arg StartPlugin) Parse() (execName string, kind string, name plugin.Name, err error) {
+	p := strings.Split(string(arg), "=")
+	execName = "inproc" // default is to use inprocess goroutine for running plugins
+	if len(p) > 1 {
+		execName = p[1]
+	}
+
+	// the format is kind[:{plugin_name}][={os|inproc}]
+	pp := strings.Split(p[0], ":")
+	kind = pp[0]
+	name = plugin.Name(kind)
+
+	// This is some special case for the legacy setup (pre v0.6)
+	switch kind {
+	case manager_kind.Kind:
+		name = plugin.Name(manager_kind.LookupName)
+	case group_kind.Kind:
+		name = plugin.Name(group_kind.LookupName)
+	}
+	// customized by user as override
+	if len(pp) > 1 {
+		name = plugin.Name(pp[1])
+	}
+
+	if kind == "" || execName == "" {
+		err = fmt.Errorf("invalid launch spec: %v", arg)
+	}
+	return
+}
+
+// Options are tuning parameters for executing a task in context of
+// a set of plugins that are started as required.
+type Options struct {
+	// StartWait is how long to wait to make sure all plugins are up
+	StartWait types.Duration
+	// StopWait is how long to wait to make sure all plugins are shut down
+	StopWait types.Duration
+}
+
+// Execute runs a unit of work with the specified list of plugins
+// running.
+func Execute(plugins func() discovery.Plugins,
+	pluginManager *manager.Manager,
+	starts func() ([]StartPlugin, error),
+	do scope.Work, options Options) error {
+
+	pluginsToStart, err := starts()
+	if err != nil {
+		return err
+	}
+
+	// first start up the plugins
+	for _, plugin := range pluginsToStart {
+		execName, kind, name, err := plugin.Parse()
+		if err != nil {
+			return err
+		}
+
+		err = pluginManager.Launch(execName, kind, name, nil)
+		if err != nil {
+			log.Warn("failed to launch", "exec", execName, "kind", kind, "name", name)
+		}
+		return err
+	}
+
+	defer func() {
+		<-time.After(options.StopWait.Duration())
+		pluginManager.TerminateAll()
+		pluginManager.WaitForAllShutdown()
+		pluginManager.Stop()
+	}()
+
+	pluginManager.WaitStarting()
+	<-time.After(options.StartWait.Duration())
+
+	log.Debug("Executing work in scope", "V", debugV)
+	err = do(scope.Scope{
+		Plugins: plugins, // Full access.  TODO -- scope this
+	})
+	if err != nil {
+		log.Error("error processing in scope", "err", err)
+	}
+	return err
+}

--- a/pkg/run/scope/scope.go
+++ b/pkg/run/scope/scope.go
@@ -1,0 +1,26 @@
+package scope
+
+import (
+	"github.com/docker/infrakit/pkg/discovery"
+)
+
+// Scope provides an environment in which the necessary plugins are available
+// for doing a unit of work.  The scope can be local or remote, namespaced,
+// depending on implementation.  The first implementation is to simply run
+// a set of steps locally on a set of required plugins.  Because the scope
+// provides the plugin lookup, it can control what plugins are available.
+// This is good for programmatically control access of what a piece of code
+// can interact with the system.
+// Scope is named scope instead of 'context' because it's much heavier weight
+// and involves lots of calls across process boundaries, yet it provides
+// lookup and scoping of services based on some business logical and locality
+// of code.
+type Scope struct {
+
+	// Plugins returns the plugin lookup
+	Plugins func() discovery.Plugins
+}
+
+// Work is a unit of work that is executed in the scope of the plugins
+// running. When work completes, the plugins are shutdown.
+type Work func(Scope) error

--- a/pkg/types/interface_spec.go
+++ b/pkg/types/interface_spec.go
@@ -17,6 +17,11 @@ type InterfaceSpec struct {
 	Sub string
 }
 
+// String implements the stringer for fmt printing
+func (i InterfaceSpec) String() string {
+	return i.Encode()
+}
+
 // Encode encodes a struct form to string
 func (i InterfaceSpec) Encode() string {
 	if i.Sub == "" {

--- a/pkg/types/interface_spec.go
+++ b/pkg/types/interface_spec.go
@@ -12,18 +12,31 @@ type InterfaceSpec struct {
 
 	// Version is the identifier for the API version.
 	Version string
+
+	// Sub is the name of 'subclass' entity that follows the general contract but has a distinguishing name
+	Sub string
 }
 
 // Encode encodes a struct form to string
 func (i InterfaceSpec) Encode() string {
-	return fmt.Sprintf("%s/%s", i.Name, i.Version)
+	if i.Sub == "" {
+		return fmt.Sprintf("%s/%s", i.Name, i.Version)
+	}
+	return fmt.Sprintf("%s/%s/%s", i.Name, i.Version, i.Sub)
 }
 
 // DecodeInterfaceSpec takes a string and returns the struct
 func DecodeInterfaceSpec(s string) InterfaceSpec {
-	p := strings.SplitN(s, "/", 2)
-	return InterfaceSpec{
+	p := strings.SplitN(s, "/", 3)
+	if len(p) == 1 {
+		return InterfaceSpec{Name: s}
+	}
+	i := InterfaceSpec{
 		Name:    p[0],
 		Version: p[1],
 	}
+	if len(p) == 3 {
+		i.Sub = p[2]
+	}
+	return i
 }


### PR DESCRIPTION
This PR

  + Addresses the issue (#729)
  + Adds the `--metadata` and `--persist` flags to set and persist metadata.
  + `util init` will parse the groups spec and starts the plugin automatically.  If `--persist` option
is specified, it will start up the manager, vars, and group plugins as pre-conditions for processing the input spec.
  + Added documentation -- see [`docs/cmd/infrakit/util/init/README.md`](docs/cmd/infrakit/util/init/README.md).

Signed-off-by: David Chung <david.chung@docker.com>
