### PR TITLE
Auto start plugins via `up` + various bug fixes

### DIFF
--- a/cmd/infrakit/up/up.go
+++ b/cmd/infrakit/up/up.go
@@ -39,6 +39,8 @@ func Command(plugins func() discovery.Plugins) *cobra.Command {
 
 	waitDuration := up.Flags().String("wait", "1s", "Wait for plugins to be ready")
 	configURL := up.Flags().String("config-url", "", "URL for the startup configs")
+	stack := up.Flags().String("stack", "mystack", "Name of the stack")
+
 	up.Flags().AddFlagSet(services.ProcessTemplateFlags)
 	metadatas := up.Flags().StringSlice("metadata", []string{}, "key=value to set metadata")
 
@@ -60,7 +62,8 @@ func Command(plugins func() discovery.Plugins) *cobra.Command {
 		wait := types.MustParseDuration(*waitDuration)
 
 		log.Info("Starting up base plugins")
-		basePlugins := []string{"vars", "manager"}
+		baseStack := fmt.Sprintf("manager:%v", *stack)
+		basePlugins := []string{"vars", "group:group-stateless", baseStack}
 		for _, base := range basePlugins {
 			execName, kind, name, _ := local.StartPlugin(base).Parse()
 			err := pluginManager.Launch(execName, kind, name, nil)

--- a/cmd/infrakit/util/init/init.go
+++ b/cmd/infrakit/util/init/init.go
@@ -174,11 +174,17 @@ func Command(plugins func() discovery.Plugins) *cobra.Command {
 			for _, start := range *starts {
 				targets = append(targets, local.StartPlugin(start))
 			}
-			more, err := local.Plugins(gid, groupSpec)
-			if err != nil {
-				return targets, err
+
+			// make this either-or to allow manual overriding.
+			if len(*starts) == 0 {
+
+				more, err := local.Plugins(gid, groupSpec)
+				if err != nil {
+					return targets, err
+				}
+				targets = append(targets, more...)
+
 			}
-			targets = append(targets, more...)
 			log.Info("plugins to start", "targets", targets)
 			return
 		}

--- a/pkg/manager/api.go
+++ b/pkg/manager/api.go
@@ -95,4 +95,10 @@ type Options struct {
 
 	// MetadataRefreshInterval is the interval to check for updates to metadata
 	MetadataRefreshInterval types.Duration
+
+	// LeaderCommitSpecsRetries is how many times to retry commit specs when becomes leader
+	LeaderCommitSpecsRetries int
+
+	// LeaderCommitSpecsRetryInterval is how long to wait before next retry
+	LeaderCommitSpecsRetryInterval types.Duration
 }

--- a/pkg/manager/manager.go
+++ b/pkg/manager/manager.go
@@ -460,8 +460,6 @@ func (m *manager) onAssumeLeadership() (err error) {
 	}
 
 	return err
-
-	return
 }
 
 func (m *manager) onLostLeadership() error {

--- a/pkg/manager/manager.go
+++ b/pkg/manager/manager.go
@@ -361,7 +361,7 @@ func (m *manager) getCurrentState() (globalSpec, error) {
 	return global, nil
 }
 
-func (m *manager) loadSpecs() error {
+func (m *manager) loadAndCommitSpecs() error {
 	if m.Options.SpecStore == nil {
 		return nil
 	}
@@ -385,7 +385,7 @@ func (m *manager) loadMetadata() (err error) {
 		return nil
 	}
 
-	log.Debug("loading metadata and committing")
+	log.Debug("loading metadata and committing", "V", debugV2)
 
 	var saved interface{}
 	err = m.Options.MetadataStore.Load(&saved)
@@ -400,11 +400,11 @@ func (m *manager) loadMetadata() (err error) {
 	}
 
 	if any == nil {
-		log.Debug("no metadata stored")
+		log.Debug("no metadata stored", "V", debugV2)
 		return
 	}
 
-	log.Debug("loaded metadata", "data", any.String())
+	log.Debug("loaded metadata", "data", any.String(), "V", debugV2)
 	_, proposed, cas, e := m.Updatable.Changes([]metadata.Change{
 		{Path: types.Dot, Value: any},
 	})
@@ -413,7 +413,7 @@ func (m *manager) loadMetadata() (err error) {
 		return
 	}
 
-	log.Debug("updating backend with stored metadata", "cas", cas, "proposed", proposed)
+	log.Debug("updating backend with stored metadata", "cas", cas, "proposed", proposed, "V", debugV2)
 	return m.Updatable.Commit(proposed, cas)
 }
 
@@ -427,10 +427,40 @@ func (m *manager) onAssumeLeadership() (err error) {
 		log.Error("error loading metadata", "err", err)
 	}
 
-	err = m.loadSpecs()
-	if err != nil {
-		log.Error("error loading specs", "err", err)
+	err = m.loadAndCommitSpecs()
+	log.Debug("Loading and committing specs", "err", err)
+
+	if err != nil && m.Options.LeaderCommitSpecsRetries > 0 {
+
+		log.Info("Retry loading and committing specs",
+			"retries", m.Options.LeaderCommitSpecsRetries,
+			"interval", m.Options.LeaderCommitSpecsRetryInterval)
+
+		delay := 1 * time.Second
+		if m.Options.LeaderCommitSpecsRetryInterval > 0 {
+			delay = m.Options.LeaderCommitSpecsRetryInterval.Duration()
+		}
+
+		for i := 1; i < m.Options.LeaderCommitSpecsRetries; i++ {
+
+			<-time.After(delay)
+
+			err = m.loadAndCommitSpecs()
+			if err == nil {
+				log.Info("Loaded and committed specs")
+				return nil
+			}
+
+			if err != nil {
+				log.Error("error loading specs", "err", err, "attempt", i)
+			}
+
+		}
+
 	}
+
+	return err
+
 	return
 }
 

--- a/pkg/rpc/client/handshake_test.go
+++ b/pkg/rpc/client/handshake_test.go
@@ -2,32 +2,10 @@ package client
 
 import (
 	"fmt"
-	"io/ioutil"
-	"net/http"
-	"path/filepath"
 	"testing"
 
-	"github.com/docker/infrakit/pkg/rpc/server"
-	"github.com/docker/infrakit/pkg/spi"
 	"github.com/stretchr/testify/require"
 )
-
-var apiSpec = spi.InterfaceSpec{
-	Name:    "TestPlugin",
-	Version: "0.1.0",
-}
-
-func startPluginServer(t *testing.T) (server.Stoppable, string) {
-	dir, err := ioutil.TempDir("", "infrakit_handshake_test")
-	require.NoError(t, err)
-
-	name := "instance"
-	socket := filepath.Join(dir, name)
-
-	testServer, err := server.StartPluginAtPath(socket, &TestPlugin{spec: apiSpec})
-	require.NoError(t, err)
-	return testServer, socket
-}
 
 func TestErrVersionMismatch(t *testing.T) {
 	var e error
@@ -37,74 +15,4 @@ func TestErrVersionMismatch(t *testing.T) {
 
 	e = fmt.Errorf("untyped")
 	require.False(t, IsErrVersionMismatch(e))
-}
-
-func TestHandshakeSuccess(t *testing.T) {
-	testServer, socket := startPluginServer(t)
-	defer testServer.Stop()
-
-	r, err := New(socket, apiSpec)
-	require.NoError(t, err)
-	client := rpcClient{client: r}
-	require.NoError(t, client.DoSomething())
-}
-
-func TestHandshakeFailVersion(t *testing.T) {
-	testServer, socket := startPluginServer(t)
-	defer testServer.Stop()
-
-	r, err := New(socket, spi.InterfaceSpec{Name: "TestPlugin", Version: "0.2.0"})
-	require.Error(t, err)
-
-	client := rpcClient{client: r}
-	err = client.DoSomething()
-	require.Error(t, err)
-	require.Equal(t, "Plugin supports TestPlugin interface version 0.1.0, client requires 0.2.0", err.Error())
-}
-
-func TestHandshakeFailWrongAPI(t *testing.T) {
-	testServer, socket := startPluginServer(t)
-	defer testServer.Stop()
-
-	r, err := New(socket, spi.InterfaceSpec{Name: "OtherPlugin", Version: "0.1.0"})
-	require.Error(t, err)
-
-	client := rpcClient{client: r}
-	err = client.DoSomething()
-	require.Error(t, err)
-	require.Equal(t, "Plugin does not support interface OtherPlugin/0.1.0", err.Error())
-}
-
-type rpcClient struct {
-	client Client
-}
-
-func (c rpcClient) DoSomething() error {
-	req := EmptyMessage{}
-	resp := EmptyMessage{}
-	return c.client.Call("TestPlugin.DoSomething", req, &resp)
-}
-
-// TestPlugin is an RPC service for this unit test.
-type TestPlugin struct {
-	spec spi.InterfaceSpec
-}
-
-// ImplementedInterface returns the interface implemented by this RPC service.
-func (p *TestPlugin) ImplementedInterface() spi.InterfaceSpec {
-	return p.spec
-}
-
-// Types returns the types
-func (p *TestPlugin) Types() []string {
-	return []string{"."}
-}
-
-// EmptyMessage is an empty test message.
-type EmptyMessage struct {
-}
-
-// DoSomething is an empty test RPC.
-func (p *TestPlugin) DoSomething(_ *http.Request, req *EmptyMessage, resp *EmptyMessage) error {
-	return nil
 }

--- a/pkg/rpc/group/publisher.go
+++ b/pkg/rpc/group/publisher.go
@@ -1,0 +1,20 @@
+package group
+
+import (
+	"fmt"
+
+	"github.com/docker/infrakit/pkg/spi/event"
+	"github.com/docker/infrakit/pkg/types"
+)
+
+// List returns a list of *child nodes* given a path for a topic.
+// A topic of "." is the top level
+func (p *Group) List(topic types.Path) (child []string, err error) {
+	fmt.Println(">>>>>> list")
+	return []string{"error", "provision", "destroy", "health", "drain", "prepare"}, nil
+}
+
+// PublishOn sets the channel to publish
+func (p *Group) PublishOn(chan<- *event.Event) {
+	fmt.Println(">>>>> publishOn")
+}

--- a/pkg/rpc/group/publisher.go
+++ b/pkg/rpc/group/publisher.go
@@ -1,8 +1,6 @@
 package group
 
 import (
-	"fmt"
-
 	"github.com/docker/infrakit/pkg/spi/event"
 	"github.com/docker/infrakit/pkg/types"
 )
@@ -10,11 +8,9 @@ import (
 // List returns a list of *child nodes* given a path for a topic.
 // A topic of "." is the top level
 func (p *Group) List(topic types.Path) (child []string, err error) {
-	fmt.Println(">>>>>> list")
 	return []string{"error", "provision", "destroy", "health", "drain", "prepare"}, nil
 }
 
 // PublishOn sets the channel to publish
 func (p *Group) PublishOn(chan<- *event.Event) {
-	fmt.Println(">>>>> publishOn")
 }

--- a/pkg/rpc/group/publisher.go
+++ b/pkg/rpc/group/publisher.go
@@ -8,7 +8,20 @@ import (
 // List returns a list of *child nodes* given a path for a topic.
 // A topic of "." is the top level
 func (p *Group) List(topic types.Path) (child []string, err error) {
-	return []string{"error", "provision", "destroy", "health", "drain", "prepare"}, nil
+	m := map[string]interface{}{}
+
+	subs := p.keyed.Types()
+	if len(subs) > 0 {
+		for _, t := range subs {
+			types.Put([]string{t, "commit"}, "", m)
+			types.Put([]string{t, "describe"}, "", m)
+		}
+	} else {
+		types.Put([]string{"commit"}, "", m)
+		types.Put([]string{"describe"}, "", m)
+	}
+
+	return types.List(topic, m), nil
 }
 
 // PublishOn sets the channel to publish

--- a/pkg/rpc/server/server.go
+++ b/pkg/rpc/server/server.go
@@ -128,7 +128,7 @@ func startAtPath(listen []string, discoverPath string,
 		}
 
 		// polymorphic -- register additional interfaces
-		if pub, is := t.(event.Publisher); is {
+		if pub, is := t.(event.Plugin); is {
 
 			t = rpc_event.PluginServer(pub)
 			interfaces[event.InterfaceSpec] = t.Types

--- a/pkg/rpc/server/server.go
+++ b/pkg/rpc/server/server.go
@@ -12,7 +12,7 @@ import (
 	broker "github.com/docker/infrakit/pkg/broker/server"
 	logutil "github.com/docker/infrakit/pkg/log"
 	rpc_server "github.com/docker/infrakit/pkg/rpc"
-	rpc_event "github.com/docker/infrakit/pkg/rpc/event"
+	//rpc_event "github.com/docker/infrakit/pkg/rpc/event"
 	"github.com/docker/infrakit/pkg/spi"
 	"github.com/docker/infrakit/pkg/spi/event"
 	"github.com/docker/infrakit/pkg/types"
@@ -128,17 +128,17 @@ func startAtPath(listen []string, discoverPath string,
 		}
 
 		// polymorphic -- register additional interfaces
-		if pub, is := t.(event.Plugin); is {
+		// if pub, is := t.(event.Plugin); is {
 
-			t = rpc_event.PluginServer(pub)
-			interfaces[event.InterfaceSpec] = t.Types
+		// 	t = rpc_event.PluginServer(pub)
+		// 	interfaces[event.InterfaceSpec] = t.Types
 
-			if err := server.RegisterService(t, ""); err != nil {
-				return nil, err
-			}
+		// 	if err := server.RegisterService(t, ""); err != nil {
+		// 		return nil, err
+		// 	}
 
-			log.Info("Object exported as event producer", "object", t)
-		}
+		// 	log.Info("Object exported as event producer", "object", t)
+		// }
 	}
 	// handshake service that can exchange interface versions with client
 	if err := server.RegisterService(rpc_server.Handshake(interfaces), ""); err != nil {

--- a/pkg/rpc/testing/handshake_test.go
+++ b/pkg/rpc/testing/handshake_test.go
@@ -1,0 +1,100 @@
+package testing
+
+import (
+	"io/ioutil"
+	"net/http"
+	"path/filepath"
+	"testing"
+
+	"github.com/docker/infrakit/pkg/rpc/client"
+	"github.com/docker/infrakit/pkg/rpc/server"
+	"github.com/docker/infrakit/pkg/spi"
+	"github.com/stretchr/testify/require"
+)
+
+var apiSpec = spi.InterfaceSpec{
+	Name:    "TestPlugin",
+	Version: "0.1.0",
+}
+
+func startPluginServer(t *testing.T) (server.Stoppable, string) {
+	dir, err := ioutil.TempDir("", "infrakit_handshake_test")
+	require.NoError(t, err)
+
+	name := "instance"
+	socket := filepath.Join(dir, name)
+
+	testServer, err := server.StartPluginAtPath(socket, &TestPlugin{spec: apiSpec})
+	require.NoError(t, err)
+	return testServer, socket
+}
+
+func TestHandshakeSuccess(t *testing.T) {
+	testServer, socket := startPluginServer(t)
+	defer testServer.Stop()
+
+	r, err := client.New(socket, apiSpec)
+	require.NoError(t, err)
+	client := rpcClient{client: r}
+	require.NoError(t, client.DoSomething())
+}
+
+func TestHandshakeFailVersion(t *testing.T) {
+	testServer, socket := startPluginServer(t)
+	defer testServer.Stop()
+
+	r, err := client.New(socket, spi.InterfaceSpec{Name: "TestPlugin", Version: "0.2.0"})
+	require.Error(t, err)
+
+	client := rpcClient{client: r}
+	err = client.DoSomething()
+	require.Error(t, err)
+	require.Equal(t, "Plugin supports TestPlugin interface version 0.1.0, client requires 0.2.0", err.Error())
+}
+
+func TestHandshakeFailWrongAPI(t *testing.T) {
+	testServer, socket := startPluginServer(t)
+	defer testServer.Stop()
+
+	r, err := client.New(socket, spi.InterfaceSpec{Name: "OtherPlugin", Version: "0.1.0"})
+	require.Error(t, err)
+
+	client := rpcClient{client: r}
+	err = client.DoSomething()
+	require.Error(t, err)
+	require.Equal(t, "Plugin does not support interface OtherPlugin/0.1.0", err.Error())
+}
+
+type rpcClient struct {
+	client client.Client
+}
+
+func (c rpcClient) DoSomething() error {
+	req := EmptyMessage{}
+	resp := EmptyMessage{}
+	return c.client.Call("TestPlugin.DoSomething", req, &resp)
+}
+
+// TestPlugin is an RPC service for this unit test.
+type TestPlugin struct {
+	spec spi.InterfaceSpec
+}
+
+// ImplementedInterface returns the interface implemented by this RPC service.
+func (p *TestPlugin) ImplementedInterface() spi.InterfaceSpec {
+	return p.spec
+}
+
+// Types returns the types
+func (p *TestPlugin) Types() []string {
+	return []string{"."}
+}
+
+// EmptyMessage is an empty test message.
+type EmptyMessage struct {
+}
+
+// DoSomething is an empty test RPC.
+func (p *TestPlugin) DoSomething(_ *http.Request, req *EmptyMessage, resp *EmptyMessage) error {
+	return nil
+}

--- a/pkg/run/serverutil.go
+++ b/pkg/run/serverutil.go
@@ -6,7 +6,6 @@ import (
 	"os"
 	"path"
 
-	"github.com/Sirupsen/logrus"
 	"github.com/docker/infrakit/pkg/discovery/local"
 	"github.com/docker/infrakit/pkg/plugin"
 	"github.com/docker/infrakit/pkg/rpc/server"
@@ -75,18 +74,30 @@ func BackgroundListener(transport plugin.Transport, onStop func(), plugin server
 func run(listen []string, discoverPath, pidPath string, onStop func(),
 	plugin server.VersionedInterface, more ...server.VersionedInterface) (server.Stoppable, <-chan struct{}) {
 
+	// make sure the pid file doesn't already exist.
+	// if it exists, PANIC because there's already a running process or something crashed and we should
+	// clean up the sockets
+	pidFile, err := os.Stat(pidPath)
+	if err == nil {
+		// No error... this file exists
+		log.Error("PID file exists", "path", pidPath, "file", pidFile)
+		fmt.Println("WARNING - There seems to be a process already running at", pidPath)
+		fmt.Println("Please remove this file if you don't think another process is already running.")
+		os.Exit(-1)
+	}
+
 	var stoppable server.Stoppable
 
 	if len(listen) > 0 {
 		s, err := server.StartListenerAtPath(listen, discoverPath, plugin, more...)
 		if err != nil {
-			logrus.Error(err)
+			log.Error("error starting listener", "err", err)
 		}
 		stoppable = s
 	} else {
 		s, err := server.StartPluginAtPath(discoverPath, plugin, more...)
 		if err != nil {
-			logrus.Error(err)
+			log.Error("error starting plugin", "err", err)
 		}
 		stoppable = s
 	}
@@ -97,20 +108,21 @@ func run(listen []string, discoverPath, pidPath string, onStop func(),
 		// write PID file
 		err := ioutil.WriteFile(pidPath, []byte(fmt.Sprintf("%v", os.Getpid())), 0644)
 		if err != nil {
-			logrus.Error(err)
+			log.Error("cannot write pid file", "err", err)
+			panic(err)
 		}
-		logrus.Infoln("PID file at", pidPath)
+		log.Info("PID file created", "path", pidPath)
 		if stoppable != nil {
-			logrus.Infoln("Server waiting at", discoverPath)
+			log.Info("Server started", "discovery", discoverPath)
 			stoppable.AwaitStopped()
 		}
 
 		// clean up
 		os.Remove(pidPath)
-		logrus.Infoln("Removed PID file at", pidPath)
+		log.Info("Removed PID file", "path", pidPath)
 
 		os.Remove(discoverPath)
-		logrus.Infoln("Removed discover file at", discoverPath)
+		log.Info("Removed discover file", "path", discoverPath)
 
 		if onStop != nil {
 			onStop()

--- a/pkg/run/serverutil.go
+++ b/pkg/run/serverutil.go
@@ -92,12 +92,14 @@ func run(listen []string, discoverPath, pidPath string, onStop func(),
 		s, err := server.StartListenerAtPath(listen, discoverPath, plugin, more...)
 		if err != nil {
 			log.Error("error starting listener", "err", err)
+			panic(err)
 		}
 		stoppable = s
 	} else {
 		s, err := server.StartPluginAtPath(discoverPath, plugin, more...)
 		if err != nil {
 			log.Error("error starting plugin", "err", err)
+			panic(err)
 		}
 		stoppable = s
 	}

--- a/pkg/run/v0/manager/manager.go
+++ b/pkg/run/v0/manager/manager.go
@@ -212,7 +212,8 @@ func Run(plugins func() discovery.Plugins, name plugin.Name,
 				Registry:   options.LeaderStore,
 			})
 		if err != nil {
-			panic(err)
+			fmt.Printf("Cannot start up mux server.  Error: %v\n", err)
+			os.Exit(-1)
 		}
 	}
 

--- a/pkg/run/v0/manager/manager.go
+++ b/pkg/run/v0/manager/manager.go
@@ -46,6 +46,10 @@ const (
 	// persisted, it is not polled and read by the non-leaders on a regular basis
 	// (unless this is set).
 	EnvMetadataUpdateInterval = "INFRAKIT_MANAGER_METADATA_UPDATE_INTERVAL"
+
+	// EnvLeaderCommitSpecsRetryInterval is the interval to wait between retries when
+	// the manager becomes the leader and fails to commit the replicated specs.
+	EnvLeaderCommitSpecsRetryInterval = "INFRAKIT_MANAGER_COMMIT_SPECS_RETRY_INTERVAL"
 )
 
 var (
@@ -90,9 +94,11 @@ func defaultOptions() (options Options) {
 
 	options = Options{
 		Options: manager.Options{
-			Group:                   plugin.Name(local.Getenv(EnvGroup, "group-stateless")),
-			Metadata:                plugin.Name(local.Getenv(EnvMetadata, "vars")),
-			MetadataRefreshInterval: types.MustParseDuration(local.Getenv(EnvMetadataUpdateInterval, "3s")),
+			Group:                          plugin.Name(local.Getenv(EnvGroup, "group-stateless")),
+			Metadata:                       plugin.Name(local.Getenv(EnvMetadata, "vars")),
+			MetadataRefreshInterval:        types.MustParseDuration(local.Getenv(EnvMetadataUpdateInterval, "5s")),
+			LeaderCommitSpecsRetries:       10,
+			LeaderCommitSpecsRetryInterval: types.MustParseDuration(local.Getenv(EnvLeaderCommitSpecsRetryInterval, "2s")),
 		},
 		Mux: &MuxConfig{
 			Listen:    local.Getenv(EnvMuxListen, ":24864"),

--- a/pkg/spi/event/spi.go
+++ b/pkg/spi/event/spi.go
@@ -30,7 +30,10 @@ type Validator interface {
 // a publish function.
 type Publisher interface {
 	Plugin
-	// PublishOn sets the channel to publish
+
+	// PublishOn sets the channel to publish.  Note that the implementation is given a channel
+	// to publish on.  This is so that the server can optionally add buffering without the
+	// implementations having any knowledge.
 	PublishOn(chan<- *Event)
 }
 

--- a/pkg/spi/event/spi.go
+++ b/pkg/spi/event/spi.go
@@ -29,7 +29,7 @@ type Validator interface {
 // Publisher is the interface that event sources also implement to be assigned
 // a publish function.
 type Publisher interface {
-
+	Plugin
 	// PublishOn sets the channel to publish
 	PublishOn(chan<- *Event)
 }

--- a/pkg/spi/event/spi.go
+++ b/pkg/spi/event/spi.go
@@ -29,7 +29,6 @@ type Validator interface {
 // Publisher is the interface that event sources also implement to be assigned
 // a publish function.
 type Publisher interface {
-	Plugin
 
 	// PublishOn sets the channel to publish.  Note that the implementation is given a channel
 	// to publish on.  This is so that the server can optionally add buffering without the


### PR DESCRIPTION
Closes #475 

This PR
   + Adds the ability to auto-start all plugins based on what's in the `groups.json`.
   + the server will exit if there are socket files or pid files and will alert the user so proper cleanup can be done.
   + If an object implements the `pkg/spi/event/Publisher` interface, it will automatically be added as an event source.  The group rpc has been added with placeholder.
   + Make the manager retry when it becomes the leader and yet fails to commit the replicated specs.  This is to make the manager robust in case it comes up before all plugins come up (e.g. when started as base plugins by `infrakit up`.)
   + Fix a problem with aws plugin that doesn't properly terminate the instance tracking event plugin.

TODO - Generate real events inside the Group rpc object to enable monitoring remotely (e.g. when committed, instances created, etc.)

Signed-off-by: David Chung david.chung@docker.com