### PR TITLE
Rename Metadata.Ls to Metadata.Keys

### DIFF
--- a/docs/plugin/metadata/vars/README.md
+++ b/docs/plugin/metadata/vars/README.md
@@ -64,7 +64,7 @@ variable `INFRAKIT_VARS_TEMPLATE` as a way to set it.
 
 Corresponding to the SPI methods, there are new commands / verbs as `metadata`:
 
-  + `ls` lists the metadata paths
+  + `keys` lists the metadata paths
   + `cat` reads metadata values
   + `change` updates metadata values, provided the plugin implements the updatable SPI (not readonly)
 
@@ -130,7 +130,7 @@ Usage:
 Available Commands:
   cat         Get metadata entry by path
   change      Update metadata where args are key=value pairs and keys are within namespace of the plugin.
-  vars        List metadata
+  keys        List metadata
 ```
 
 ### Listing, Reading
@@ -138,7 +138,7 @@ Available Commands:
 Listing metadata values:
 
 ```shell
-$ infrakit vars vars -al
+$ infrakit vars keys -al
 total 6:
 cluster/name
 cluster/size
@@ -151,7 +151,7 @@ zones/west/cidr
 or
 
 ```shell
-$ infrakit vars vars -al zones
+$ infrakit vars keys -al zones
 total 2:
 east/cidr
 west/cidr
@@ -363,7 +363,7 @@ Committing 2 changes, hash=ad861ded7a0742f9662c2b78354c89f6
 Now querying:
 
 ```shell
-$ infrakit vars vars -al
+$ infrakit vars keys -al
 total 2:
 cluster/name
 cluster/workers/size

--- a/pkg/cli/v0/metadata/cmd.go
+++ b/pkg/cli/v0/metadata/cmd.go
@@ -13,22 +13,14 @@ import (
 var log = logutil.New("module", "cli/v1/metadata")
 
 func init() {
-	// cli.Register(metadata.InterfaceSpec,
-	// 	[]cli.CmdBuilder{
-	// 		Metadata,
-	// 	})
-	// cli.Register(metadata.UpdatableInterfaceSpec,
-	// 	[]cli.CmdBuilder{
-	// 		Updatable,
-	// 	})
 	cli.Register(metadata.InterfaceSpec,
 		[]cli.CmdBuilder{
-			Ls,
+			Keys,
 			Cat,
 		})
 	cli.Register(metadata.UpdatableInterfaceSpec,
 		[]cli.CmdBuilder{
-			Ls,
+			Keys,
 			Cat,
 			Change,
 		})
@@ -63,7 +55,7 @@ func Metadata(name string, services *cli.Services) *cobra.Command {
 	}
 
 	cmd.AddCommand(
-		Ls(name, services),
+		Keys(name, services),
 		Cat(name, services),
 	)
 
@@ -79,7 +71,7 @@ func Updatable(name string, services *cli.Services) *cobra.Command {
 	}
 
 	cmd.AddCommand(
-		Ls(name, services),
+		Keys(name, services),
 		Cat(name, services),
 		Change(name, services),
 	)

--- a/pkg/cli/v0/metadata/keys.go
+++ b/pkg/cli/v0/metadata/keys.go
@@ -9,19 +9,19 @@ import (
 	"github.com/spf13/cobra"
 )
 
-// Ls returns the Ls command
-func Ls(name string, services *cli.Services) *cobra.Command {
+// Keys returns the Keys command
+func Keys(name string, services *cli.Services) *cobra.Command {
 
-	ls := &cobra.Command{
-		Use:   "ls",
+	keys := &cobra.Command{
+		Use:   "keys",
 		Short: "List metadata",
 	}
 
-	long := ls.Flags().BoolP("long", "l", false, "Print full path")
-	all := ls.Flags().BoolP("all", "a", false, "Find all under the paths given")
-	quick := ls.Flags().BoolP("quick", "q", false, "True to turn off headers, etc.")
+	long := keys.Flags().BoolP("long", "l", false, "Print full path")
+	all := keys.Flags().BoolP("all", "a", false, "Find all under the paths given")
+	quick := keys.Flags().BoolP("quick", "q", false, "True to turn off headers, etc.")
 
-	ls.RunE = func(cmd *cobra.Command, args []string) error {
+	keys.RunE = func(cmd *cobra.Command, args []string) error {
 
 		metadataPlugin, err := loadPlugin(services.Plugins(), name)
 		if err != nil {
@@ -89,7 +89,7 @@ func Ls(name string, services *cli.Services) *cobra.Command {
 		}
 		return nil
 	}
-	return ls
+	return keys
 }
 
 func listAll(m metadata.Plugin, path types.Path) ([]types.Path, error) {

--- a/pkg/cli/v0/metadata/keys.go
+++ b/pkg/cli/v0/metadata/keys.go
@@ -59,7 +59,7 @@ func Keys(name string, services *cli.Services) *cobra.Command {
 					nodes = append(nodes, c)
 				}
 			} else {
-				children, err := metadataPlugin.List(path)
+				children, err := metadataPlugin.Keys(path)
 				if err != nil {
 					log.Warn("Cannot metadata ls on plugin", "name", name, "err", err)
 				}
@@ -97,7 +97,7 @@ func listAll(m metadata.Plugin, path types.Path) ([]types.Path, error) {
 		return nil, fmt.Errorf("no plugin")
 	}
 	result := []types.Path{}
-	nodes, err := m.List(path)
+	nodes, err := m.Keys(path)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/plugin/flavor/kubernetes/flavor.go
+++ b/pkg/plugin/flavor/kubernetes/flavor.go
@@ -209,12 +209,12 @@ func (s *baseFlavor) Healthy(flavorProperties *types.Any, inst instance.Descript
 	return flavor.Healthy, nil
 }
 
-// List implements the metadata.Plugin SPI's List method
-func (s *baseFlavor) List(path types.Path) ([]string, error) {
+// Keys implements the metadata.Plugin SPI's Keys method
+func (s *baseFlavor) Keys(path types.Path) ([]string, error) {
 	return nil, nil
 }
 
-// Get implements the metadata.Plugin SPI's List method
+// Get implements the metadata.Plugin SPI's Get method
 func (s *baseFlavor) Get(path types.Path) (*types.Any, error) {
 	if s.metadataPlugin != nil {
 		return s.metadataPlugin.Get(path)

--- a/pkg/plugin/flavor/swarm/flavor.go
+++ b/pkg/plugin/flavor/swarm/flavor.go
@@ -113,15 +113,15 @@ func (s *baseFlavor) runMetadataSnapshot(stopSnapshot <-chan struct{}) chan func
 	return updateSnapshot
 }
 
-// List implements the metadata.Plugin SPI's List method
-func (s *baseFlavor) List(path types.Path) ([]string, error) {
+// Keys implements the metadata.Plugin SPI's Keys method
+func (s *baseFlavor) Keys(path types.Path) ([]string, error) {
 	if s.metadataPlugin != nil {
-		return s.metadataPlugin.List(path)
+		return s.metadataPlugin.Keys(path)
 	}
 	return nil, nil
 }
 
-// Get implements the metadata.Plugin SPI's List method
+// Get implements the metadata.Plugin SPI's Get method
 func (s *baseFlavor) Get(path types.Path) (*types.Any, error) {
 	if s.metadataPlugin != nil {
 		return s.metadataPlugin.Get(path)

--- a/pkg/plugin/metadata/lazy.go
+++ b/pkg/plugin/metadata/lazy.go
@@ -88,9 +88,9 @@ func (c *lazyConnect) do(f func(p metadata.Plugin) error) (err error) {
 	return f(c.client)
 }
 
-func (c *lazyConnect) List(path types.Path) (child []string, err error) {
+func (c *lazyConnect) Keys(path types.Path) (child []string, err error) {
 	err = c.do(func(p metadata.Plugin) error {
-		child, err = p.List(path)
+		child, err = p.Keys(path)
 		return err
 	})
 	return

--- a/pkg/plugin/metadata/lazy_test.go
+++ b/pkg/plugin/metadata/lazy_test.go
@@ -54,7 +54,7 @@ func TestLazyNoBlock(t *testing.T) {
 
 type fake chan int
 
-func (f fake) List(path types.Path) (child []string, err error) {
+func (f fake) Keys(path types.Path) (child []string, err error) {
 	f <- 1
 	return
 }

--- a/pkg/plugin/metadata/plugin.go
+++ b/pkg/plugin/metadata/plugin.go
@@ -52,9 +52,9 @@ type plugin struct {
 	reads chan func(data map[string]interface{})
 }
 
-// List returns a list of *child nodes* given a path, which is specified as a slice
+// Keys returns a list of *child nodes* given a path, which is specified as a slice
 // where for i > j path[i] is the parent of path[j]
-func (p *plugin) List(path types.Path) ([]string, error) {
+func (p *plugin) Keys(path types.Path) ([]string, error) {
 	if p.reads == nil && p.data != nil {
 		return types.List(path, p.data), nil
 	}

--- a/pkg/plugin/metadata/plugin_test.go
+++ b/pkg/plugin/metadata/plugin_test.go
@@ -23,7 +23,7 @@ func TestPluginUnserializedReadWrites(t *testing.T) {
 
 	p := NewPluginFromData(m)
 
-	require.Equal(t, []string{"us-west-1", "us-west-2"}, first(p.List(types.PathFromString("/"))))
+	require.Equal(t, []string{"us-west-1", "us-west-2"}, first(p.Keys(types.PathFromString("/"))))
 	require.Nil(t, first(p.Get(types.PathFromString("us-west-1/metrics/instances/foo"))))
 	require.Equal(t, "2000", first(p.Get(types.PathFromString("us-west-1/metrics/instances/count"))).(*types.Any).String())
 

--- a/pkg/provider/aws/plugin/metadata/template.go
+++ b/pkg/provider/aws/plugin/metadata/template.go
@@ -94,9 +94,9 @@ func (c *Context) start() {
 	}()
 }
 
-// List returns a list of *child nodes* given a path, which is specified as a slice
+// Keys returns a list of *child nodes* given a path, which is specified as a slice
 // where for i > j path[i] is the parent of path[j]
-func (c *Context) List(path types.Path) (child []string, err error) {
+func (c *Context) Keys(path types.Path) (child []string, err error) {
 	if path.Len() == 0 || path.Dot() {
 		return []string{"export", "local"}, nil
 	}
@@ -116,7 +116,7 @@ func (c *Context) List(path types.Path) (child []string, err error) {
 		}
 		return trimmed, nil
 	}
-	return c.impl.List(path.Shift(1))
+	return c.impl.Keys(path.Shift(1))
 }
 
 // Get retrieves the value at path given.

--- a/pkg/provider/docker/plugin/instance/instance.go
+++ b/pkg/provider/docker/plugin/instance/instance.go
@@ -403,15 +403,15 @@ func (p dockerInstancePlugin) DescribeInstances(tags map[string]string, properti
 	return p.describeInstances(tags)
 }
 
-// List implements the metadata.Plugin SPI's List method
-func (p dockerInstancePlugin) List(path types.Path) ([]string, error) {
+// Keys implements the metadata.Plugin SPI's Keys method
+func (p dockerInstancePlugin) Keys(path types.Path) ([]string, error) {
 	if p.metadataPlugin != nil {
-		return p.metadataPlugin.List(path)
+		return p.metadataPlugin.Keys(path)
 	}
 	return nil, nil
 }
 
-// Get implements the metadata.Plugin SPI's List method
+// Get implements the metadata.Plugin SPI's Get method
 func (p dockerInstancePlugin) Get(path types.Path) (*types.Any, error) {
 	if p.metadataPlugin != nil {
 		return p.metadataPlugin.Get(path)

--- a/pkg/provider/google/plugin/metadata/plugin.go
+++ b/pkg/provider/google/plugin/metadata/plugin.go
@@ -63,9 +63,9 @@ func (p *plugin) addTopic(topics map[string]interface{}, path string, getter fun
 	}, topics)
 }
 
-// List returns a list of *child nodes* given a path, which is specified as a slice
+// Keys returns a list of *child nodes* given a path, which is specified as a slice
 // where for i > j path[i] is the parent of path[j]
-func (p *plugin) List(topic types.Path) ([]string, error) {
+func (p *plugin) Keys(topic types.Path) ([]string, error) {
 	p.loadTopics()
 
 	return types.List(topic, p.topics), nil

--- a/pkg/provider/google/plugin/metadata/plugin_test.go
+++ b/pkg/provider/google/plugin/metadata/plugin_test.go
@@ -23,11 +23,11 @@ func NewPlugin(api gcloud.API, apiMetadata gcloud.APIMetadata) metadata.Plugin {
 	}
 }
 
-func TestList(t *testing.T) {
+func TestKeys(t *testing.T) {
 	api, apiMetadata, _ := NewMockAPI(t)
 
 	plugin := NewPlugin(api, apiMetadata)
-	children, err := plugin.List(types.Path([]string{""}))
+	children, err := plugin.Keys(types.Path([]string{""}))
 
 	require.EqualValues(t, []string{"instance", "project", "zone"}, children)
 	require.NoError(t, err)
@@ -37,7 +37,7 @@ func TestListInstance(t *testing.T) {
 	api, apiMetadata, _ := NewMockAPI(t)
 
 	plugin := NewPlugin(api, apiMetadata)
-	children, err := plugin.List(types.Path([]string{"instance"}))
+	children, err := plugin.Keys(types.Path([]string{"instance"}))
 
 	require.EqualValues(t, []string{"ID", "externalIP", "hostname", "internalIP", "name", "network", "numericalProjectID", "projectID", "zone"}, children)
 	require.NoError(t, err)

--- a/pkg/rpc/metadata/client.go
+++ b/pkg/rpc/metadata/client.go
@@ -51,9 +51,9 @@ type client struct {
 	client rpc_client.Client
 }
 
-// List returns a list of nodes under path.
-func (c client) List(path types.Path) ([]string, error) {
-	return list(c.name, c.client, "Metadata.List", path)
+// Keys returns a list of nodes under path.
+func (c client) Keys(path types.Path) ([]string, error) {
+	return list(c.name, c.client, "Metadata.Keys", path)
 }
 
 // Get retrieves the metadata at path.

--- a/pkg/rpc/metadata/init.go
+++ b/pkg/rpc/metadata/init.go
@@ -10,8 +10,8 @@ import (
 var log = logutil.New("module", "rpc/controller")
 
 func list(name plugin.Name, client rpc.Client, method string, path types.Path) ([]string, error) {
-	req := ListRequest{Name: name, Path: path}
-	resp := ListResponse{}
+	req := KeysRequest{Name: name, Path: path}
+	resp := KeysResponse{}
 	err := client.Call(method, req, &resp)
 	return resp.Nodes, err
 }

--- a/pkg/rpc/metadata/rpc_test.go
+++ b/pkg/rpc/metadata/rpc_test.go
@@ -75,7 +75,7 @@ func TestMetadataMultiPlugin(t *testing.T) {
 		func() (map[string]metadata.Plugin, error) {
 			return map[string]metadata.Plugin{
 				"aws": &testing_metadata.Plugin{
-					DoList: func(path types.Path) ([]string, error) {
+					DoKeys: func(path types.Path) ([]string, error) {
 						inputMetadataPathListActual1 <- path
 						return types.List(path, m), nil
 					},
@@ -85,7 +85,7 @@ func TestMetadataMultiPlugin(t *testing.T) {
 					},
 				},
 				"azure": &testing_metadata.Plugin{
-					DoList: func(path types.Path) ([]string, error) {
+					DoKeys: func(path types.Path) ([]string, error) {
 						inputMetadataPathListActual2 <- path
 						return nil, errors.New("azure-error")
 					},
@@ -108,14 +108,14 @@ func TestMetadataMultiPlugin(t *testing.T) {
 	require.Equal(t, []string{"aws", "azure"}, found)
 
 	require.Equal(t, []string{"region"}, first(must(NewClient(nameFromPath(socketPath, "aws"),
-		socketPath)).List(types.PathFromString("."))))
+		socketPath)).Keys(types.PathFromString("."))))
 	require.Equal(t, []string(nil), first(must(NewClient(nameFromPath(socketPath),
-		socketPath)).List(types.PathFromString("aws"))))
+		socketPath)).Keys(types.PathFromString("aws"))))
 	require.Error(t, second(must(NewClient(nameFromPath(socketPath, "azure"),
-		socketPath)).List(types.PathFromString("."))).(error))
+		socketPath)).Keys(types.PathFromString("."))).(error))
 
 	require.Equal(t, []string(nil),
-		first(must(NewClient(nameFromPath(socketPath), socketPath)).List(types.PathFromString("/"))))
+		first(must(NewClient(nameFromPath(socketPath), socketPath)).Keys(types.PathFromString("/"))))
 
 	require.Equal(t, []string{"."}, <-inputMetadataPathListActual1)
 	require.Equal(t, []string{"."}, <-inputMetadataPathListActual2)
@@ -154,7 +154,7 @@ func TestMetadataMultiPlugin2(t *testing.T) {
 		func() (map[string]metadata.Plugin, error) {
 			return map[string]metadata.Plugin{
 				"aws": &testing_metadata.Plugin{
-					DoList: func(path types.Path) ([]string, error) {
+					DoKeys: func(path types.Path) ([]string, error) {
 						res := types.List(path, m1)
 						return res, nil
 					},
@@ -163,7 +163,7 @@ func TestMetadataMultiPlugin2(t *testing.T) {
 					},
 				},
 				"azure": &testing_metadata.Plugin{
-					DoList: func(path types.Path) ([]string, error) {
+					DoKeys: func(path types.Path) ([]string, error) {
 						res := types.List(path, m2)
 						return res, nil
 					},
@@ -176,16 +176,16 @@ func TestMetadataMultiPlugin2(t *testing.T) {
 	require.NoError(t, err)
 
 	require.Equal(t, []string(nil),
-		first(must(NewClient(nameFromPath(socketPath), socketPath)).List(types.PathFromString(""))))
+		first(must(NewClient(nameFromPath(socketPath), socketPath)).Keys(types.PathFromString(""))))
 	require.Equal(t, []string{"region"},
-		first(must(NewClient(nameFromPath(socketPath, "aws"), socketPath)).List(types.PathFromString("."))))
+		first(must(NewClient(nameFromPath(socketPath, "aws"), socketPath)).Keys(types.PathFromString("."))))
 	require.Equal(t, []string{"us-1", "us-2"},
-		first(must(NewClient(nameFromPath(socketPath, "azure"), socketPath)).List(types.PathFromString("dc/"))))
+		first(must(NewClient(nameFromPath(socketPath, "azure"), socketPath)).Keys(types.PathFromString("dc/"))))
 	require.Equal(t, []string(nil),
-		first(must(NewClient(nameFromPath(socketPath, "gce"), socketPath)).List(types.PathFromString("."))))
+		first(must(NewClient(nameFromPath(socketPath, "gce"), socketPath)).Keys(types.PathFromString("."))))
 	require.Equal(t, []string{"network10", "network11"},
 		first(must(NewClient(nameFromPath(socketPath, "aws"),
-			socketPath)).List(types.PathFromString("region/us-west-1/vpc/vpc2/network"))))
+			socketPath)).Keys(types.PathFromString("region/us-west-1/vpc/vpc2/network"))))
 
 	require.Equal(t, "100",
 		firstAny(must(NewClient(nameFromPath(socketPath, "aws"),
@@ -227,7 +227,7 @@ func TestMetadataMultiPlugin3(t *testing.T) {
 		ServerWithNames(func() (map[string]metadata.Plugin, error) {
 			return map[string]metadata.Plugin{
 				".": &testing_metadata.Plugin{
-					DoList: func(path types.Path) ([]string, error) {
+					DoKeys: func(path types.Path) ([]string, error) {
 						res := types.List(path, m0)
 						return res, nil
 					},
@@ -236,7 +236,7 @@ func TestMetadataMultiPlugin3(t *testing.T) {
 					},
 				},
 				"aws": &testing_metadata.Plugin{
-					DoList: func(path types.Path) ([]string, error) {
+					DoKeys: func(path types.Path) ([]string, error) {
 						res := types.List(path, m1)
 						return res, nil
 					},
@@ -245,7 +245,7 @@ func TestMetadataMultiPlugin3(t *testing.T) {
 					},
 				},
 				"azure": &testing_metadata.Plugin{
-					DoList: func(path types.Path) ([]string, error) {
+					DoKeys: func(path types.Path) ([]string, error) {
 						res := types.List(path, m2)
 						return res, nil
 					},
@@ -258,18 +258,18 @@ func TestMetadataMultiPlugin3(t *testing.T) {
 	require.NoError(t, err)
 
 	require.Equal(t, []string{"metrics"},
-		first(must(NewClient(nameFromPath(socketPath), socketPath)).List(types.Path([]string{}))))
+		first(must(NewClient(nameFromPath(socketPath), socketPath)).Keys(types.Path([]string{}))))
 	require.Equal(t, []string{"metrics"},
-		first(must(NewClient(nameFromPath(socketPath), socketPath)).List(types.PathFromString("/"))))
+		first(must(NewClient(nameFromPath(socketPath), socketPath)).Keys(types.PathFromString("/"))))
 	require.Equal(t, []string{"region"},
-		first(must(NewClient(nameFromPath(socketPath, "aws"), socketPath)).List(types.PathFromString("."))))
+		first(must(NewClient(nameFromPath(socketPath, "aws"), socketPath)).Keys(types.PathFromString("."))))
 	require.Equal(t, []string{"dc"},
-		first(must(NewClient(nameFromPath(socketPath, "azure"), socketPath)).List(types.PathFromString("."))))
+		first(must(NewClient(nameFromPath(socketPath, "azure"), socketPath)).Keys(types.PathFromString("."))))
 	require.Equal(t, []string(nil),
-		first(must(NewClient(nameFromPath(socketPath), socketPath)).List(types.PathFromString("gce"))))
+		first(must(NewClient(nameFromPath(socketPath), socketPath)).Keys(types.PathFromString("gce"))))
 	require.Equal(t, []string{"network10", "network11"},
 		first(must(NewClient(nameFromPath(socketPath, "aws"),
-			socketPath)).List(types.PathFromString("region/us-west-1/vpc/vpc2/network"))))
+			socketPath)).Keys(types.PathFromString("region/us-west-1/vpc/vpc2/network"))))
 
 	require.Equal(t, "100",
 		firstAny(must(NewClient(nameFromPath(socketPath),
@@ -293,7 +293,7 @@ func TestMetadataMultiPlugin4(t *testing.T) {
 
 	server, err := rpc_server.StartPluginAtPath(socketPath,
 		Server(&testing_metadata.Plugin{
-			DoList: func(path types.Path) ([]string, error) {
+			DoKeys: func(path types.Path) ([]string, error) {
 				res := types.List(path, m0)
 				return res, nil
 			},
@@ -304,9 +304,9 @@ func TestMetadataMultiPlugin4(t *testing.T) {
 	require.NoError(t, err)
 
 	require.Equal(t, []string{"metrics"},
-		first(must(NewClient(nameFromPath(socketPath), socketPath)).List(types.PathFromString(""))))
+		first(must(NewClient(nameFromPath(socketPath), socketPath)).Keys(types.PathFromString(""))))
 	require.Equal(t, []string{"instances", "managers", "networks", "workers"},
-		first(must(NewClient(nameFromPath(socketPath), socketPath)).List(types.PathFromString("metrics/"))))
+		first(must(NewClient(nameFromPath(socketPath), socketPath)).Keys(types.PathFromString("metrics/"))))
 
 	require.Equal(t, "100",
 		firstAny(must(NewClient(nameFromPath(socketPath),

--- a/pkg/rpc/metadata/service.go
+++ b/pkg/rpc/metadata/service.go
@@ -60,12 +60,12 @@ func (p *Metadata) Types() []string {
 	return p.keyed.Types()
 }
 
-// List returns a list of child nodes given a path.
-func (p *Metadata) List(_ *http.Request, req *ListRequest, resp *ListResponse) error {
+// Keys returns a list of child nodes given a path.
+func (p *Metadata) Keys(_ *http.Request, req *KeysRequest, resp *KeysResponse) error {
 
 	return p.keyed.Do(req, func(v interface{}) error {
 		resp.Name = req.Name
-		nodes, err := v.(metadata.Plugin).List(req.Path)
+		nodes, err := v.(metadata.Plugin).Keys(req.Path)
 		if err == nil {
 			sort.Strings(nodes)
 			resp.Nodes = nodes

--- a/pkg/rpc/metadata/types.go
+++ b/pkg/rpc/metadata/types.go
@@ -6,19 +6,19 @@ import (
 	"github.com/docker/infrakit/pkg/types"
 )
 
-// ListRequest is the rpc wrapper for request parameters to List
-type ListRequest struct {
+// KeysRequest is the rpc wrapper for request parameters to Keys
+type KeysRequest struct {
 	Name plugin.Name
 	Path types.Path
 }
 
 // Plugin implements pkg/rpc/internal/Addressable
-func (r ListRequest) Plugin() (plugin.Name, error) {
+func (r KeysRequest) Plugin() (plugin.Name, error) {
 	return r.Name, nil
 }
 
-// ListResponse is the rpc wrapper for the results of List
-type ListResponse struct {
+// KeysResponse is the rpc wrapper for the results of Keys
+type KeysResponse struct {
 	Name  plugin.Name
 	Nodes []string
 }

--- a/pkg/rpc/metadata/updatable.go
+++ b/pkg/rpc/metadata/updatable.go
@@ -62,12 +62,12 @@ func (u *Updatable) Types() []string {
 	return u.keyed.Types()
 }
 
-// List returns a list of child nodes given a path.
-func (u *Updatable) List(_ *http.Request, req *ListRequest, resp *ListResponse) error {
+// Keys returns a list of child nodes given a path.
+func (u *Updatable) Keys(_ *http.Request, req *KeysRequest, resp *KeysResponse) error {
 
 	return u.keyed.Do(req, func(v interface{}) error {
 		resp.Name = req.Name
-		nodes, err := v.(metadata.Plugin).List(req.Path)
+		nodes, err := v.(metadata.Plugin).Keys(req.Path)
 		if err == nil {
 			sort.Strings(nodes)
 			resp.Nodes = nodes
@@ -143,9 +143,9 @@ func AdaptUpdatable(name plugin.Name, rpcClient rpc_client.Client) metadata.Upda
 	return &updatable{name: name, client: rpcClient}
 }
 
-// List returns a list of nodes under path.
-func (u updatable) List(path types.Path) ([]string, error) {
-	return list(u.name, u.client, "Updatable.List", path)
+// Keys returns a list of nodes under path.
+func (u updatable) Keys(path types.Path) ([]string, error) {
+	return list(u.name, u.client, "Updatable.Keys", path)
 }
 
 // Get retrieves the metadata at path.

--- a/pkg/rpc/mux/reverse_proxy_test.go
+++ b/pkg/rpc/mux/reverse_proxy_test.go
@@ -107,7 +107,7 @@ func startPlugin(t *testing.T, name string) (string, rpc_server.Stoppable) {
 		func() (map[string]metadata.Plugin, error) {
 			return map[string]metadata.Plugin{
 				"aws": &testing_metadata.Plugin{
-					DoList: func(path types.Path) ([]string, error) {
+					DoKeys: func(path types.Path) ([]string, error) {
 						return types.List(path, m), nil
 					},
 					DoGet: func(path types.Path) (*types.Any, error) {
@@ -139,9 +139,9 @@ func TestMuxPlugins(t *testing.T) {
 
 	T(100).Infoln("Basic client")
 	require.Equal(t, []string(nil),
-		first(must(rpc_metadata.NewClient(nameFromPath(socketPath), socketPath)).List(types.PathFromString("aws"))))
+		first(must(rpc_metadata.NewClient(nameFromPath(socketPath), socketPath)).Keys(types.PathFromString("aws"))))
 	require.Equal(t, []string{"region"},
-		first(must(rpc_metadata.NewClient(nameFromPath(socketPath)+"/aws", socketPath)).List(types.PathFromString("."))))
+		first(must(rpc_metadata.NewClient(nameFromPath(socketPath)+"/aws", socketPath)).Keys(types.PathFromString("."))))
 
 	infoClient, err := client.NewPluginInfoClient(socketPath)
 	require.NoError(t, err)

--- a/pkg/rpc/mux/server_test.go
+++ b/pkg/rpc/mux/server_test.go
@@ -34,9 +34,9 @@ func TestMuxServer(t *testing.T) {
 
 	T(100).Infoln("Basic client")
 	require.Equal(t, []string{"region"},
-		first(must(rpc_metadata.NewClient(nameFromPath(socketPath)+"/aws", socketPath)).List(types.PathFromString("."))))
+		first(must(rpc_metadata.NewClient(nameFromPath(socketPath)+"/aws", socketPath)).Keys(types.PathFromString("."))))
 	require.Equal(t, []string(nil),
-		first(must(rpc_metadata.NewClient(nameFromPath(socketPath), socketPath)).List(types.PathFromString("aws"))))
+		first(must(rpc_metadata.NewClient(nameFromPath(socketPath), socketPath)).Keys(types.PathFromString("aws"))))
 
 	infoClient, err := client.NewPluginInfoClient(socketPath)
 	require.NoError(t, err)

--- a/pkg/rpc/server/server_test.go
+++ b/pkg/rpc/server/server_test.go
@@ -86,7 +86,7 @@ func TestTCPServer(t *testing.T) {
 
 	discover := filepath.Join(os.TempDir(), fmt.Sprintf("%d.listen", time.Now().Unix()))
 	name := plugin.Name(filepath.Base(discover))
-	server, err := StartListenerAtPath([]string{"localhost:7777"}, discover, service)
+	server, err := StartListenerAtPath([]string{"localhost:7778"}, discover, service)
 	require.NoError(t, err)
 
 	c, err := plugin_rpc.NewClient(name, discover)

--- a/pkg/spi/metadata/spi.go
+++ b/pkg/spi/metadata/spi.go
@@ -22,8 +22,8 @@ var (
 // Plugin is the interface for metadata-related operations.
 type Plugin interface {
 
-	// List returns a list of *child nodes* given a path, which is specified as a slice
-	List(path types.Path) (child []string, err error)
+	// Keys returns a list of *child nodes* given a path, which is specified as a slice
+	Keys(path types.Path) (child []string, err error)
 
 	// Get retrieves the value at path given.
 	Get(path types.Path) (value *types.Any, err error)

--- a/pkg/testing/metadata/plugin.go
+++ b/pkg/testing/metadata/plugin.go
@@ -8,16 +8,16 @@ import (
 // Plugin implements metadata.Plugin
 type Plugin struct {
 
-	// DoList implements List via function
-	DoList func(path types.Path) (child []string, err error)
+	// DoKeys implements Keys via function
+	DoKeys func(path types.Path) (child []string, err error)
 
 	// DoGet implements Get via function
 	DoGet func(path types.Path) (value *types.Any, err error)
 }
 
-// List lists the child nodes under path
-func (t *Plugin) List(path types.Path) (child []string, err error) {
-	return t.DoList(path)
+// Keys lists the child nodes under path
+func (t *Plugin) Keys(path types.Path) (child []string, err error) {
+	return t.DoKeys(path)
 }
 
 // Get gets the value


### PR DESCRIPTION
This PR 

  + renames the CLI verb `ls` for metadata plugins to `keys`, so that when the CLI discovers this interface it will not generate a command verb that clashes with the `ls` for Group controller.
  + Updates the docs to use `keys` in place of `ls`.

closes #733 

Signed-off-by: David Chung <david.chung@docker.com>