### PR TITLE
Use the LogicalID in the resource name during tf import

### DIFF
--- a/pkg/run/v0/terraform/terraform.go
+++ b/pkg/run/v0/terraform/terraform.go
@@ -193,6 +193,10 @@ func parseInstanceSpecFromGroup(groupSpecURL, groupID string) (*instance.Spec, e
 		}
 		tags["infrakit.group"] = groupID
 	}
+	// Use the first logical ID if set
+	if len(groupProps.Allocation.LogicalIDs) > 0 {
+		tags["LogicalID"] = string(groupProps.Allocation.LogicalIDs[0])
+	}
 
 	spec := instance.Spec{
 		Properties: groupProps.Instance.Properties,


### PR DESCRIPTION
When moving to the inproc startup this logic was missed (it exists in the `pkg/provider/instance/terraform/cmd/main.go`). Adding in the `LogicalID` tag tells the import code to use this ID in the resource name for the imported resource.

Signed-off-by: Steven Kaufer <kaufer@us.ibm.com>