### PR TITLE
Aws metadata should start when no template is provided

### DIFF
--- a/docs/cmd/infrakit/util/init/README.md
+++ b/docs/cmd/infrakit/util/init/README.md
@@ -29,7 +29,7 @@ of `init` works as follows:
   2. The CLI fetches this and evaluates it as a template.
     + The engine uses the `INFRAKIT_VARS_TEMPLATE` env to determine a variables JSON to
     initialize some variables.  These can be overridden by appropriately named `--var`
-    and `--metdata` flags in the command line.
+    and `--metadata` flags in the command line.
     + The engine uses the `--var` to set parameters in memory for the scope of *this*
     evaluation.  These are ephemeral and can override the defaults set in above.
     + The engine uses the `--metadata` to set parameters that will persist, as some
@@ -44,7 +44,7 @@ of `init` works as follows:
   renders a template.  Depending on the plugin implementation, values that are not known
   at this time may be deferred (as multipass = true -- see `swarm/flavor.go#31).
   7. The CLI renders the text blob from the `Init` field of the instance spec returned
-  by the `Prepare` method.  This will apply the same set of `--var` as varaibles.
+  by the `Prepare` method.  This will apply the same set of `--var` as variables.
   8. The CLI prints out the rendered init script
   9. If `--persist` is set, the CLI will commit the current state of the vars plugin
   (which was started in the beginning of this process).

--- a/pkg/cli/services.go
+++ b/pkg/cli/services.go
@@ -107,7 +107,7 @@ func templateProcessor(scope scope.Scope) (*pflag.FlagSet,
 
 	fs := pflag.NewFlagSet("template", pflag.ExitOnError)
 
-	globals := fs.StringSlice("var", []string{}, "key=value pairs of globally scoped variagbles")
+	globals := fs.StringSlice("var", []string{}, "key=value pairs of globally scoped variables")
 	yamlDoc := fs.BoolP("yaml", "y", false, "True if input is in yaml format; json is the default")
 	dump := fs.BoolP("dump", "x", false, "True to dump to output instead of executing")
 	singlePass := fs.BoolP("final", "f", false, "True to render template as the final pass")

--- a/pkg/manager/stored.go
+++ b/pkg/manager/stored.go
@@ -15,7 +15,7 @@ type key struct {
 }
 
 type record struct {
-	// Handler is the actuall plugin used to process the input
+	// Handler is the actual plugin used to process the input
 	Handler plugin.Name
 
 	// Spec is a copy of the spec

--- a/pkg/plugin/flavor/kubernetes/README.md
+++ b/pkg/plugin/flavor/kubernetes/README.md
@@ -87,9 +87,9 @@ wget -qO- https://get.docker.com/ | sh
 ### A Word on Security
 
 Since Kubeadm use Token to authorize nodes, initializing
-the Kubernetes requires:
+Kubernetes requires:
 
-Docken socke API server exposes the remote API, but it is protected by TLS. Infrakit intends to make access to kubernetes manager from the side, but we can not send commands such as `get nodes` yet.
+Docker engine exposes its remote API, but it is protected by TLS. Infrakit intends to make access to kubernetes manager from the side, but we can not send commands such as `get nodes` yet.
 For installation, we use [kubeadm](https://kubernetes.io/docs/admin/kubeadm/) and build a secure cluster.
 
 
@@ -102,25 +102,26 @@ Building the binaries - do this from the top level project directory:
 make binaries
 ```
 
-Start required plugins.  We use the `infrakit plugin start` utility and a `plugins.json` to start up all the plugins,
-along with the InfraKit manager:
+Start required plugins.
+We can use the plugin utility to start up all the plugins along with the InfraKit manager:
 
 ```shell
-infrakit-group-default
-infrakit-instance-vagrant
-infrakit-flavor-kubernetes
+export INFRAKIT_LEADER_FILE=$HOME/.infrakit/leader
+echo "manager1" > $INFRAKIT_LEADER_FILE
+export PATH=$PWD/build:$PATH
+infrakit plugin start manager group vagrant kubernetes &
 ```
 
 Now start up the cluster comprised of a manager and a worker group.  In this case, see `groups-master.json` where we will create a manager group of one node and in `group-worker.json` create a worker group of 3 nodes. The topology in this is a single ensemble of infrakit running on your local machine that manages 4 vagrant vms running Kubernetes.  
 At Kubernetes flavor, you should run manager group first.
 Worker group will try to connect to manager before start.
-And as this flavor based on kubeadm, currently it support only one manager node.
+And as this flavor is based on kubeadm, it currently supports only one manager node.
 
 ```shell
 infrakit group commit groups-manager.json
 ```
-Wait for manager comes up.
-As it need to install docker and kubeadm, it take a little time...
+Wait for manager to come up.
+As it needs to install docker and kubeadm, it takes a little time...
 
 ```shell
 infrakit group commit groups-worker.json

--- a/pkg/plugin/flavor/swarm/README.md
+++ b/pkg/plugin/flavor/swarm/README.md
@@ -122,38 +122,45 @@ along with the InfraKit manager:
 
 ```shell
 ~/projects/src/github.com/docker/infrakit$ examples/flavor/swarm/start-plugins.sh
-Starting up manager
-Starting up group-stateless
-INFO[0000] Waiting for manager to start: {
-                "Cmd" : "infrakit-manager --name group  --proxy-for-group group-stateless os --leader-file /Users/me/.infrakit/leader --store-dir /Users/me/.infrakit/configs > /Users/me/.infrakit/logs/manager.log 2>&1"
-            } 
-INFO[0000] OS launcher: Plugin manager setPgId= true starting infrakit-manager --name group  --proxy-for-group group-stateless os --leader-file /Users/me/.infrakit/leader --store-dir /Users/me/.infrakit/configs > /Users/me/.infrakit/logs/manager.log 2>&1 
-INFO[0000] Running /bin/sh /bin/sh -c infrakit-manager --name group  --proxy-for-group group-stateless os --leader-file /Users/me/.infrakit/leader --store-dir /Users/me/.infrakit/configs > /Users/me/.infrakit/logs/manager.log 2>&1 
-INFO[0000] Starting with <nil> sh= infrakit-manager --name group  --proxy-for-group group-stateless os --leader-file /Users/me/.infrakit/leader --store-dir /Users/me/.infrakit/configs > /Users/me/.infrakit/logs/manager.log 2>&1 
-INFO[0000] Waiting for group-stateless to start: {
-                "Cmd" : "infrakit-group-default --poll-interval 10s --name group-stateless --log 5 > /Users/me/.infrakit/logs/group-stateless.log 2>&1"
-            } 
-INFO[0000] OS launcher: Plugin group-stateless setPgId= true starting infrakit-group-default --poll-interval 10s --name group-stateless --log 5 > /Users/me/.infrakit/logs/group-stateless.log 2>&1 
-INFO[0000] Running /bin/sh /bin/sh -c infrakit-group-default --poll-interval 10s --name group-stateless --log 5 > /Users/me/.infrakit/logs/group-stateless.log 2>&1 
-manager started.
-Starting up flavor-swarm
-INFO[0000] Starting with <nil> sh= infrakit-group-default --poll-interval 10s --name group-stateless --log 5 > /Users/me/.infrakit/logs/group-stateless.log 2>&1 
-INFO[0000] Waiting for flavor-swarm to start: {
-                "Cmd" : "infrakit-flavor-swarm --log 5 > /Users/me/.infrakit/logs/flavor-swarm.log 2>&1"
-            } 
-INFO[0000] OS launcher: Plugin flavor-swarm setPgId= true starting infrakit-flavor-swarm --log 5 > /Users/me/.infrakit/logs/flavor-swarm.log 2>&1 
-INFO[0000] Running /bin/sh /bin/sh -c infrakit-flavor-swarm --log 5 > /Users/me/.infrakit/logs/flavor-swarm.log 2>&1 
-group-stateless started.
-Starting up instance-vagrant
-INFO[0000] Starting with <nil> sh= infrakit-flavor-swarm --log 5 > /Users/me/.infrakit/logs/flavor-swarm.log 2>&1 
-INFO[0000] Waiting for instance-vagrant to start: {
-                "Cmd" : "infrakit-instance-vagrant --log 5 > /Users/me/.infrakit/logs/instance-vagrant.log 2>&1"
-            } 
-INFO[0000] OS launcher: Plugin instance-vagrant setPgId= true starting infrakit-instance-vagrant --log 5 > /Users/me/.infrakit/logs/instance-vagrant.log 2>&1 
-INFO[0000] Running /bin/sh /bin/sh -c infrakit-instance-vagrant --log 5 > /Users/me/.infrakit/logs/instance-vagrant.log 2>&1 
-flavor-swarm started.
-INFO[0000] Starting with <nil> sh= infrakit-instance-vagrant --log 5 > /Users/me/.infrakit/logs/instance-vagrant.log 2>&1 
-instance-vagrant started.
+INFO[11-03|14:34:31] config                                   module=cli/plugin url=file:////Users/me/go/src/github.com/docker/infrakit/pkg/plugin/flavor/swarm/plugins.json fn=github.com/docker/infrakit/cmd/infrakit/plugin.Command.func2
+INFO[11-03|14:34:31] Launching                                module=cli/plugin kind=manager name=group fn=github.com/docker/infrakit/cmd/infrakit/plugin.Command.func2
+INFO[11-03|14:34:31] Launching                                module=cli/plugin kind=group name=group-stateless fn=github.com/docker/infrakit/cmd/infrakit/plugin.Command.func2
+INFO[11-03|14:34:31] Starting plugin                          module=core/launch executor=inproc key=manager name=group exec=inproc fn=github.com/docker/infrakit/pkg/launch.(*Monitor).Start.func1
+INFO[11-03|14:34:31] Decoded input                            module=run/manager config="{Options:{Name: Group:group-stateless Metadata:vars Plugins:<nil> Leader:<nil> LeaderStore:<nil> SpecStore:<nil> MetadataStore:<nil> MetadataRefreshInterval:5000000000 LeaderCommitSpecsRetries:10 LeaderCommitSpecsRetryInterval:2000000000} Backend:file Settings:{\n\"PollInterval\": \"5s\",\n\"LeaderFile\": \"/Users/me/.infrakit/leader\",\n\"StoreDir\": \"/Users/me/.infrakit/configs\",\n\"ID\": \"manager1\"\n} Mux:0xc4204ca0a0 cleanUpFunc:<nil>}" fn=github.com/docker/infrakit/pkg/run/v0/manager.Run
+INFO[11-03|14:34:31] Starting up                              module=run/manager backend=file fn=github.com/docker/infrakit/pkg/run/v0/manager.Run
+INFO[11-03|14:34:31] starting up file backend                 module=run/manager options="{PollInterval:5000000000 LeaderFile:/Users/me/.infrakit/leader StoreDir:/Users/me/.infrakit/configs ID:manager1}" fn=github.com/docker/infrakit/pkg/run/v0/manager.Run
+INFO[11-03|14:34:31] file backend                             module=run/manager leader="&{pollInterval:5000000000 tick:0xc4203561e0 stop:<nil> pollFunc:0x1689b90 store:<nil> lock:{state:0 sema:0} receivers:[]}" store="&{dir:/Users/me/.infrakit/configs name:global.config}" cleanup=<nil> fn=github.com/docker/infrakit/pkg/run/v0/manager.Run
+INFO[11-03|14:34:31] Start manager                            module=run/manager m="&{Options:{Name:group Group:group-stateless Metadata:vars Plugins:0x16d71a0 Leader:0xc42008a190 LeaderStore:/Users/me/.infrakit/leader.loc SpecStore:0xc4204ca1e0 MetadataStore:0xc4204ca200 MetadataRefreshInterval:5000000000 LeaderCommitSpecsRetries:10 LeaderCommitSpecsRetryInterval:2000000000} Plugin:0xc42031a060 Updatable:0xc42031a0c0 isLeader:false lock:{state:0 sema:0} stop:<nil> running:<nil> Status:0xc4202ba680 doneStatusUpdates:0xc42007e240 backendOps:<nil>}" fn=github.com/docker/infrakit/pkg/run/v0/manager.Run
+INFO[11-03|14:34:31] Manager starting                         module=manager fn=github.com/docker/infrakit/pkg/manager.(*manager).Start
+INFO[11-03|14:34:31] Manager running                          module=run/manager fn=github.com/docker/infrakit/pkg/run/v0/manager.Run
+INFO[11-03|14:34:31] Starting mux server                      module=run/manager listen=:24864 advertise=localhost:24864 fn=github.com/docker/infrakit/pkg/run/v0/manager.Run
+INFO[11-03|14:34:31] written pid                              module=rpc/mux path=/Users/me/.infrakit/plugins/24864.pid fn=github.com/docker/infrakit/pkg/rpc/mux.SavePID
+INFO[11-03|14:34:31] Listening                                module=rpc/mux listen=:24864 fn=github.com/docker/infrakit/pkg/rpc/mux.NewServer
+INFO[11-03|14:34:31] exported objects                         module=run/manager fn=github.com/docker/infrakit/pkg/run/v0/manager.Run
+INFO[11-03|14:34:31] Object is an event producer              module=rpc/server object=&{keyed:0xc42017e208} discover=/Users/me/.infrakit/plugins/group fn=github.com/docker/infrakit/pkg/rpc/server.startAtPath
+INFO[11-03|14:34:31] Listening                                module=rpc/server discover=/Users/me/.infrakit/plugins/group fn=github.com/docker/infrakit/pkg/rpc/server.startAtPath
+INFO[11-03|14:34:31] Waiting for startup                      module=core/launch key=manager name=group config="{\n          \"Kind\": \"manager\",\n          \"Options\": {\n            \"Name\": \"\",\n            \"Group\": \"group-stateless\"\n          },\n\t  \"Settings\": {\n\t\t  \"LeaderFile\": \"/Users/me/.infrakit/leader\",\n\t\t  \"StoreDir\": \"/Users/me/.infrakit/configs\"\n\t  },\n          \"Backend\": \"file\"\n        }" as=group fn=github.com/docker/infrakit/pkg/launch.(*Monitor).Start.func1
+INFO[11-03|14:34:31] Starting plugin                          module=core/launch executor=inproc key=group name=group-stateless exec=inproc fn=github.com/docker/infrakit/pkg/launch.(*Monitor).Start.func1
+INFO[11-03|14:34:31] Launching                                module=cli/plugin kind=flavor-swarm name=flavor-swarm fn=github.com/docker/infrakit/cmd/infrakit/plugin.Command.func2
+INFO[11-03|14:34:31] PID file created                         module=run path=/Users/me/.infrakit/plugins/group.pid fn=github.com/docker/infrakit/pkg/run.run.func1
+INFO[11-03|14:34:31] Server started                           module=run discovery=/Users/me/.infrakit/plugins/group fn=github.com/docker/infrakit/pkg/run.run.func1
+INFO[11-03|14:34:31] Object is an event producer              module=rpc/server object=&{keyed:0xc42017e720} discover=/Users/me/.infrakit/plugins/group-stateless fn=github.com/docker/infrakit/pkg/rpc/server.startAtPath
+INFO[11-03|14:34:31] Listening                                module=rpc/server discover=/Users/me/.infrakit/plugins/group-stateless fn=github.com/docker/infrakit/pkg/rpc/server.startAtPath
+INFO[11-03|14:34:31] Waiting for startup                      module=core/launch key=group name=group-stateless config="{\n\"Kind\": \"group\",\n\"Options\": {\n\"PollInterval\": \"10s\",\n\"MaxParallelNum\": 0,\n\"PollIntervalGroupSpec\": \"10s\",\n\"PollIntervalGroupDetail\": \"10s\"\n}\n}" as=group-stateless fn=github.com/docker/infrakit/pkg/launch.(*Monitor).Start.func1
+INFO[11-03|14:34:31] Starting plugin                          module=core/launch executor=inproc key=flavor-swarm name=flavor-swarm exec=inproc fn=github.com/docker/infrakit/pkg/launch.(*Monitor).Start.func1
+INFO[11-03|14:34:31] Launching                                module=cli/plugin kind=instance-vagrant name=instance-vagrant fn=github.com/docker/infrakit/cmd/infrakit/plugin.Command.func2
+INFO[11-03|14:34:31] PID file created                         module=run path=/Users/me/.infrakit/plugins/group-stateless.pid fn=github.com/docker/infrakit/pkg/run.run.func1
+INFO[11-03|14:34:31] Server started                           module=run discovery=/Users/me/.infrakit/plugins/group-stateless fn=github.com/docker/infrakit/pkg/run.run.func1
+INFO[11-03|14:34:31] Listening                                module=rpc/server discover=/Users/me/.infrakit/plugins/flavor-swarm fn=github.com/docker/infrakit/pkg/rpc/server.startAtPath
+INFO[11-03|14:34:31] Waiting for startup                      module=core/launch key=flavor-swarm name=flavor-swarm config="{\n          \"Kind\": \"swarm\"\n        }" as=flavor-swarm fn=github.com/docker/infrakit/pkg/launch.(*Monitor).Start.func1
+INFO[11-03|14:34:31] Starting plugin                          module=core/launch executor=inproc key=instance-vagrant name=instance-vagrant exec=inproc fn=github.com/docker/infrakit/pkg/launch.(*Monitor).Start.func1
+INFO[11-03|14:34:31] PID file created                         module=run path=/Users/me/.infrakit/plugins/flavor-swarm.pid fn=github.com/docker/infrakit/pkg/run.run.func1
+INFO[11-03|14:34:31] Server started                           module=run discovery=/Users/me/.infrakit/plugins/flavor-swarm fn=github.com/docker/infrakit/pkg/run.run.func1
+INFO[11-03|14:34:31] Listening                                module=rpc/server discover=/Users/me/.infrakit/plugins/instance-vagrant fn=github.com/docker/infrakit/pkg/rpc/server.startAtPath
+INFO[11-03|14:34:31] Waiting for startup                      module=core/launch key=instance-vagrant name=instance-vagrant config="{\n          \"Kind\": \"vagrant\",\n          \"Options\": {\n          }\n        }" as=instance-vagrant fn=github.com/docker/infrakit/pkg/launch.(*Monitor).Start.func1
+INFO[11-03|14:34:31] Done waiting on plugin starts            module=cli/plugin fn=github.com/docker/infrakit/cmd/infrakit/plugin.Command.func2
+INFO[11-03|14:34:31] PID file created                         module=run path=/Users/me/.infrakit/plugins/instance-vagrant.pid fn=github.com/docker/infrakit/pkg/run.run.func1
+INFO[11-03|14:34:31] Server started                           module=run discovery=/Users/me/.infrakit/plugins/instance-vagrant fn=github.com/docker/infrakit/pkg/run.run.func1
 Plugins started.
 Do something like: infrakit manager commit file:///Users/me/projects/src/github.com/docker/infrakit/examples/flavor/swarm/groups-fast.json
  
@@ -267,12 +274,27 @@ And stop all the plugins:
 
 ```
 ~/projects/src/github.com/docker/infrakit$ infrakit plugin stop --all
-INFO[0000] Stopping flavor-swarm at PID= 69525          
-INFO[0000] Process for flavor-swarm exited              
-INFO[0000] Stopping group at PID= 69522                 
-INFO[0000] Process for group exited                     
-INFO[0000] Stopping group-stateless at PID= 69524       
-INFO[0000] Process for group-stateless exited           
-INFO[0000] Stopping instance-vagrant at PID= 69527      
-INFO[0000] Process for instance-vagrant exited
+INFO[11-03|14:41:17] Stopping                                 module=run/manager name=group-stateless pid=7201 fn=github.com/docker/infrakit/pkg/run/manager.(*Manager).Terminate
+INFO[11-03|14:41:17] Process exited                           module=run/manager name=group-stateless fn=github.com/docker/infrakit/pkg/run/manager.(*Manager).Terminate
+INFO[11-03|14:41:17] Stopping                                 module=run/manager name=instance-vagrant pid=7201 fn=github.com/docker/infrakit/pkg/run/manager.(*Manager).Terminate
+INFO[11-03|14:41:17] Process exited                           module=run/manager name=instance-vagrant fn=github.com/docker/infrakit/pkg/run/manager.(*Manager).Terminate
+INFO[11-03|14:41:17] listener stopped                         module=rpc/mux fn=github.com/docker/infrakit/pkg/rpc/mux.NewServer.func2.1
+INFO[11-03|14:41:17] Stopping                                 module=run/manager name=flavor-swarm pid=7201 fn=github.com/docker/infrakit/pkg/run/manager.(*Manager).Terminate
+INFO[11-03|14:41:17] Process exited                           module=run/manager name=flavor-swarm fn=github.com/docker/infrakit/pkg/run/manager.(*Manager).Terminate
+INFO[11-03|14:41:17] Stopping                                 module=run/manager name=group pid=7201 fn=github.com/docker/infrakit/pkg/run/manager.(*Manager).Terminate
+INFO[11-03|14:41:17] Stop checking leadership                 module=rpc/mux fn=github.com/docker/infrakit/pkg/rpc/mux.NewServer.func1
+INFO[11-03|14:41:17] Stopping event relay                     module=rpc/server fn=github.com/docker/infrakit/pkg/rpc/server.startAtPath.func1
+INFO[11-03|14:41:17] Stopping event relay                     module=rpc/server fn=github.com/docker/infrakit/pkg/rpc/server.startAtPath.func1
+INFO[11-03|14:41:17] Process exited                           module=run/manager name=group fn=github.com/docker/infrakit/pkg/run/manager.(*Manager).Terminate
+INFO[11-03|14:41:17] Removed PID file                         module=run path=/Users/me/.infrakit/plugins/instance-vagrant.pid fn=github.com/docker/infrakit/pkg/run.run.func1
+INFO[11-03|14:41:17] Removed discover file                    module=run path=/Users/me/.infrakit/plugins/instance-vagrant fn=github.com/docker/infrakit/pkg/run.run.func1
+INFO[11-03|14:41:17] Removed PID file                         module=run path=/Users/me/.infrakit/plugins/group-stateless.pid fn=github.com/docker/infrakit/pkg/run.run.func1
+INFO[11-03|14:41:17] Removed discover file                    module=run path=/Users/me/.infrakit/plugins/group-stateless fn=github.com/docker/infrakit/pkg/run.run.func1
+INFO[11-03|14:41:17] Removed PID file                         module=run path=/Users/me/.infrakit/plugins/group.pid fn=github.com/docker/infrakit/pkg/run.run.func1
+INFO[11-03|14:41:17] Removed PID file                         module=run path=/Users/me/.infrakit/plugins/flavor-swarm.pid fn=github.com/docker/infrakit/pkg/run.run.func1
+INFO[11-03|14:41:17] Removed discover file                    module=run path=/Users/me/.infrakit/plugins/flavor-swarm fn=github.com/docker/infrakit/pkg/run.run.func1
+INFO[11-03|14:41:17] Snapshot updater stopped                 module=run/group fn=github.com/docker/infrakit/pkg/run/v0/group.Run.func3
+INFO[11-03|14:41:17] Snapshot updater stopped                 module=flavor/swarm fn=github.com/docker/infrakit/pkg/plugin/flavor/swarm.(*baseFlavor).runMetadataSnapshot.func1
+INFO[11-03|14:41:17] Removed discover file                    module=run path=/Users/me/.infrakit/plugins/group fn=github.com/docker/infrakit/pkg/run.run.func1
+INFO[11-03|14:41:17] Snapshot updater stopped                 module=flavor/swarm fn=github.com/docker/infrakit/pkg/plugin/flavor/swarm.(*baseFlavor).runMetadataSnapshot.func1
 ```

--- a/pkg/plugin/flavor/swarm/plugins.json
+++ b/pkg/plugin/flavor/swarm/plugins.json
@@ -1,37 +1,54 @@
 [
     {
-        "Plugin" : "manager",
-        "Launch" : {
-            "os": {
-                "Cmd" : "infrakit-manager --name group  --proxy-for-group group-stateless os --leader-file {{env "INFRAKIT_HOME"}}/leader --store-dir {{env "INFRAKIT_HOME"}}/configs > {{env "INFRAKIT_HOME"}}/logs/manager.log 2>&1"
-            }
+      "Key": "manager",
+      "Launch": {
+        "inproc": {
+          "Kind": "manager",
+          "Options": {
+            "Name": "",
+            "Group": "group-stateless"
+          },
+	  "Settings": {
+		  "LeaderFile": "{{env "INFRAKIT_HOME"}}/leader",
+		  "StoreDir": "{{env "INFRAKIT_HOME"}}/configs"
+	  },
+          "Backend": "file"
         }
+      }
     }
     ,
     {
-        "Plugin" : "group-stateless",
-        "Launch" : {
-            "os": {
-                "Cmd" : "infrakit-group-default --poll-interval 10s --name group-stateless --log 5 > {{env "INFRAKIT_HOME"}}/logs/group-stateless.log 2>&1"
-            }
+      "Key": "group-stateless",
+      "Launch": {
+        "inproc": {
+          "Kind": "group",
+          "Options": {
+            "PollInterval": "10s",
+            "MaxParallelNum": 0,
+            "PollIntervalGroupSpec": "10s",
+            "PollIntervalGroupDetail": "10s"
+          }
         }
+      }
     }
     ,
     {
-        "Plugin" : "instance-vagrant",
-        "Launch" : {
-            "os" : {
-                "Cmd" : "infrakit-instance-vagrant --log 5 > {{env "INFRAKIT_HOME"}}/logs/instance-vagrant.log 2>&1"
-            }
+      "Key": "instance-vagrant",
+      "Launch": {
+        "inproc": {
+          "Kind": "vagrant",
+          "Options": {
+          }
         }
+      }
     }
     ,
     {
-        "Plugin" : "flavor-swarm",
-        "Launch" : {
-            "os" : {
-                "Cmd" : "infrakit-flavor-swarm --log 5 > {{env "INFRAKIT_HOME"}}/logs/flavor-swarm.log 2>&1"
-            }
+      "Key": "flavor-swarm",
+      "Launch": {
+        "inproc": {
+          "Kind": "swarm"
         }
+      }
     }
 ]

--- a/pkg/plugin/flavor/swarm/start-plugins.sh
+++ b/pkg/plugin/flavor/swarm/start-plugins.sh
@@ -28,11 +28,11 @@ echo group > $leaderfile
 
 export INFRAKIT_HOME=$INFRAKIT_HOME
 
-infrakit plugin start --config-url file:///$PWD/examples/flavor/swarm/plugins.json --exec os \
+infrakit plugin start --config-url file:///$PWD/plugin/flavor/swarm/plugins.json \
 	 manager \
-	 group-stateless \
+	 group \
 	 flavor-swarm \
-	 instance-vagrant
+	 instance-vagrant &
 
 sleep 5
 

--- a/pkg/provider/aws/plugin/metadata/builder.go
+++ b/pkg/provider/aws/plugin/metadata/builder.go
@@ -59,7 +59,7 @@ func NewPlugin(options Options, stop <-chan struct{}) (*Context, error) {
 		providers = append(providers, &staticCreds)
 	}
 
-	if options.Region == "" {
+	if options.Region == "" || options.Region == "auto" {
 		log.Warn("region not specified, attempting to discover from EC2 instance metadata")
 		region, err := instance.GetRegion()
 		if err != nil {

--- a/pkg/run/v0/terraform/README.md
+++ b/pkg/run/v0/terraform/README.md
@@ -58,7 +58,7 @@ infrakit plugin start terraform:terraform=inproc
 ```
 
 where the launch system will look for `Key` of `terraform`, and use the `inproc` launcher which uses the
-embeded `terraform` Kind.  That then will look for the `Options` field and provide that to the code
+embedded `terraform` Kind.  That then will look for the `Options` field and provide that to the code
 that is in `terraform.go`.
 
 Once you have the new fields defined and updated your `plugins.json` file to reflect these new changes,

--- a/pkg/template/template.go
+++ b/pkg/template/template.go
@@ -419,7 +419,7 @@ func (t *Template) Render(context interface{}) (string, error) {
 	return buff.String(), err
 }
 
-// converts a function of f(Context, ags...) to a regular template function
+// converts a function of f(Context, args...) to a regular template function
 func makeTemplateFunc(ctx Context, f interface{}) (interface{}, error) {
 
 	contextType := reflect.TypeOf((*Context)(nil)).Elem()


### PR DESCRIPTION
`infrakit plugin start manager aws` was failing, the aws metadata plugin crashing because of a missing template (the one that can be set with the INFRAKIT_AWS_METADATA_TEMPLATE_URL variable).
This PR fixes this issue, and updates the documentation with the new plugins.json syntax.