### PR TITLE
Conditionally include UCS plugin in core binary

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,8 +14,8 @@ E2E_TESTS?=true
 #Source file target
 SRCS  := $(shell find . -type f -name '*.go')
 
-# Set the go build tags here.  By default we disable building of libvirt
-GO_BUILD_TAGS?=nolibvirt
+# Set the go build tags here.  By default we disable building of libvirt and ucs.  Must be space-separated.
+GO_BUILD_TAGS?='nolibvirt noucs'
 
 # Allow turning off function inlining and variable registerization
 ifeq (${DISABLE_OPTIMIZATION},true)

--- a/cmd/infrakit/main.go
+++ b/cmd/infrakit/main.go
@@ -63,7 +63,6 @@ import (
 	_ "github.com/docker/infrakit/pkg/run/v0/tailer"
 	_ "github.com/docker/infrakit/pkg/run/v0/terraform"
 	_ "github.com/docker/infrakit/pkg/run/v0/time"
-	_ "github.com/docker/infrakit/pkg/run/v0/ucs"
 	_ "github.com/docker/infrakit/pkg/run/v0/vagrant"
 	_ "github.com/docker/infrakit/pkg/run/v0/vanilla"
 	_ "github.com/docker/infrakit/pkg/run/v0/vars"

--- a/cmd/infrakit/ucs.go
+++ b/cmd/infrakit/ucs.go
@@ -1,0 +1,7 @@
+// +build ucs
+
+package main
+
+import (
+	_ "github.com/docker/infrakit/pkg/run/v0/ucs"
+)

--- a/pkg/cli/registry.go
+++ b/pkg/cli/registry.go
@@ -125,9 +125,11 @@ func LoadAll(services *Services) ([]*cobra.Command, error) {
 			// 'info' subcommands map to the each interface the plugin implements
 			seen := map[string]*cobra.Command{}
 
-			list := []string{}
+			interfaces := map[string]struct{}{}
+
 			for _, spi := range spis {
-				list = append(list, spi.Encode())
+
+				interfaces[spi.Encode()] = struct{}{}
 
 				visitCommands(spi, func(buildCmd CmdBuilder) {
 
@@ -148,6 +150,11 @@ func LoadAll(services *Services) ([]*cobra.Command, error) {
 					command.AddCommand(subcommand)
 					seen[verb] = subcommand
 				})
+			}
+
+			list := []string{}
+			for k := range interfaces {
+				list = append(list, k)
 			}
 
 			command.Short = fmt.Sprintf("Access object %s which implements %s",


### PR DESCRIPTION
The UCS plugin has a dependency on "github.com/micdoher/GoUtils" which pulls in the flags in Golang's `testing` package even for non-test binaries.  We need to look at patching / removing that dependency, which was needed only to add a logger.

This PR also adds a small bug fix to make sure the help text in the CLI don't contain duplicate interface descriptions.

Signed-off-by: David Chung <david.chung@docker.com>