### PR TITLE
VMware vSphere logging and stability fixes.

### DIFF
--- a/pkg/provider/vsphere/plugin.go
+++ b/pkg/provider/vsphere/plugin.go
@@ -4,28 +4,40 @@ import (
 	"context"
 	"fmt"
 	"math/rand"
+	"os"
 	"time"
 
 	"github.com/docker/infrakit/pkg/spi"
 	"github.com/docker/infrakit/pkg/spi/instance"
 	"github.com/docker/infrakit/pkg/types"
 
-	log "github.com/Sirupsen/logrus"
+	logutil "github.com/docker/infrakit/pkg/log"
 )
 
 var ignoreVMs bool
 
+// Provides the logging capabilit
+var log = logutil.New("module", "provider/oneview")
+
 // Spec is just whatever that can be unmarshalled into a generic JSON map
 type Spec map[string]interface{}
 
-// This contains the two main structs used to
+// This contains all of the information that the plugin needs to be aware of for provisioning and managing instances
 type plugin struct {
 	vC               *vCenter
 	vCenterInternals *vcInternal
+	fsm              []provisioningFSM
 }
 
 func init() {
 	rand.Seed(time.Now().UTC().UnixNano())
+}
+
+//miniFSM for managing the provisioning -> provisioned state
+type provisioningFSM struct {
+	countdown    int64             // ideally will be a counter of minutes / seconds
+	tags         map[string]string // tags that will be passed back per a describe function
+	instanceName string            // name that we will use as a lookup to the actual backend that is privisioning
 }
 
 // NewInstancePlugin will take the cmdline/env configuration
@@ -48,7 +60,8 @@ func NewVSphereInstancePlugin(vc *vCenter, ignoreOnDestroy bool) instance.Plugin
 	internals, err := vCenterConnect(vc)
 	if err != nil {
 		// Exit with an error if we can't connect to vCenter (no point continuing)
-		log.Fatalf("%v\n", err)
+		log.Crit("Error connecting to vCenter", "Response", err.Error)
+		os.Exit(-1)
 	}
 	return &plugin{
 		vC:               vc,
@@ -82,14 +95,14 @@ func (p *plugin) ExampleProperties() *types.Any {
 
 // Validate performs local validation on a provision request.
 func (p *plugin) Validate(req *types.Any) error {
-	log.Debugln("validate", req.String())
+	log.Debug("validate", "Request", req.String())
 
 	spec := Spec{}
 	if err := req.Decode(&spec); err != nil {
 		return err
 	}
 
-	log.Debugln("Validated:", spec)
+	log.Debug("Validated:", "Spec", spec)
 	return nil
 }
 
@@ -104,15 +117,15 @@ func (p *plugin) Provision(spec instance.Spec) (*instance.ID, error) {
 		}
 	}
 
-	newInstance, err := parseParameters(properties, p)
+	newVM, err := parseParameters(properties, p)
 	if err != nil {
-		log.Errorf("Error: \n%v", err)
+		log.Error("Problems Whilst Parsting", "Error", err)
 		return nil, err
 	}
 
 	err = setInternalStructures(p.vC, p.vCenterInternals)
 	if err != nil {
-		log.Errorf("Error: \n%v", err)
+		log.Error("Problem whilst setting Internal Config", "Error", err)
 		return nil, err
 	}
 
@@ -121,9 +134,9 @@ func (p *plugin) Provision(spec instance.Spec) (*instance.ID, error) {
 	}
 
 	// Use the VMware plugin data in order to provision a new VM server
-	vmName := instance.ID(fmt.Sprintf(newInstance.vmPrefix+"-%d", rand.Int63()))
+	vmName := instance.ID(fmt.Sprintf(newVM.vmPrefix+"-%d", rand.Int63()))
 	if spec.Tags != nil {
-		log.Infof("Adding %s to Group %v", string(vmName), spec.Tags["infrakit.group"])
+		log.Info(fmt.Sprintf("Adding %s to Group %v", string(vmName), spec.Tags["infrakit.group"]))
 	}
 
 	if err != nil {
@@ -132,19 +145,32 @@ func (p *plugin) Provision(spec instance.Spec) (*instance.ID, error) {
 
 	//  Spawn a goroutine to provision in the background
 	go func() {
-		newInstance.vmName = string(vmName)
+		newVM.vmName = string(vmName)
 		var newInstanceError error
-		if newInstance.vmTemplate != "" {
-			log.Infof("Cloning new instance from template: %s", newInstance.vmTemplate)
-			newInstanceError = cloneNewInstance(p, &newInstance, spec)
+		if newVM.vmTemplate != "" {
+			log.Info(fmt.Sprintf("Cloning new instance from template: %s", newVM.vmTemplate))
+			newInstanceError = cloneNewInstance(p, &newVM, spec)
 		} else {
-			newInstanceError = createNewVMInstance(p, &newInstance, spec)
+			newInstanceError = createNewVMInstance(p, &newVM, spec)
 		}
 		if newInstanceError != nil {
-			log.Warnf("Error adding %s", newInstance.vmName)
-			log.Errorf("vSphere Error: %v", newInstanceError)
+			log.Warn(fmt.Sprintf("Error adding %s", newVM.vmName))
+			log.Error(fmt.Sprintf("vSphere Error: %v", newInstanceError))
 		}
 	}()
+
+	var newInstance provisioningFSM
+	newInstance.instanceName = string(newVM.vmName)
+	newInstance.countdown = 5 // FIXED 10 minute timeout (TODO)
+
+	// duplicate the tags for the instance
+	newInstance.tags = make(map[string]string)
+	for k, v := range spec.Tags {
+		newInstance.tags[k] = v
+	}
+	newInstance.tags["infrakit.state"] = "Provisioning"
+	p.fsm = append(p.fsm, newInstance)
+	log.Debug("New Instance added to state, count: %d", len(p.fsm))
 
 	return &vmName, nil
 }
@@ -156,7 +182,7 @@ func (p *plugin) Label(instance instance.ID, labels map[string]string) error {
 
 // Destroy terminates an existing instance.
 func (p *plugin) Destroy(instance instance.ID, context instance.Context) error {
-	log.Infof("Currently running %s on instance: %v", context, instance)
+	log.Info(fmt.Sprintf("Currently running %s on instance: %v", context, instance))
 	// Spawn a goroutine to delete in the background
 	go func() {
 		// TODO: Checks need adding to examine the instance that are quick enough not to trip timeout
@@ -167,25 +193,27 @@ func (p *plugin) Destroy(instance instance.ID, context instance.Context) error {
 			err = deleteVM(p, string(instance))
 		}
 		if err != nil {
-			log.Errorf("%v", err)
+			log.Error(fmt.Sprintf("%v", err))
 		}
 	}()
+
+	// TODO: Ideally the goroutine should return the error otherwise this function can never fail for InfraKit
 	return nil
 }
 
 // DescribeInstances returns descriptions of all instances matching all of the provided tags.
 // TODO - need to define the fitlering of tags => AND or OR of matches?
 func (p *plugin) DescribeInstances(tags map[string]string, properties bool) ([]instance.Description, error) {
-	log.Debugln("describe-instances", tags)
+	log.Debug(fmt.Sprintf("describe-instances: %v", tags))
 	results := []instance.Description{}
 
 	groupName := tags["infrakit.group"]
 	instances, err := findGroupInstances(p, groupName)
 	if err != nil {
-		log.Debugf("%v", err)
+		log.Error(err.Error())
 	}
 	if len(instances) == 0 {
-		log.Warnln("No Instances found")
+		log.Warn("No Instances found")
 	}
 
 	// Iterate through group instances and find the sha from their annotation field
@@ -210,5 +238,40 @@ func (p *plugin) DescribeInstances(tags map[string]string, properties bool) ([]i
 			Tags:      vmTags,
 		})
 	}
+	log.Debug("Modifying provisining state count:  %d", len(p.fsm))
+
+	// DIFF what the endpoint is saying as reported versus what we have in the FSM
+	var updatedFSM []provisioningFSM
+	for _, unprovisionedInstance := range p.fsm {
+		var provisioned bool
+
+		for _, provisionedInstance := range results {
+
+			if string(provisionedInstance.ID) == unprovisionedInstance.instanceName {
+				provisioned = true
+				// instance has been provisioned so break from loop
+				break
+			} else {
+				provisioned = false
+			}
+		}
+		if provisioned == false && unprovisionedInstance.countdown != 0 && unprovisionedInstance.tags["infrakit.group"] == tags["infrakit.group"] {
+			unprovisionedInstance.countdown--
+			updatedFSM = append(updatedFSM, unprovisionedInstance)
+		}
+	}
+
+	p.fsm = make([]provisioningFSM, len(updatedFSM))
+	copy(p.fsm, updatedFSM)
+
+	log.Debug("Updated provisining state count: %d", len(p.fsm))
+	for _, unprovisionedInstances := range p.fsm {
+		results = append(results, instance.Description{
+			ID:        instance.ID(unprovisionedInstances.instanceName),
+			LogicalID: nil,
+			Tags:      unprovisionedInstances.tags,
+		})
+	}
+
 	return results, nil
 }

--- a/pkg/provider/vsphere/vsphere.go
+++ b/pkg/provider/vsphere/vsphere.go
@@ -80,7 +80,7 @@ func vCenterConnect(vc *vCenter) (vcInternal, error) {
 	// Connect and log in to ESX or vCenter
 	internals.client, err = govmomi.NewClient(ctx, u, true)
 	if err != nil {
-		return internals, fmt.Errorf("Error logging into vCenter, check address and credentials\nClient Error: %v", err)
+		return internals, err
 	}
 	return internals, nil
 }
@@ -149,7 +149,7 @@ func parseParameters(properties map[string]interface{}, p *plugin) (vmInstance, 
 		return newInstance, errors.New("Property 'Datastore' must be set")
 	}
 	*p.vC.dsName = properties["Datastore"].(string)
-	log.Debug(fmt.Sprintf("Datastore set to %s", *p.vC.dsName))
+	log.Debug("Setting datastore", "datastore", *p.vC.dsName)
 
 	if properties["Hostname"] == nil {
 		return newInstance, errors.New("Property 'Hostname' must be set")

--- a/pkg/provider/vsphere/vsphere.go
+++ b/pkg/provider/vsphere/vsphere.go
@@ -9,8 +9,6 @@ import (
 	"github.com/vmware/govmomi"
 	"github.com/vmware/govmomi/find"
 	"github.com/vmware/govmomi/object"
-
-	log "github.com/Sirupsen/logrus"
 )
 
 // Options capture the config parameters required to create the plugin
@@ -133,7 +131,7 @@ func parseParameters(properties map[string]interface{}, p *plugin) (vmInstance, 
 
 	var newInstance vmInstance
 
-	log.Debugf("Building vCenter specific parameters")
+	log.Debug("Building vCenter specific parameters")
 	if *p.vC.vCenterURL == "" {
 		if properties["vCenterURL"] == nil {
 			return newInstance, errors.New("Environment variable VCURL or .yml vCenterURL must be set")
@@ -142,7 +140,7 @@ func parseParameters(properties map[string]interface{}, p *plugin) (vmInstance, 
 	}
 
 	if properties["Datacenter"] == nil {
-		log.Warnf("The property 'Datacenter' hasn't been set the API will choose the default, which could cause errors in Linked-Mode")
+		log.Warn("The property 'Datacenter' hasn't been set the API will choose the default, which could cause errors in Linked-Mode")
 	} else {
 		*p.vC.dcName = properties["Datacenter"].(string)
 	}
@@ -151,7 +149,7 @@ func parseParameters(properties map[string]interface{}, p *plugin) (vmInstance, 
 		return newInstance, errors.New("Property 'Datastore' must be set")
 	}
 	*p.vC.dsName = properties["Datastore"].(string)
-	log.Debugf("Datastore set to %s", *p.vC.dsName)
+	log.Debug(fmt.Sprintf("Datastore set to %s", *p.vC.dsName))
 
 	if properties["Hostname"] == nil {
 		return newInstance, errors.New("Property 'Hostname' must be set")
@@ -159,7 +157,7 @@ func parseParameters(properties map[string]interface{}, p *plugin) (vmInstance, 
 	*p.vC.vSphereHost = properties["Hostname"].(string)
 
 	if properties["Network"] == nil {
-		log.Warnf("The property 'Network' hasn't been set, no networks will be attached to VM")
+		log.Warn("The property 'Network' hasn't been set, no networks will be attached to VM")
 	} else {
 		*p.vC.networkName = properties["Network"].(string)
 	}
@@ -175,7 +173,7 @@ func parseParameters(properties map[string]interface{}, p *plugin) (vmInstance, 
 	}
 
 	if properties["isoPath"] == nil {
-		log.Debugf("The property 'isoPath' hasn't been set, bootable ISO will not be added to the VM")
+		log.Debug("The property 'isoPath' hasn't been set, bootable ISO will not be added to the VM")
 	} else {
 		newInstance.isoPath = properties["isoPath"].(string)
 	}

--- a/pkg/provider/vsphere/vsphereTasks.go
+++ b/pkg/provider/vsphere/vsphereTasks.go
@@ -12,8 +12,6 @@ import (
 	"github.com/vmware/govmomi/object"
 	"github.com/vmware/govmomi/vim25/mo"
 	"github.com/vmware/govmomi/vim25/types"
-
-	log "github.com/Sirupsen/logrus"
 )
 
 func cloneNewInstance(p *plugin, vm *vmInstance, vmSpec instance.Spec) error {
@@ -64,7 +62,7 @@ func cloneNewInstance(p *plugin, vm *vmInstance, vmSpec instance.Spec) error {
 	vmObj := object.NewVirtualMachine(p.vCenterInternals.client.Client, vmTemplate.Reference())
 	groupFolder, err := f.Folder(ctx, vmSpec.Tags["infrakit.group"])
 	if err != nil {
-		log.Debugf("%v", err)
+		log.Debug(err.Error())
 		groupFolder, err = p.vCenterInternals.dcFolders.VmFolder.CreateFolder(ctx, vmSpec.Tags["infrakit.group"])
 		if err != nil {
 			if err.Error() == "ServerFaultCode: The operation is not supported on the object." {
@@ -74,7 +72,7 @@ func cloneNewInstance(p *plugin, vm *vmInstance, vmSpec instance.Spec) error {
 				if err.Error() == "ServerFaultCode: The name '"+vmSpec.Tags["infrakit.group"]+"' already exists." {
 					return errors.New("A Virtual Machine exists with the same name as the InfraKit group")
 				}
-				log.Warnf("%v", err)
+				log.Warn(err.Error())
 			}
 		}
 	}
@@ -131,7 +129,7 @@ func createNewVMInstance(p *plugin, vm *vmInstance, vmSpec instance.Spec) error 
 
 	groupFolder, err := f.Folder(ctx, vmSpec.Tags["infrakit.group"])
 	if err != nil {
-		log.Debugf("%v", err)
+		log.Debug(err.Error())
 		groupFolder, err = p.vCenterInternals.dcFolders.VmFolder.CreateFolder(ctx, vmSpec.Tags["infrakit.group"])
 		if err != nil {
 			if err.Error() == "ServerFaultCode: The operation is not supported on the object." {
@@ -141,7 +139,7 @@ func createNewVMInstance(p *plugin, vm *vmInstance, vmSpec instance.Spec) error 
 				if err.Error() == "ServerFaultCode: The name '"+vmSpec.Tags["infrakit.group"]+"' already exists." {
 					return errors.New("A Virtual Machine exists with the same name as the InfraKit group")
 				}
-				log.Warnf("%v", err)
+				log.Warn(err.Error())
 			}
 		}
 	}
@@ -161,17 +159,17 @@ func createNewVMInstance(p *plugin, vm *vmInstance, vmSpec instance.Spec) error 
 
 	err = addISO(p, *vm, newVM)
 	if err != nil {
-		log.Warnf("%v", err)
+		log.Warn(err.Error())
 	}
 
 	if *p.vC.networkName != "" {
 		err = findNetwork(p.vC, p.vCenterInternals)
 		if err != nil {
-			log.Warnf("%v", err)
+			log.Warn(err.Error())
 		} else {
 			err = addNIC(newVM, p.vCenterInternals.network)
 			if err != nil {
-				log.Warnf("%v", err)
+				log.Warn(err.Error())
 			}
 		}
 	}
@@ -179,12 +177,12 @@ func createNewVMInstance(p *plugin, vm *vmInstance, vmSpec instance.Spec) error 
 	if vm.persistentSz > 0 {
 		err = addVMDK(p, newVM, *vm)
 		if err != nil {
-			log.Warnf("%v", err)
+			log.Warn(err.Error())
 		}
 	}
 
 	if vm.poweron == true {
-		log.Infoln("Powering on provisioned Virtual Machine")
+		log.Info("Powering on provisioned Virtual Machine")
 		return setVMPowerOn(true, newVM)
 	}
 
@@ -306,7 +304,7 @@ func addNIC(vm *object.VirtualMachine, net object.NetworkReference) error {
 		return fmt.Errorf("Unable to create vmxnet3 network interface\n%v", err)
 	}
 
-	log.Infof("Adding VM Networking")
+	log.Info("Adding VM Networking")
 	var add []types.BaseVirtualDevice
 	add = append(add, netdev)
 
@@ -337,7 +335,7 @@ func addVMDK(p *plugin, vm *object.VirtualMachine, newVM vmInstance) error {
 	var add []types.BaseVirtualDevice
 	add = append(add, disk)
 
-	log.Infof("Adding a persistent disk to the Virtual Machine")
+	log.Info("Adding a persistent disk to the Virtual Machine")
 
 	if vm.AddDevice(ctx, add...); err != nil {
 		return fmt.Errorf("Unable to add new storage device to VM configuration\n%v", err)
@@ -367,7 +365,7 @@ func addISO(p *plugin, newInstance vmInstance, vm *object.VirtualMachine) error 
 	var add []types.BaseVirtualDevice
 	add = append(add, devices.InsertIso(cdrom, p.vCenterInternals.datastore.Path(fmt.Sprintf("%s", newInstance.isoPath))))
 
-	log.Debugln("Adding ISO to the Virtual Machine")
+	log.Debug("Adding ISO to the Virtual Machine")
 
 	if vm.AddDevice(ctx, add...); err != nil {
 		return fmt.Errorf("Unable to add new CD-ROM device to VM configuration\n%v", err)
@@ -410,7 +408,7 @@ func findGroupInstances(p *plugin, groupName string) ([]*object.VirtualMachine, 
 			return vmList, err
 		}
 	} else {
-		log.Debugf("%v", err)
+		log.Debug(err.Error())
 	}
 	// Go through the VMs and find the correct ones from the groupname
 	foundVMs, err := findInstancesFromAnnotation(ctx, vmList, groupName)
@@ -426,7 +424,7 @@ func findInstancesFromAnnotation(ctx context.Context, vmList []*object.VirtualMa
 	for _, vmInstance := range vmList {
 		instanceGroup := returnDataFromVM(ctx, vmInstance, "group")
 		if instanceGroup == groupName {
-			log.Debugf("%s matches groupName %s\n", vmInstance.Name(), groupName)
+
 			foundVMS = append(foundVMS, vmInstance)
 		}
 	}
@@ -438,7 +436,7 @@ func returnDataFromVM(ctx context.Context, vmInstance *object.VirtualMachine, da
 	if dataType == "guestIP" {
 		err := vmInstance.Properties(ctx, vmInstance.Reference(), []string{"guest.ipAddress"}, &machineConfig)
 		if err != nil {
-			log.Errorf("%v", vmInstance)
+			log.Error(err.Error())
 		} else {
 			// Ensure that we're pointing to a Guest Config struct
 			if machineConfig.Guest != nil {
@@ -449,7 +447,7 @@ func returnDataFromVM(ctx context.Context, vmInstance *object.VirtualMachine, da
 	} else {
 		err := vmInstance.Properties(ctx, vmInstance.Reference(), []string{"config.annotation"}, &machineConfig)
 		if err != nil {
-			log.Errorf("%v", vmInstance)
+			log.Error(err.Error())
 		}
 		// Ensure that we're pointing to a Configuration struct
 		if machineConfig.Config != nil {

--- a/pkg/run/v0/vsphere/vsphere.go
+++ b/pkg/run/v0/vsphere/vsphere.go
@@ -21,6 +21,9 @@ const (
 	// EnvNamespaceTags is the env to set for namespace tags. It's k=v,...
 	EnvNamespaceTags = "INFRAKIT_VSPHERE_NAMESPACE_TAGS"
 
+	// EnvVCAlias is an alias that is given to the plugin
+	EnvVCAlias = "INFRAKIT_VSPHERE_VCALIAS"
+
 	// EnvVCURL is the env for setting the VCenter URL to connect to
 	EnvVCURL = "INFRAKIT_VSPHERE_VCURL"
 
@@ -103,7 +106,9 @@ func Run(scope scope.Scope, name plugin.Name,
 	hypervisors := map[string]instance.Plugin{}
 
 	for _, vcenter := range options.VCenters {
-		hypervisors[vcenter.VSphereHost] = vsphere.NewInstancePlugin(vcenter)
+		// Assign either an alias or the initial vSphere hosts to differentiate the plugins
+		vcenterName := local.Getenv(EnvVCAlias, EnvVCHost)
+		hypervisors[vcenterName] = vsphere.NewInstancePlugin(vcenter)
 	}
 
 	transport.Name = name


### PR DESCRIPTION
Removed the old style of logging, also updated comments and implemented
a State machine for systems with slow storage. This should allow
reliable provisioning regardless of the usage of VAAI/VAPI, closing one
of the issues and bringing the plugin inline. (FSM will need changing
later on)

Signed-off-by: Dan Finneran <daniel.finneran@gmail.com>