### PR TITLE
Update terraform file system lock to use a mutex

### DIFF
--- a/pkg/provider/terraform/instance/apply.go
+++ b/pkg/provider/terraform/instance/apply.go
@@ -144,10 +144,7 @@ type tfFuncs struct {
 // Once these steps are done then "terraform apply" can execute without the
 // file system lock.
 func (p *plugin) handleFiles(fns tfFuncs) error {
-	if err := p.fsLock.TryLock(); err != nil {
-		log.Infof("In handleFiles, cannot acquire file lock")
-		return err
-	}
+	p.fsLock.Lock()
 	defer p.fsLock.Unlock()
 
 	// Refresh resources and get updated resources names


### PR DESCRIPTION
The current file system lock was intended to prevent multiple instances of the instance plugin from reading/writing the file system; **it does not serialize operations for the current instance**. The file lock is not necessary since the group controller only runs on the leader and the tf `apply` goroutine only runs `terraform ...` commands on the manager. Moreover, if the leader dies (or looses network connectivity) while it has the process lock then we are deadlocked.

This causes issues if multiple `Provision` requests come in (and quorum groups do not serialize `Provision` requests) because the same `instance-<timestamp>` files may be used (then then the last request overrides the file).

The fix is to use a mutex instead of a file lock.