### PR TITLE
Add cert label support in schema

### DIFF
--- a/docs/controller/ingress/example2.yml
+++ b/docs/controller/ingress/example2.yml
@@ -68,6 +68,9 @@ properties:
     RouteSources:
       swarm:
         Host: unix:///var/run/docker.sock
+        # CertificateLabel is the swarm service label that has the certificate id.
+        CertificateLabel: lb-cert-label
+
   - Vhost: system
     Backends:
       Groups:
@@ -80,4 +83,5 @@ properties:
       - LoadBalancerPort: 80
         LoadBalancerProtocol: https
         Port: 8080
-        Protocol: http
+        Protocol: https
+        Certificate: external-cert-id

--- a/pkg/controller/ingress/swarm/init.go
+++ b/pkg/controller/ingress/swarm/init.go
@@ -35,6 +35,9 @@ type Docker docker.ConnectInfo
 type Spec struct {
 	// Docker holds the connection params to the Docker engine for join tokens, etc.
 	Docker `json:",inline" yaml:",inline"`
+
+	// CertificateLabel is the label on swarm services that we look for to get the certificate id.
+	CertificateLabel *string
 }
 
 type handler struct {
@@ -74,7 +77,10 @@ func (h *handler) Routes(properties *types.Any,
 	log.Info("Connected to Docker", "client", dockerClient)
 	h.dockerClient = dockerClient
 
-	routes, err := NewServiceRoutes(dockerClient).SetOptions(options).Build()
+	routes, err := NewServiceRoutes(dockerClient).
+		SetOptions(options).
+		SetCertLabel(spec.CertificateLabel).
+		Build()
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/controller/ingress/swarm/init_test.go
+++ b/pkg/controller/ingress/swarm/init_test.go
@@ -12,6 +12,8 @@ import (
 
 func TestParseSpec(t *testing.T) {
 
+	certLabel := "certLabel"
+
 	properties := ingress.Properties{
 		{
 			Vhost:    ingress.Vhost("test.com"),
@@ -19,9 +21,10 @@ func TestParseSpec(t *testing.T) {
 			RouteSources: map[string]*types.Any{
 				"swarm": types.AnyValueMust(
 					Spec{
-						Docker(docker.ConnectInfo{
+						Docker: Docker(docker.ConnectInfo{
 							Host: "/var/run/docker.sock",
 						}),
+						CertificateLabel: &certLabel,
 					},
 				),
 			},
@@ -41,4 +44,5 @@ func TestParseSpec(t *testing.T) {
 	err = properties[0].RouteSources["swarm"].Decode(&spec)
 	require.NoError(t, err)
 	require.Equal(t, "/var/run/docker.sock", spec.Docker.Host)
+	require.Equal(t, certLabel, *spec.CertificateLabel)
 }

--- a/pkg/controller/ingress/swarm/routes.go
+++ b/pkg/controller/ingress/swarm/routes.go
@@ -100,10 +100,18 @@ func (b *RoutesBuilder) SetOptions(options ingress.Options) *RoutesBuilder {
 	return b
 }
 
-// SetSpecLabels sets the label to look for for loadbalancer spec and certifcate spec
+// SetSpecLabels sets the label to look for loadbalancer spec and certifcate spec
 func (b *RoutesBuilder) SetSpecLabels(lbSpec, certSpec string) *RoutesBuilder {
 	b.lbSpecLabel = lbSpec
 	b.certSpecLabel = certSpec
+	return b
+}
+
+// SetCertLabel sets the label to look for the certifcate id
+func (b *RoutesBuilder) SetCertLabel(certLabel *string) *RoutesBuilder {
+	if certLabel != nil {
+		b.certSpecLabel = *certLabel
+	}
 	return b
 }
 

--- a/pkg/controller/ingress/swarm/services_test.go
+++ b/pkg/controller/ingress/swarm/services_test.go
@@ -9,11 +9,14 @@ import (
 )
 
 func TestExternalLoadBalancerListenersFromService1(t *testing.T) {
-	certLabel := "emptylabel"
+
+	certLabel := "cert.id"
+	certLookupID := "cert-uuid"
 
 	s := swarm.Service{}
 	s.Spec.Labels = map[string]string{
 		LabelExternalLoadBalancerSpec: "http://:8080",
+		certLabel:                     certLookupID,
 	}
 	s.Endpoint.Ports = []swarm.PortConfig{} // no exposed ports
 
@@ -48,14 +51,17 @@ func TestExternalLoadBalancerListenersFromService1(t *testing.T) {
 	require.Equal(t, HostNotSpecified, listener.host())
 	require.Equal(t, loadbalancer.HTTP, listener.protocol())
 	require.Equal(t, 8080, listener.extPort())
+	require.Equal(t, certLookupID, *listener.CertASN())
 }
 
 func TestExternalLoadBalancerListenersFromService2(t *testing.T) {
-	certLabel := "emptylabel"
+	certLabel := "certLabel"
+	certID := "certID"
 
 	s := swarm.Service{}
 	s.Spec.Labels = map[string]string{
 		LabelExternalLoadBalancerSpec: "http://",
+		certLabel:                     certID,
 	}
 	s.Spec.Name = "web1"
 	s.Endpoint.Ports = []swarm.PortConfig{
@@ -82,6 +88,7 @@ func TestExternalLoadBalancerListenersFromService2(t *testing.T) {
 	require.Equal(t, HostNotSpecified, listener.host())
 	require.Equal(t, loadbalancer.HTTP, listener.protocol())
 	require.Equal(t, 80, listener.extPort())
+	require.Equal(t, certID, *listener.CertASN())
 }
 
 func TestExternalLoadBalancerListenersFromService3(t *testing.T) {


### PR DESCRIPTION
Closes #754 

This PR adds a `CertificateLabel` field in the Swarm configuration of the ingress controller schema.  The field is optional and the value will be used by the sync code to look for the named label for an
external certificate identifier.

The `Backends` section can include this field under the `swarm` section of `RouteSources`:
```
- Backends:
      Groups:
        - group/workers # This is a group at socket(group), groupID(workers).

    # This is the plugin name of the L4 plugin. When you run `infrakit plugin start ... simulator`
    # the default socket file name is 'simulator' and there's a default lb2 in the RPC object.
    L4Plugin: simulator/lb1

    # Plus all the services in Swarm that have --publish <frontend-port>:<container_port>
    RouteSources:
      swarm:
        Host: unix:///var/run/docker.sock
        # CertificateLabel is the swarm service label that has the certificate id.
        CertificateLabel: lb-cert-label

```
Then a service created like

```
docker service create --network ingress --name t2 --label lb-cert-label=lb-cert-external-id --publish 7777:80 nginx
```
Will show up as the route 
```
FRONTEND PORT    FRONTEND PROTOCOL      BACKEND PORT      BACKEND PROTOCOL        CERT
7777             TCP                    7777              TCP                     lb-cert-external-id
```
The README documentation has been updated to reflect this use case.

Signed-off-by: David Chung <david.chung@docker.com>

cc: @ericvn 