### PR TITLE
Add validation and parsing to properly handle casing of protocols

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,7 +27,7 @@ endif
 .DEFAULT: all
 all: clean fmt vet lint build test binaries
 
-ci: fmt vet lint check-docs coverage e2e-test
+ci: fmt vet lint check-docs coverage
 
 AUTHORS: .mailmap .git/HEAD
 	git log --format='%aN <%aE>' | sort -fu > $@

--- a/circle.yml
+++ b/circle.yml
@@ -51,6 +51,7 @@ deployment:
   release:
     branch: /release-.*/
     commands:
+      - make e2e-test
       - docker login -e $DOCKER_HUB_EMAIL -u $DOCKER_HUB_USER -p $DOCKER_HUB_PASSWD
       - DOCKER_PUSH=true DOCKER_TAG_LATEST=false DOCKER_TAG=$(echo $CIRCLE_BRANCH | awk -F - '{print $2}') DOCKER_BUILD_FLAGS="--rm=false" make build-docker
       # Install minio.io for S3 bucket uploads
@@ -63,6 +64,7 @@ deployment:
   docker:
     branch: master
     commands:
+      - make e2e-test
       - docker login -e $DOCKER_HUB_EMAIL -u $DOCKER_HUB_USER -p $DOCKER_HUB_PASSWD
       - DOCKER_PUSH=true DOCKER_TAG_LATEST=true DOCKER_TAG="master-$CIRCLE_BUILD_NUM" DOCKER_BUILD_FLAGS="--rm=false" make build-docker
       # Install minio.io for S3 bucket uploads

--- a/docs/controller/ingress/example.yml
+++ b/docs/controller/ingress/example.yml
@@ -59,6 +59,7 @@ properties:
     Routes:
       - LoadBalancerPort: 80
         LoadBalancerProtocol: https
+        Certificate: external-cert-id
         Port: 8080
         Protocol: http
 

--- a/pkg/controller/ingress/types/funcs.go
+++ b/pkg/controller/ingress/types/funcs.go
@@ -94,6 +94,10 @@ func (p Properties) Routes(options Options) (result map[Vhost][]loadbalancer.Rou
 	result = map[Vhost][]loadbalancer.Route{}
 	for _, spec := range p {
 
+		if err := spec.Validate(); err != nil {
+			return nil, err
+		}
+
 		result[spec.Vhost] = spec.Routes
 
 		for key, config := range spec.RouteSources {

--- a/pkg/controller/ingress/types/types.go
+++ b/pkg/controller/ingress/types/types.go
@@ -65,6 +65,16 @@ type Spec struct {
 	HealthChecks []loadbalancer.HealthCheck
 }
 
+// Validate validates the struct and can mutate the fields as necessary.
+func (s *Spec) Validate() error {
+	for _, r := range s.Routes {
+		if err := r.Validate(); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
 // Group is a qualified plugin name. The 'type' field of the name is the group ID.
 type Group plugin.Name
 

--- a/pkg/controller/ingress/types/types_test.go
+++ b/pkg/controller/ingress/types/types_test.go
@@ -1,0 +1,51 @@
+package types
+
+import (
+	"testing"
+
+	"github.com/docker/infrakit/pkg/spi/loadbalancer"
+	"github.com/docker/infrakit/pkg/types"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSpecParsing(t *testing.T) {
+
+	any, err := types.AnyYAML([]byte(`
+kind: ingress
+metadata:
+  name: test.com
+  tags:
+    project: testing
+    user: chungers
+
+options:
+  SyncInterval: 10s  # syntax is a string form of Go time.Duration
+
+properties:
+  - Backends:
+      Groups:
+        - group/workers # This is a group at socket(group), groupID(workers).
+
+    L4Plugin: simulator/lb1
+    Routes:
+      - LoadBalancerPort: 80
+        LoadBalancerProtocol: https
+        Port: 8080
+        Protocol: http
+`))
+
+	require.NoError(t, err)
+
+	spec := types.Spec{}
+
+	err = any.Decode(&spec)
+	require.NoError(t, err)
+
+	specs := []Spec{}
+	err = spec.Properties.Decode(&specs)
+	require.NoError(t, err)
+
+	require.Equal(t, loadbalancer.HTTPS, specs[0].Routes[0].LoadBalancerProtocol)
+
+	require.Error(t, specs[0].Validate())
+}

--- a/pkg/spi/loadbalancer/protocol.go
+++ b/pkg/spi/loadbalancer/protocol.go
@@ -28,21 +28,6 @@ var (
 	Invalid = Protocol("")
 )
 
-// MarshalJSON returns the json representation
-func (r Protocol) MarshalJSON() ([]byte, error) {
-	return []byte("\"" + string(r) + "\""), nil
-}
-
-// UnmarshalJSON unmarshals the buffer to this struct
-func (r *Protocol) UnmarshalJSON(buff []byte) error {
-	parsed := ProtocolFromString(strings.Trim(string(buff), "\""))
-	if parsed == Invalid {
-		return fmt.Errorf("not valid protocol %v", string(buff))
-	}
-	*r = parsed
-	return nil
-}
-
 // ProtocolFromString gets the matching protocol for a string value.
 func ProtocolFromString(protocol string) Protocol {
 	for _, p := range []Protocol{HTTP, HTTPS, TCP, SSL, UDP} {
@@ -51,6 +36,21 @@ func ProtocolFromString(protocol string) Protocol {
 		}
 	}
 	return Invalid
+}
+
+// MarshalJSON returns the json representation
+func (p Protocol) MarshalJSON() ([]byte, error) {
+	return []byte("\"" + string(p) + "\""), nil
+}
+
+// UnmarshalJSON unmarshals the buffer to this struct
+func (p *Protocol) UnmarshalJSON(buff []byte) error {
+	parsed := ProtocolFromString(strings.Trim(string(buff), "\""))
+	if parsed == Invalid {
+		return fmt.Errorf("not valid protocol %v", string(buff))
+	}
+	*p = parsed
+	return nil
 }
 
 // Valid tests whether a protocol is known and valid.

--- a/pkg/spi/loadbalancer/protocol.go
+++ b/pkg/spi/loadbalancer/protocol.go
@@ -1,6 +1,7 @@
 package loadbalancer
 
 import (
+	"fmt"
 	"strings"
 )
 
@@ -26,6 +27,21 @@ var (
 	// Invalid - This is the 'nil' value
 	Invalid = Protocol("")
 )
+
+// MarshalJSON returns the json representation
+func (r Protocol) MarshalJSON() ([]byte, error) {
+	return []byte("\"" + string(r) + "\""), nil
+}
+
+// UnmarshalJSON unmarshals the buffer to this struct
+func (r *Protocol) UnmarshalJSON(buff []byte) error {
+	parsed := ProtocolFromString(strings.Trim(string(buff), "\""))
+	if parsed == Invalid {
+		return fmt.Errorf("not valid protocol %v", string(buff))
+	}
+	*r = parsed
+	return nil
+}
 
 // ProtocolFromString gets the matching protocol for a string value.
 func ProtocolFromString(protocol string) Protocol {

--- a/pkg/spi/loadbalancer/spi.go
+++ b/pkg/spi/loadbalancer/spi.go
@@ -32,6 +32,27 @@ type Route struct {
 	Certificate *string
 }
 
+// Validate validates the data herein. If necessary, some data values will be mutated as needed.
+func (r *Route) Validate() error {
+	if r.Port == 0 {
+		return fmt.Errorf("no port")
+	}
+	if r.LoadBalancerPort == 0 {
+		return fmt.Errorf("no loadbalancer port")
+	}
+	if !r.Protocol.Valid() {
+		return fmt.Errorf("bad protocol: %v", r.Protocol)
+	}
+	if !r.LoadBalancerProtocol.Valid() {
+		return fmt.Errorf("bad loadbalancer protocol: %v", r.LoadBalancerProtocol)
+	}
+	if r.LoadBalancerProtocol == HTTPS && r.Certificate == nil {
+		return fmt.Errorf("HTTPS but no certificate")
+	}
+
+	return nil
+}
+
 // HealthCheck models the a probe that checks against a given backend port at given
 // intervals and with timeout.
 type HealthCheck struct {


### PR DESCRIPTION
Closes #770 

  + Add marshal/unmarshal methods to handle casing of protocols in routes
  + Add validation logic to require static routes that are HTTPS to also require certificate.

Signed-off-by: David Chung <david.chung@docker.com>