### PR TITLE
VMWScript engine code updates

### DIFF
--- a/cmd/infrakit/x/vmwscript.go
+++ b/cmd/infrakit/x/vmwscript.go
@@ -16,8 +16,6 @@ var cmdResults = map[string]string{}
 var debugV = logutil.V(200) // 100-500 are for typical debug levels, > 500 for highly repetitive logs (e.g. from polling)
 
 func vmwscriptCommand() *cobra.Command {
-	vmwscript.InitDeployment()
-	vm := vmwscript.VMwareConfig() //Pull VMware configuration from JSON
 
 	var vc, dc, ds, nn, vh, gu, gp *string
 
@@ -33,76 +31,38 @@ func vmwscriptCommand() *cobra.Command {
 			log.Crit("Please specify the path to a configuration file")
 			os.Exit(-1)
 		}
-		err := vmwscript.OpenFile(args[0])
+		plan, err := vmwscript.OpenFile(args[0])
 		if err != nil {
 			log.Crit("Error opening file", "Error", err)
 			os.Exit(-1)
 		}
 
-		// if configuration isn't set in JSON, check Environment vars/flags
-		if (vm.VCenterURL == nil) || *vm.VCenterURL == "" {
-			if vm.VCenterURL = vc; *vm.VCenterURL == "" {
-				log.Crit("VMware vCenter/vSphere credentials are missing")
-				os.Exit(-1)
-			}
-		}
+		// set the values from flags
+		plan.VMWConfig.VCenterURL = vc
+		plan.VMWConfig.DCName = dc
+		plan.VMWConfig.DSName = ds
+		plan.VMWConfig.NetworkName = nn
+		plan.VMWConfig.VSphereHost = vh
+		plan.VMWConfig.VMTemplateAuth.Username = gu
+		plan.VMWConfig.VMTemplateAuth.Password = gp
 
-		if (vm.DCName == nil) || *vm.DCName == "" {
-			if vm.DCName = dc; *vm.DCName == "" {
-				log.Error("No Datacenter was specified, will try to use the default (will cause errors with Linked-Mode)")
-			}
-		}
-
-		if (vm.DSName == nil) || *vm.DSName == "" {
-			if vm.DSName = ds; *vm.DSName == "" {
-				log.Crit("A VMware vCenter datastore is required for provisioning")
-				os.Exit(-1)
-			}
-		}
-
-		if (vm.NetworkName == nil) || *vm.NetworkName == "" {
-			if vm.NetworkName = nn; *vm.NetworkName == "" {
-				log.Crit("Specify a Network to connect to")
-				os.Exit(-1)
-			}
-		}
-
-		if (vm.VSphereHost == nil) || *vm.VSphereHost == "" {
-			if vm.VSphereHost = vh; *vm.VSphereHost == "" {
-				log.Crit("A Host inside of vCenter/vSphere is required to provision on for VM capacity")
-				os.Exit(-1)
-			}
-		}
-
-		// Ideally these should be populated as they're needed for a lot of the tasks.
-		if (vm.VMTemplateAuth.Username == nil) || *vm.VMTemplateAuth.Username == "" {
-			if vm.VMTemplateAuth.Username = gu; *vm.VMTemplateAuth.Username == "" {
-				log.Error("No Username for inside of the Guest OS was specified, somethings may fail")
-			}
-		}
-
-		if (vm.VMTemplateAuth.Password == nil) || *vm.VMTemplateAuth.Password == "" {
-			if vm.VMTemplateAuth.Password = gp; *vm.VMTemplateAuth.Username == "" {
-				log.Error("No Password for inside of the Guest OS was specified, somethings may fail")
-			}
-		}
-
-		if *vm.VCenterURL == "" || *vm.DSName == "" || *vm.VSphereHost == "" || len(args) != 1 {
-			cmd.Usage()
-			os.Exit(1)
+		err = plan.Validate()
+		if err != nil {
+			log.Crit("Error validating input", "Error", err)
+			os.Exit(-1)
 		}
 
 		ctx, cancel := context.WithCancel(context.Background())
 		defer cancel()
 
-		client, err := vmwscript.VCenterLogin(ctx, *vm)
+		client, err := vmwscript.VCenterLogin(ctx, plan.VMWConfig)
 		if err != nil {
 			log.Crit("Error connecting to vCenter", "err", err)
 			os.Exit(-1)
 		}
 		// Iterate through the deployments and tasks
 		log.Info("Starting VMwScript engine")
-		vmwscript.RunTasks(ctx, client)
+		plan.RunTasks(ctx, client)
 		log.Info("VMwScript has completed succesfully")
 		return nil
 	}

--- a/pkg/x/vmwscript/cmd_parser.go
+++ b/pkg/x/vmwscript/cmd_parser.go
@@ -1,9 +1,7 @@
 package vmwscript
 
 import (
-	"encoding/json"
 	"fmt"
-	"os"
 
 	logutil "github.com/docker/infrakit/pkg/log"
 )
@@ -83,27 +81,27 @@ type DeploymentCommand struct {
 	CMDDelete   bool   `json:"delAfterDownload"` //remove the file once downloaded
 }
 
-//OpenFile opens a file, check file can be read and also checks the format and returns a parsed plan
-func OpenFile(filePath string) (*DeploymentPlan, error) {
+// //OpenFile opens a file, check file can be read and also checks the format and returns a parsed plan
+// func OpenFile(filePath string) (*DeploymentPlan, error) {
 
-	// Attempt to open file
-	deploymentFile, err := os.Open(filePath)
-	defer deploymentFile.Close()
-	if err != nil {
-		return nil, err
-	}
-	// Attempt to parse JSON
-	jsonParser := json.NewDecoder(deploymentFile)
+// 	// Attempt to open file
+// 	deploymentFile, err := os.Open(filePath)
+// 	defer deploymentFile.Close()
+// 	if err != nil {
+// 		return nil, err
+// 	}
+// 	// Attempt to parse JSON
+// 	jsonParser := json.NewDecoder(deploymentFile)
 
-	plan := DeploymentPlan{}
-	err = jsonParser.Decode(&plan)
-	if err != nil {
-		return nil, fmt.Errorf("Error Parsing JSON: %v", err)
-	}
+// 	plan := DeploymentPlan{}
+// 	err = jsonParser.Decode(&plan)
+// 	if err != nil {
+// 		return nil, fmt.Errorf("Error Parsing JSON: %v", err)
+// 	}
 
-	log.Info(fmt.Sprintf("Finished parsing [%s], [%d] tasks will be deployed", plan.Label, len(plan.Deployment)))
-	return &plan, nil
-}
+// 	log.Info(fmt.Sprintf("Finished parsing [%s], [%d] tasks will be deployed", plan.Label, len(plan.Deployment)))
+// 	return &plan, nil
+// }
 
 // The following functions all provide the functionality to traverse through the list of commands
 // and provide a stable way of passing the commands to the VMware tools


### PR DESCRIPTION
This PR suggests a number of changes to the VMWScript engine in preparation of deeper integration with infrakit as a playbook backend:

  + Avoid the use of package-scoped, static variables (`plan`, `commandCounter`, etc.) which will not be thread-safe if multiple VMWScript engines are running in the same process.
  + Moved these states into the `DeploymentPlan` struct so that these are instance variables which track the state of the running engine instance.

Next step after this is to embed this engine as a Playbook backend (see pkg/cli/backend) so that users can create custom VMWScripts with added functionality of  templating and including other scripts and command line flags integration with the CLI.

Signed-off-by: David Chung <david.chung@docker.com>