### PR TITLE
New playbook backend: VMWScript engine + example playbook

### DIFF
--- a/cmd/infrakit/main.go
+++ b/cmd/infrakit/main.go
@@ -36,6 +36,7 @@ import (
 	_ "github.com/docker/infrakit/pkg/cli/backend/manager"
 	_ "github.com/docker/infrakit/pkg/cli/backend/print"
 	_ "github.com/docker/infrakit/pkg/cli/backend/sh"
+	_ "github.com/docker/infrakit/pkg/cli/backend/vmwscript"
 
 	// Supported "kinds"
 	_ "github.com/docker/infrakit/pkg/run/v0/aws"
@@ -157,7 +158,13 @@ func main() {
 	}
 
 	if !pb.Empty() {
-		cmd.AddCommand(useCommand(scope, pb))
+		useCommandName := "use"
+		useCommandDescription := "Use a playbook"
+		cmd.AddCommand(useCommand(scope, useCommandName, useCommandDescription, pb))
+		if len(os.Args) > 2 && os.Args[1] == useCommandName {
+			cmd.SetArgs(os.Args[1:2])
+		}
+
 	}
 
 	base.VisitModules(scope, func(c *cobra.Command) {
@@ -196,14 +203,11 @@ func main() {
 	}
 }
 
-func useCommand(scope scope.Scope, pb *playbook.Playbooks) *cobra.Command {
+func useCommand(scope scope.Scope, use, description string, pb *playbook.Playbooks) *cobra.Command {
 
 	// Log setup
 	logOptions := &logutil.ProdDefaults
 	logFlags := cli.Flags(logOptions)
-
-	use := "use"
-	description := "Use a playbook"
 
 	cmd := &cobra.Command{
 		Use:   use,

--- a/examples/playbooks/vmwscript/Docker-EE.json
+++ b/examples/playbooks/vmwscript/Docker-EE.json
@@ -1,0 +1,174 @@
+{{/*
+
+This is actually a template that renders to JSON.
+Here we demonstrate the use of local variables in the template (e.g. $url)
+and just fetch the information from the user either as command line flags or
+user input via prompts.
+
+*/}}
+
+{{/* =% vmwscript %= */}}{{/* directive to use the vmwscript engine */}}
+
+{{ $url := flag "vcenter-url" "string" "VCenter URL" | prompt "VCenter URL?" "string" "https://username@vsphere.local:password@vc.unifydc.io/sdk" }}
+{{ $dc := flag "data-center" "string" "Data Center name" | prompt "Data Center Name?" "string" "Datacenter" }}
+{{ $ds := flag "data-store" "string" "Data Store name" | prompt "Data Store Name?" "string" "datastore1" }}
+{{ $nn := flag "network-name" "string" "Network name" | prompt "Network Name?" "string" "Internal Network (NAT)" }}
+{{ $host := flag "vsphere-host" "string" "VSphere host" | prompt "Host Name?" "string" "exsi01.unifydc.io" }}
+
+{{ $user := flag "user" "string" "Username" | prompt "User Name?" "string" }}
+{{ $pass := flag "pass" "string" "Password" | prompt "Password?" "string" }}
+
+{
+    "label":"Docker-CE-on-CentOS",
+    "version":"0.1",
+    "vmconfig" : {
+	"vcenterURL" : "{{ $url }}",
+        "datacentre" : "{{ $dc }}",
+        "datastore":"{{ $ds }}",
+        "network" : "{{ $nn }}",
+        "host" : "{{ $host }}",
+        "guestCredentials" : {
+            "guestUser" : "{{ $user }}",
+            "guestPass" :"{{ $pass }}"
+        }
+    },
+    "deployment": [
+        {"name": "Docker Template",
+         "note": "Build new template for CentOS",
+         "task":{
+            "inputTemplate": "Centos7-Template",
+            "outputName": "DockerEETemplate",
+            "outputType": "Template",
+            "import":"",
+            "commands": [
+                {
+                    "type":"execute",
+                    "note":"Remove TTY requirement for sudo (old RHEL issue)",
+                    "cmd":"sed -i -e 's/Defaults    requiretty.*/ #Defaults    requiretty/g' /etc/sudoers"
+                },
+                {
+                    "type":"execute",                    
+                    "note":"Disable SELINUX (FirewallD bug)",
+                    "cmd":"/usr/sbin/setenforce 0",
+                    "sudoUser":"root"
+                },
+                {
+                    "type":"execute",                    
+                    "note":"Upgrade all packages (except VMware Tools)",            
+                    "cmd":"/bin/yum upgrade --exclude=open-vm-tools -y > /tmp/ce-yum-upgrade.log",
+                    "sudoUser":"root"
+                },
+                {
+                    "type":"execute",                    
+                    "note":"Remove any pre-existing Docker Installation",            
+                    "cmd":"/bin/yum remove docker docker-common docker-selinux docker-engine",
+                    "sudoUser":"root"
+                },
+                {
+                    "type":"execute",                    
+                    "note":"Install Docker-CE Supporting tools",            
+                    "cmd":"/bin/yum install -y yum-utils device-mapper-persistent-data lvm2 -y > /tmp/ce-docker-deps.log",
+                    "sudoUser":"root"
+                },
+                {
+                    "type":"execute",                    
+                    "note":"Add Docker CE Repository",            
+                    "cmd":"/usr/bin/yum-config-manager --add-repo https://download.docker.com/linux/centos/docker-ce.repo",
+                    "sudoUser":"root"
+                },
+                {            
+                    "type":"execute",                    
+                    "note":"Update Yum Cache",            
+                    "cmd":"/bin/yum -y makecache fast",
+                    "args":""
+                },
+                {
+                    "type":"execute",                    
+                    "note":"Installation of Docker-CE",            
+                    "cmd":"/bin/yum -y install docker-ce > /tmp/ce-docker-install.log",
+                    "sudoUser":"root"
+                },
+                {
+                    "type":"execute",                    
+                    "note":"Enable Docker on Boot",            
+                    "cmd":"/usr/bin/systemctl enable docker",
+                    "sudoUser":"root"
+                },
+                {
+                    "type":"execute",                    
+                    "note":"Start Docker to pre-configure system",            
+                    "cmd":"/usr/bin/systemctl start docker",
+                    "sudoUser":"root"
+                },                
+                {
+                    "type":"execute",                    
+                    "note":"Set Storage Driver to devicemapper",            
+                    "cmd":"/usr/bin/echo -en '{\n  \"storage-driver\": \"devicemapper\"\n}' > /etc/docker/daemon.json",
+                    "sudoUser":"root"
+                },
+                {
+                    "type":"execute",                    
+                    "note":"Set Swarm firewall rules",            
+                    "cmd":"/usr/bin/firewall-cmd --add-port=2376-2377/tcp --permanent",
+                    "sudoUser":"root"
+                },
+                {
+                    "type":"execute",                    
+                    "note":"Set Gossip TCP firewall rules",            
+                    "cmd":"/usr/bin/firewall-cmd --add-port=7946/tcp --permanent",
+                    "sudoUser":"root"
+                },
+                {
+                    "type":"execute",                    
+                    "note":"Set Gossip UDP firewall rules",            
+                    "cmd":"/usr/bin/firewall-cmd --add-port=7946/udp --permanent",
+                    "sudoUser":"root"
+                },
+                {
+                    "type":"execute",                    
+                    "note":"Set TLS Proxy firewall rules",            
+                    "cmd":"/usr/bin/firewall-cmd --add-port=12376/tcp --permanent",
+                    "sudoUser":"root"
+                },
+
+                {
+                    "type":"execute",                    
+                    "note":"Set Overlay firewall rules",            
+                    "cmd":"/usr/bin/firewall-cmd --add-port=4789/udp --permanent",
+                    "sudoUser":"root"
+                },
+                {
+                    "type":"execute",                    
+                    "note":"Reload firewall rules",            
+                    "cmd":"/usr/bin/firewall-cmd --reload",
+                    "sudoUser":"root"
+                },
+                {
+                    "type":"execute",                    
+                    "note":"Restart Docker to pick up new storage/network Configuration",            
+                    "cmd":"/usr/bin/systemctl restart docker",
+                    "sudoUser":"root"
+                },
+                {
+                    "type":"execute",                    
+                    "note":"Download UCP 2.2.4",            
+                    "cmd":"/usr/bin/docker pull docker/ucp:2.2.4 >> /tmp/docker-pull.log",
+                    "sudoUser":"root"
+                },
+                {
+                    "type":"execute",                    
+                    "note":"Download DTR 2.2.7",            
+                    "cmd":"/usr/bin/docker pull docker/dtr:2.2.7 >> /tmp/docker-pull.log",
+                    "sudoUser":"root"
+                },
+                {
+                    "type":"execute",                    
+                    "note":"Re-Enable SELINUX",
+                    "cmd":"/usr/sbin/setenforce 1",
+                    "sudoUser":"root"
+                }
+                ]
+            }            
+        }
+    ]
+}

--- a/examples/playbooks/vmwscript/README.md
+++ b/examples/playbooks/vmwscript/README.md
@@ -1,0 +1,34 @@
+VMWScript Playbook Example
+==========================
+
+This is a simple playbook example to build Docker EE template and launch
+Docker EE swarm cluster using the VMWScript engine in infrakit.
+
+### How to add this playbook:
+
+```
+infrakit playbook add myplaybook https://raw.githubusercontent.com/docker/infrakit/master/examples/playbooks/vmwscript/index.yml
+```
+
+### Using the playbook
+
+Now that the playbook has been added as `myplaybook` you can access it:
+
+```
+infrakit use myplaybook -h
+```
+
+The `launch-swarm` playbook depends on a VCenter template built by `build-dockerEE`.  So run `build-dockerEE` first in a
+new environment.
+
+All playbook commands support the flags `--print-only` and `--test`.  When `--print-only` is used, the playbook will
+print the input to the backend without actually executing anything.  The `--test` flag is interpreted by the backends
+to mean a dry run.  This may involve validation of data without actually running anything.
+
+For more details on what you can include in the playbook templates, see the [Sprig](http://masterminds.github.io/sprig/)
+documentation for template functions, as well as, the Golang [template doc](https://golang.org/pkg/text/template/).
+There are also additional template functions such as include, source, and accessing infrakit services
+([doc](https://github.com/docker/infrakit/blob/master/pkg/template/funcs.go#L399)).
+
+
+--

--- a/examples/playbooks/vmwscript/index.yml
+++ b/examples/playbooks/vmwscript/index.yml
@@ -1,0 +1,9 @@
+# An index file.
+# This file is in YAML format.  All it does is to map command line verbs to
+# more templates which are executed as commands.
+
+# Build Docker EE template
+build-dockerEE : Docker-EE.json
+
+# Launch swarm
+launch-swarm : swarm.pb

--- a/examples/playbooks/vmwscript/swarm.json
+++ b/examples/playbooks/vmwscript/swarm.json
@@ -1,0 +1,131 @@
+{
+    "label":"Docker-EE-on-CentOS",
+    "version":"0.1",
+    "vmconfig" : {
+	"vcenterURL" : "{{var `input/url`}}",
+        "datacentre" : "{{var `input/dc`}}",
+        "datastore":"{{var `input/ds`}}",
+        "network" : "{{var `input/nn`}}",
+        "host" : "{{var `input/host`}}",
+        "guestCredentials" : {
+            "guestUser" : "{{var `input/user`}}",
+            "guestPass" : "{{var `input/password`}}"
+        }
+    },
+    "deployment": [
+        {"name": "UCP Manager",
+            "note": "Build UCP Virtual machine",
+            "task":{
+               "inputTemplate": "DockerEETemplate",
+               "outputName": "{{ var `input/stack` }}-manager001",
+               "outputType": "VM",
+               "import":"",
+               "networkConfig":{
+                    "distro":"centos",
+                    "device":"ens192",
+                    "address":"10.0.0.101/24",
+                    "gateway":"10.0.0.1",
+                    "dns":"8.8.8.8",
+                    "hostname":"manager01.local",
+                    "sudoUser":"root"
+                },
+               "commands": [
+                {
+                    "type":"execute",                    
+                    "note":"Disable SELINUX (FirewallD bug)",
+                    "cmd":"/usr/sbin/setenforce 0",
+                    "sudoUser":"root"
+                },
+                   {
+                    "type":"execute",                    
+                    "note":"Set UCP firewall rules",            
+                    "cmd":"/usr/bin/firewall-cmd --add-port=12379-12387/tcp --permanent",
+                    "sudoUser":"root"
+                   },
+                   {
+                    "type":"execute",                    
+                    "note":"Set UCP HTTPs firewall rules",            
+                    "cmd":"/usr/bin/firewall-cmd --add-port=443/tcp --permanent",
+                    "sudoUser":"root"
+                   },
+                   {
+                    "type":"execute",                    
+                    "note":"Reload firewall rules",            
+                    "cmd":"/usr/bin/firewall-cmd --reload",
+                    "sudoUser":"root"
+                   },
+                   {
+                    "type":"execute",                    
+                    "note":"Installation of Docker Universal Control plane 2.2.4",            
+                    "cmd":"/usr/bin/docker container run --rm -t --name ucp -v /var/run/docker.sock:/var/run/docker.sock  docker/ucp:2.2.4 install --admin-password xK8dVA_Pnh --admin-username infrakit",
+                    "sudoUser":"root"
+                   },
+                   {
+                    "type":"execute",                    
+                    "note":"Backing up swarm key for other nodes",            
+                    "cmd":"/usr/bin/docker swarm join-token worker | grep SWMTKN > /tmp/swm.tkn",
+                    "sudoUser":"root"
+                   },
+                   {
+                    "type":"download",
+                    "filePath":"/tmp/swm.tkn",
+                    "resultKey":"jointoken",
+                    "delAfterDownload": false
+                   }
+                ]
+            }
+        },
+        {"name": "Swarm Worker",
+            "note": "Add worker",
+            "task":{
+               "inputTemplate": "DockerEETemplate",
+               "outputName": "{{ var `input/stack` }}-worker001",
+               "outputType": "VM",
+               "import":"",
+               "networkConfig":{
+                  "distro":"centos",
+                  "device":"ens192",
+                  "address":"10.0.0.102/24",
+                  "gateway":"10.0.0.1",
+                  "dns":"8.8.8.8",
+                  "hostname":"worker01.local",
+                  "sudoUser":"root"
+                },
+               "commands": [
+                   {
+                       "type":"execute",                    
+                       "note":"Join Swarm",
+                       "execKey":"jointoken",
+                       "sudoUser":"root"
+                   }
+                ]
+            }
+        },
+        {"name": "Swarm Worker",
+            "note": "Add worker",
+            "task":{
+               "inputTemplate": "DockerEETemplate",
+               "outputName": "{{ var `input/stack` }}-worker002",
+               "outputType": "VM",
+               "import":"",
+               "networkConfig":{
+                 "distro":"centos",
+                 "device":"ens192",
+                 "address":"10.0.0.103/24",
+                 "gateway":"10.0.0.1",
+                 "dns":"8.8.8.8",
+                 "hostname":"worker02.local",
+                 "sudoUser":"root"
+              },
+               "commands": [
+                   {
+                       "type":"execute",                    
+                       "note":"Join Swarm",
+                       "execKey":"jointoken",
+                       "sudoUser":"root"
+                   }
+                ]
+            }
+        }
+    ]
+}

--- a/examples/playbooks/vmwscript/swarm.json
+++ b/examples/playbooks/vmwscript/swarm.json
@@ -57,7 +57,7 @@
                    {
                     "type":"execute",                    
                     "note":"Installation of Docker Universal Control plane 2.2.4",            
-                    "cmd":"/usr/bin/docker container run --rm -t --name ucp -v /var/run/docker.sock:/var/run/docker.sock  docker/ucp:2.2.4 install --admin-password xK8dVA_Pnh --admin-username infrakit",
+                    "cmd":"/usr/bin/docker container run --rm -t --name ucp -v /var/run/docker.sock:/var/run/docker.sock  docker/ucp:2.2.4 install --admin-password {{ var `input/admin_pass`}} --admin-username {{ var `input/admin_user`}}",
                     "sudoUser":"root"
                    },
                    {

--- a/examples/playbooks/vmwscript/swarm.pb
+++ b/examples/playbooks/vmwscript/swarm.pb
@@ -9,6 +9,9 @@
 
 {{ flag "user" "string" "Username" | prompt "User Name?" "string" | var "input/user"}}
 {{ flag "pass" "string" "Password" | prompt "Password?" "string" | var "input/password"}}
+{{ flag "stack" "string" "Stack name" | prompt "Stack?" "string" | var "input/stack"}}
+{{ flag "admin-user" "string" "Admin user" | prompt "Admin User?" "string" "admin" | var "input/admin_user"}}
+{{ flag "admin-pass" "string" "Admin password" | prompt "Admin Password?" "string" "adminpass" | var "input/admin_pass" }}
 
 {{/* The flags are piped to set variables (var); now are available in the scope of this playbook template */}}
 {{ include `./swarm.json` }}

--- a/examples/playbooks/vmwscript/swarm.pb
+++ b/examples/playbooks/vmwscript/swarm.pb
@@ -1,0 +1,14 @@
+{{/* Runs the vmwscript playbook to provision a Swarm on VMSphere */}}
+{{/* =% vmwscript %= */}}
+
+{{ flag "vcenter-url" "string" "VCenter URL" | prompt "VCenter URL?" "string" "https://username@vsphere.local:password@vc.unifydc.io/sdk" | var "input/url"}}
+{{ flag "data-center" "string" "Data Center name" | prompt "Data Center Name?" "string" "Datacenter" | var "input/dc"}}
+{{ flag "data-store" "string" "Data Store name" | prompt "Data Store Name?" "string" "datastore1" | var "input/ds"}}
+{{ flag "network-name" "string" "Network name" | prompt "Network Name?" "string" "Internal Network (NAT)" | var "input/nn"}}
+{{ flag "vsphere-host" "string" "VSphere host" | prompt "Host Name?" "string" "exsi01.unifydc.io" | var "input/host"}}
+
+{{ flag "user" "string" "Username" | prompt "User Name?" "string" | var "input/user"}}
+{{ flag "pass" "string" "Password" | prompt "Password?" "string" | var "input/password"}}
+
+{{/* The flags are piped to set variables (var); now are available in the scope of this playbook template */}}
+{{ include `./swarm.json` }}

--- a/pkg/cli/backend/http/http.go
+++ b/pkg/cli/backend/http/http.go
@@ -18,7 +18,7 @@ func init() {
 
 // HTTP takes a method parameter (string) and a URL (string) and then
 // performs the http operation with the rendered data
-func HTTP(scope scope.Scope, opt ...interface{}) (backend.ExecFunc, error) {
+func HTTP(scope scope.Scope, test bool, opt ...interface{}) (backend.ExecFunc, error) {
 
 	if len(opt) < 2 {
 		return nil, fmt.Errorf("requires at least two parameters: first method (string), second url (string)")

--- a/pkg/cli/backend/instance/provision.go
+++ b/pkg/cli/backend/instance/provision.go
@@ -16,7 +16,7 @@ func init() {
 // Provision backend requires the name of the plugin and a boolean to indicate if the content is yaml.
 // It then returns an executable function based on that specification to call the named instance plugin's provision
 // method.
-func Provision(scope scope.Scope, opt ...interface{}) (backend.ExecFunc, error) {
+func Provision(scope scope.Scope, test bool, opt ...interface{}) (backend.ExecFunc, error) {
 
 	if len(opt) != 2 {
 		return nil, fmt.Errorf("require params: pluginName (string) and isYAML (bool)")

--- a/pkg/cli/backend/manager/commit.go
+++ b/pkg/cli/backend/manager/commit.go
@@ -20,7 +20,7 @@ func init() {
 // Commit requires two parameters, first is isYAML (bool) and second is pretend (bool)
 // It then returns an executable function based on that specification to call the manager's commit
 // method with the content
-func Commit(scope scope.Scope, opt ...interface{}) (backend.ExecFunc, error) {
+func Commit(scope scope.Scope, test bool, opt ...interface{}) (backend.ExecFunc, error) {
 
 	if len(opt) != 2 {
 		return nil, fmt.Errorf("require params: isYAML (bool), pretend (bool)")

--- a/pkg/cli/backend/print/print.go
+++ b/pkg/cli/backend/print/print.go
@@ -14,7 +14,7 @@ func init() {
 
 // Print takes a list of optional parameters and returns an executable function that prints
 // arg0 is the prefix. it's optional
-func Print(scope scope.Scope, opt ...interface{}) (backend.ExecFunc, error) {
+func Print(scope scope.Scope, test bool, opt ...interface{}) (backend.ExecFunc, error) {
 
 	prefix := ""
 	if len(opt) > 0 {

--- a/pkg/cli/backend/sh/sh.go
+++ b/pkg/cli/backend/sh/sh.go
@@ -20,7 +20,7 @@ func init() {
 
 // Sh takes a list of optional parameters and returns an executable function that
 // executes the content as a shell script
-func Sh(scope scope.Scope, opt ...interface{}) (backend.ExecFunc, error) {
+func Sh(scope scope.Scope, test bool, opt ...interface{}) (backend.ExecFunc, error) {
 
 	args := []string{}
 	for _, v := range opt {

--- a/pkg/cli/backend/types.go
+++ b/pkg/cli/backend/types.go
@@ -10,7 +10,7 @@ import (
 type ExecFunc func(script string) error
 
 // TemplateFunc is the type of function exported / available to the scripting template
-type TemplateFunc func(scope scope.Scope, opt ...interface{}) (ExecFunc, error)
+type TemplateFunc func(scope scope.Scope, trial bool, opt ...interface{}) (ExecFunc, error)
 
 var (
 	backends = map[string]TemplateFunc{}

--- a/pkg/cli/backend/vmwscript/script.go
+++ b/pkg/cli/backend/vmwscript/script.go
@@ -1,0 +1,59 @@
+package vmwscript
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/docker/infrakit/pkg/cli/backend"
+	logutil "github.com/docker/infrakit/pkg/log"
+	"github.com/docker/infrakit/pkg/run/scope"
+	"github.com/docker/infrakit/pkg/types"
+	"github.com/docker/infrakit/pkg/x/vmwscript"
+)
+
+var log = logutil.New("module", "playbook/vmwscript")
+
+func init() {
+	backend.Register("vmwscript", Script)
+}
+
+// Script takes a list of optional parameters and returns an executable function that
+// executes the payload using the VMWScript engine for automating VMWare
+func Script(scope scope.Scope, test bool, opt ...interface{}) (backend.ExecFunc, error) {
+
+	return func(script string) error {
+
+		plan := vmwscript.DeploymentPlan{}
+
+		err := types.Decode([]byte(script), &plan)
+		if err != nil {
+			return err
+		}
+
+		err = plan.Validate()
+		if err != nil {
+			return err
+		}
+
+		if test {
+			log.Info("Trial run. Printing input")
+			fmt.Print(script)
+			return nil
+		}
+
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+
+		client, err := vmwscript.VCenterLogin(ctx, plan.VMWConfig)
+		if err != nil {
+			log.Crit("Error connecting to vCenter", "err", err)
+			return err
+		}
+
+		log.Info("Starting VMwScript engine")
+		plan.RunTasks(ctx, client)
+		log.Info("VMwScript has completed succesfully")
+
+		return nil
+	}, nil
+}

--- a/pkg/cli/backends.go
+++ b/pkg/cli/backends.go
@@ -15,7 +15,7 @@ func (c *Context) loadBackends(t *template.Template) error {
 		func(funcName string, backend backend.TemplateFunc) {
 			t.AddFunc(funcName,
 				func(opt ...interface{}) error {
-					executor, err := backend(c.scope, opt...)
+					executor, err := backend(c.scope, c.test, opt...)
 					if err != nil {
 						return err
 					}

--- a/pkg/cli/context.go
+++ b/pkg/cli/context.go
@@ -22,15 +22,17 @@ const (
 
 // Context is the context for the running module
 type Context struct {
-	cmd      *cobra.Command
-	src      string
-	input    io.Reader
-	exec     bool
-	template *template.Template
-	options  template.Options
-	run      func(string) error
-	script   string
-	scope    scope.Scope
+	test      bool
+	printOnly bool
+	cmd       *cobra.Command
+	src       string
+	input     io.Reader
+	exec      bool
+	template  *template.Template
+	options   template.Options
+	run       func(string) error
+	script    string
+	scope     scope.Scope
 }
 
 // NewContext creates a context
@@ -454,14 +456,17 @@ func (c *Context) getTemplate() (*template.Template, error) {
 
 // BuildFlags from parsing the body which is a template
 func (c *Context) BuildFlags() (err error) {
-	var t *template.Template
+	c.cmd.Flags().BoolVar(&c.test, "test", false, "True to do a trial run")
+	c.cmd.Flags().BoolVar(&c.printOnly, "print-only", false, "True to print the rendered input")
 
+	var t *template.Template
 	t, err = c.getTemplate()
 	if err != nil {
 		return
 	}
 	t.SetOptions(c.options)
 	_, err = t.Render(c)
+
 	return
 }
 
@@ -489,6 +494,11 @@ func (c *Context) Execute() (err error) {
 		return err
 	}
 	c.script = script
+	if c.printOnly {
+		fmt.Print(c.script)
+		return nil
+	}
+
 	log.Debug("running", "script", script)
 
 	opt = c.options

--- a/pkg/types/any.go
+++ b/pkg/types/any.go
@@ -35,6 +35,22 @@ func AnyYAMLMust(y []byte) *Any {
 	return any
 }
 
+// Decode constructs an Any based on either YAML or JSON buffer then decodes into the second arg.
+// Since there is no content-type known with a simple buffer, it tries to parse the payload as JSON
+// first, then as YAML if that doesn't work.
+func Decode(b []byte, decoded interface{}) error {
+	err := AnyBytes(b).Decode(decoded)
+	if err == nil {
+		return nil
+	}
+	// try YAML -- yes it's because we are guessing the data format.
+	y, err := AnyYAML(b)
+	if err != nil {
+		return err
+	}
+	return y.Decode(decoded)
+}
+
 // AnyBytes returns an Any from the encoded message bytes
 func AnyBytes(data []byte) *Any {
 	any := &Any{}


### PR DESCRIPTION
This PR

  + Adds a new `vmwscript` backend for playbooks (see `pkg/cli/backend/vmwscript`)
  + Adds support for print-only and test runs so that it's easy to see the input to the backends without running it.
  + Adds a playbook based on the examples in `pkg/x/vmwscript/examples`. 
    * README.md becomes the help text of the playbook CLI
    * Two commands indexed by `index.yml`: building DockerEE template and launching a swarm. 

See `examples/playbooks/vmwscript/README.md` for documentation on how to use.

Signed-off-by: David Chung david.chung@docker.com