### PR TITLE
Handshake protocol refactor 

### DIFF
--- a/docs/plugin/flavor.md
+++ b/docs/plugin/flavor.md
@@ -1,6 +1,6 @@
 # Flavor plugin API
 
-<!-- SOURCE-CHECKSUM pkg/spi/flavor/* 1f30ac75124d7d85397bd5a820a4f1382bd38769 -->
+<!-- SOURCE-CHECKSUM pkg/spi/flavor/* f8592646751fecf235b8fa19ef8ab5b0d958c24f -->
 
 ## API
 

--- a/docs/plugin/group.md
+++ b/docs/plugin/group.md
@@ -1,6 +1,6 @@
 # Group plugin API
 
-<!-- SOURCE-CHECKSUM pkg/spi/group/* 81798dff05b86a30ccc12885bad298c774d730fd0149e9fac35a776ab000a983d08501858773f6c8 -->
+<!-- SOURCE-CHECKSUM pkg/spi/group/* 0149e9fac35a776ab000a983d08501858773f6c8 -->
 
 ## API
 

--- a/docs/plugin/group.md
+++ b/docs/plugin/group.md
@@ -1,6 +1,6 @@
 # Group plugin API
 
-<!-- SOURCE-CHECKSUM pkg/spi/group/* d95c0675e71c3a843edce1ff00f8de8597773c46 -->
+<!-- SOURCE-CHECKSUM pkg/spi/group/* 81798dff05b86a30ccc12885bad298c774d730fd0149e9fac35a776ab000a983d08501858773f6c8 -->
 
 ## API
 

--- a/docs/plugin/instance.md
+++ b/docs/plugin/instance.md
@@ -1,6 +1,6 @@
 # Instance plugin API
 
-<!-- SOURCE-CHECKSUM pkg/spi/instance/* 6b3c98bed4470312a41376f651cee99a9e35ffb09117db2da2ea1073a6f94b241e6c6a9a0a9048d452c44631323150dfeffdfde2b8c5ba85e274fabe -->
+<!-- SOURCE-CHECKSUM pkg/spi/instance/* 6b3c98bed4470312a41376f651cee99a9e35ffb04985443915889a519c689181d3818d20aa0ae48852c44631323150dfeffdfde2b8c5ba85e274fabe -->
 
 
 ## API

--- a/pkg/cli/registry.go
+++ b/pkg/cli/registry.go
@@ -48,31 +48,20 @@ func getPluginObjects(hs rpc.Handshaker, major string) map[string][]spi.Interfac
 	objects := map[string][]spi.InterfaceSpec{}
 
 	// The spi this object implements (e.g. Instance/0.5.0)
-	spis, err := hs.Implements()
-	if err != nil {
-		log.Debug("error getting interface", "name", major, "err", err)
-		return objects
-	}
-
 	// For each spi, eg. Instance/0.5.0 a list of object names
-	typesBySpi, err := hs.Types()
+	typesBySpi, err := hs.Hello()
 	if err != nil {
 		log.Debug("error getting typed objects in this plugin", "name", major, "err", err)
 
-		// Here we assume there are no lower level objects
-		objects[major] = spis
 		return objects
 	}
 
-	for encodedSpi, names := range typesBySpi {
-
-		// the key is a string form of InterfaceSpec because yaml/ json don't handle
-		// objects as keys very well.
-
-		theSpi := spi.DecodeInterfaceSpec(string(encodedSpi))
+	for theSpi, objs := range typesBySpi {
 
 		objectName := major
-		for _, minor := range names {
+		for _, object := range objs {
+
+			minor := object.Name
 
 			if minor != "." {
 				objectName = path.Join(major, minor)

--- a/pkg/controller/api.go
+++ b/pkg/controller/api.go
@@ -26,7 +26,7 @@ var (
 	// InterfaceSpec is the current name and version of the Instance API.
 	InterfaceSpec = spi.InterfaceSpec{
 		Name:    "Controller",
-		Version: "0.1.0",
+		Version: "0.1.1",
 	}
 )
 

--- a/pkg/rpc/client/client.go
+++ b/pkg/rpc/client/client.go
@@ -133,24 +133,18 @@ func parseAddress(address string) (*url.URL, *http.Client, error) {
 	return nil, nil, fmt.Errorf("invalid address %v", address)
 }
 
-// Implements is the method from the Handshaker interface
-func (c client) Implements() ([]spi.InterfaceSpec, error) {
-	req := rpc.ImplementsRequest{}
-	resp := rpc.ImplementsResponse{}
-	if err := c.Call("Handshake.Implements", req, &resp); err != nil {
+// Hello implements the Handshaker interface
+func (c client) Hello() (map[spi.InterfaceSpec][]rpc.Object, error) {
+	req := rpc.HelloRequest{}
+	resp := rpc.HelloResponse{}
+	if err := c.Call("Handshake.Hello", req, &resp); err != nil {
 		return nil, err
 	}
-	return resp.APIs, nil
-}
-
-// Types returns a list of types exposed by this object
-func (c client) Types() (map[rpc.InterfaceSpec][]string, error) {
-	req := rpc.TypesRequest{}
-	resp := rpc.TypesResponse{}
-	if err := c.Call("Handshake.Types", req, &resp); err != nil {
-		return nil, err
+	objects := map[spi.InterfaceSpec][]rpc.Object{}
+	for k, o := range resp.Objects {
+		objects[spi.DecodeInterfaceSpec(k)] = o
 	}
-	return resp.Types, nil
+	return objects, nil
 }
 
 func (c client) Addr() string {

--- a/pkg/rpc/client/handshake.go
+++ b/pkg/rpc/client/handshake.go
@@ -44,13 +44,13 @@ func (c *handshakingClient) handshake() error {
 
 	if c.handshakeResult == nil {
 
-		apis, err := c.client.Implements()
+		objects, err := c.client.Hello()
 		if err != nil {
 			return err
 		}
 
 		err = fmt.Errorf("Plugin does not support interface %v", c.iface.Encode())
-		for _, iface := range apis {
+		for iface := range objects {
 			if iface.Name == c.iface.Name {
 				if iface.Version == c.iface.Version {
 					err = nil

--- a/pkg/rpc/controller/service.go
+++ b/pkg/rpc/controller/service.go
@@ -6,6 +6,7 @@ import (
 	"github.com/docker/infrakit/pkg/controller"
 	logutil "github.com/docker/infrakit/pkg/log"
 	"github.com/docker/infrakit/pkg/plugin"
+	"github.com/docker/infrakit/pkg/rpc"
 	"github.com/docker/infrakit/pkg/rpc/internal"
 	"github.com/docker/infrakit/pkg/spi"
 	"github.com/docker/infrakit/pkg/types"
@@ -69,8 +70,8 @@ func (c *Controller) ImplementedInterface() spi.InterfaceSpec {
 }
 
 // Types returns the types exposed by this kind of RPC service
-func (c *Controller) Types() []string {
-	return c.keyed.Types()
+func (c *Controller) Objects() []rpc.Object {
+	return c.keyed.Objects()
 }
 
 // Plan is the rpc method for Plan

--- a/pkg/rpc/controller/service.go
+++ b/pkg/rpc/controller/service.go
@@ -69,7 +69,7 @@ func (c *Controller) ImplementedInterface() spi.InterfaceSpec {
 	return controller.InterfaceSpec
 }
 
-// Types returns the types exposed by this kind of RPC service
+// Objects returns the objects exposed by this kind of RPC service
 func (c *Controller) Objects() []rpc.Object {
 	return c.keyed.Objects()
 }

--- a/pkg/rpc/event/service.go
+++ b/pkg/rpc/event/service.go
@@ -5,6 +5,7 @@ import (
 	"sort"
 
 	broker "github.com/docker/infrakit/pkg/broker/server"
+	"github.com/docker/infrakit/pkg/rpc"
 	"github.com/docker/infrakit/pkg/spi"
 	"github.com/docker/infrakit/pkg/spi/event"
 	"github.com/docker/infrakit/pkg/types"
@@ -57,8 +58,8 @@ func (p *Event) ImplementedInterface() spi.InterfaceSpec {
 	return event.InterfaceSpec
 }
 
-// Types returns the types exposed by this service (or kind/ category)
-func (p *Event) Types() []string {
+// Objects returns the objects exposed by this service (or kind/ category)
+func (p *Event) Objects() []rpc.Object {
 	types := []string{}
 	for k := range p.typedPlugins {
 		types = append(types, k)
@@ -67,7 +68,11 @@ func (p *Event) Types() []string {
 		types = append(types, ".")
 	}
 	sort.Strings(types)
-	return types
+	objects := []rpc.Object{}
+	for _, t := range types {
+		objects = append(objects, rpc.Object{Name: t})
+	}
+	return objects
 }
 
 func (p *Event) getPlugin(eventType string) event.Plugin {

--- a/pkg/rpc/flavor/service.go
+++ b/pkg/rpc/flavor/service.go
@@ -5,6 +5,7 @@ import (
 	"net/http"
 	"sort"
 
+	"github.com/docker/infrakit/pkg/rpc"
 	"github.com/docker/infrakit/pkg/spi"
 	"github.com/docker/infrakit/pkg/spi/flavor"
 	"github.com/docker/infrakit/pkg/template"
@@ -112,8 +113,8 @@ func (p *Flavor) ImplementedInterface() spi.InterfaceSpec {
 	return flavor.InterfaceSpec
 }
 
-// Types returns the types exposed by this service (or kind/ category)
-func (p *Flavor) Types() []string {
+// Objects returns the objects exposed by this service (or kind/ category)
+func (p *Flavor) Objects() []rpc.Object {
 	types := []string{}
 	for k := range p.typedPlugins {
 		types = append(types, k)
@@ -122,7 +123,12 @@ func (p *Flavor) Types() []string {
 		types = append(types, ".")
 	}
 	sort.Strings(types)
-	return types
+
+	objects := []rpc.Object{}
+	for _, t := range types {
+		objects = append(objects, rpc.Object{Name: t})
+	}
+	return objects
 }
 
 func (p *Flavor) getPlugin(flavorType string) flavor.Plugin {

--- a/pkg/rpc/group/publisher.go
+++ b/pkg/rpc/group/publisher.go
@@ -10,11 +10,11 @@ import (
 func (p *Group) List(topic types.Path) (child []string, err error) {
 	m := map[string]interface{}{}
 
-	subs := p.keyed.Types()
+	subs := p.keyed.Objects()
 	if len(subs) > 0 {
-		for _, t := range subs {
-			types.Put([]string{t, "commit"}, "", m)
-			types.Put([]string{t, "describe"}, "", m)
+		for _, o := range subs {
+			types.Put([]string{o.Name, "commit"}, "", m)
+			types.Put([]string{o.Name, "describe"}, "", m)
 		}
 	} else {
 		types.Put([]string{"commit"}, "", m)

--- a/pkg/rpc/group/service.go
+++ b/pkg/rpc/group/service.go
@@ -4,6 +4,7 @@ import (
 	"net/http"
 
 	"github.com/docker/infrakit/pkg/plugin"
+	"github.com/docker/infrakit/pkg/rpc"
 	"github.com/docker/infrakit/pkg/rpc/internal"
 	"github.com/docker/infrakit/pkg/spi"
 	"github.com/docker/infrakit/pkg/spi/group"
@@ -67,9 +68,9 @@ func (p *Group) ImplementedInterface() spi.InterfaceSpec {
 
 }
 
-// Types returns the types exposed by this kind of RPC service
-func (p *Group) Types() []string {
-	return p.keyed.Types()
+// Objects returns the objects exposed by this kind of RPC service
+func (p *Group) Objects() []rpc.Object {
+	return p.keyed.Objects()
 }
 
 // CommitGroup is the rpc method to commit a group

--- a/pkg/rpc/handshake.go
+++ b/pkg/rpc/handshake.go
@@ -3,59 +3,45 @@ package rpc
 import (
 	"net/http"
 
+	"github.com/docker/infrakit/pkg/plugin"
 	"github.com/docker/infrakit/pkg/spi"
 )
 
-// ImplementsRequest is the rpc wrapper for the Implements method args.
-type ImplementsRequest struct {
-}
+// Object is the RPC remote object
+type Object struct {
+	// Name is the simple name of the object (e.g. aws/ec2-instance ==> ec2-instance).
+	Name string
 
-// ImplementsResponse is the rpc wrapper for the Implements return value.
-type ImplementsResponse struct {
-	APIs []spi.InterfaceSpec
-}
-
-// TypesRequest is the request for getting the types exposed by the rpc object
-type TypesRequest struct {
-}
-
-// InterfaceSpec is the string version of the InterfaceSpec
-type InterfaceSpec string
-
-// TypesResponse is the response for returning the types exposed by the rpc object
-type TypesResponse struct {
-	Types map[InterfaceSpec][]string
+	// ProxyFor is the Name of the plugin for which this object is a proxy (if applicable).
+	ProxyFor plugin.Name
 }
 
 // Handshake is a simple RPC object for doing handshake
-type Handshake map[spi.InterfaceSpec]func() []string
+type Handshake map[spi.InterfaceSpec]func() []Object
 
-// Implements responds to a request for the supported plugin interfaces.
-func (h Handshake) Implements(_ *http.Request, req *ImplementsRequest, resp *ImplementsResponse) error {
-	spi := []spi.InterfaceSpec{}
-	for k := range h {
-		spi = append(spi, k)
+// Hello returns a list of hello exposed by this object
+func (h Handshake) Hello(_ *http.Request, req *HelloRequest, resp *HelloResponse) error {
+	resp.Objects = map[string][]Object{}
+	for k, v := range h {
+		resp.Objects[k.Encode()] = v()
 	}
-	resp.APIs = spi
 	return nil
 }
 
-// Types returns a list of types exposed by this object
-func (h Handshake) Types(_ *http.Request, req *TypesRequest, resp *TypesResponse) error {
-	m := map[InterfaceSpec][]string{}
-	for k, v := range h {
-		m[InterfaceSpec(k.Encode())] = v()
-	}
-	resp.Types = m
-	return nil
+// HelloRequest is the rpc request for Hello
+type HelloRequest struct {
+}
+
+// HelloResponse is the rpc response for Hello
+type HelloResponse struct {
+	// Objects is an index of Objects by Interface
+	Objects map[string][]Object
 }
 
 // Handshaker is the interface implemented by all rpc objects that can give information
 // about the interfaces it implements
 type Handshaker interface {
-	// Implementes returns a list of interface specs implemented by this object
-	Implements() ([]spi.InterfaceSpec, error)
 
-	// Types returns a list of types exposed by this object
-	Types() (map[InterfaceSpec][]string, error)
+	// Hello is initiated by the client to get some information from the server
+	Hello() (map[spi.InterfaceSpec][]Object, error)
 }

--- a/pkg/rpc/handshake_test.go
+++ b/pkg/rpc/handshake_test.go
@@ -1,0 +1,75 @@
+package rpc
+
+import (
+	"testing"
+
+	"github.com/docker/infrakit/pkg/spi"
+	"github.com/docker/infrakit/pkg/types"
+	"github.com/stretchr/testify/require"
+)
+
+func TestEncodeDecode(t *testing.T) {
+
+	objects := map[spi.InterfaceSpec]func() []Object{
+		{
+			Name:    "test",
+			Version: "1.0",
+		}: func() []Object {
+			return []Object{
+				{
+					Name: "a",
+				},
+				{
+					Name: "b",
+				},
+			}
+		},
+		{
+			Name:    "compute",
+			Version: "1.1",
+		}: func() []Object {
+			return []Object{
+				{
+					Name: "x",
+				},
+				{
+					Name: "y",
+				},
+			}
+		},
+	}
+
+	resp := HelloResponse{}
+
+	err := Handshake(objects).Hello(nil, nil, &resp)
+	require.NoError(t, err)
+
+	any := types.AnyValueMust(resp)
+	buff, err := any.MarshalJSON()
+	require.NoError(t, err)
+	require.Equal(t, `{
+"Objects": {
+"compute/1.1": [
+{
+"Name": "x",
+"ProxyFor": ""
+},
+{
+"Name": "y",
+"ProxyFor": ""
+}
+],
+"test/1.0": [
+{
+"Name": "a",
+"ProxyFor": ""
+},
+{
+"Name": "b",
+"ProxyFor": ""
+}
+]
+}
+}`, string(buff))
+
+}

--- a/pkg/rpc/instance/service.go
+++ b/pkg/rpc/instance/service.go
@@ -5,6 +5,7 @@ import (
 	"net/http"
 	"sort"
 
+	"github.com/docker/infrakit/pkg/rpc"
 	"github.com/docker/infrakit/pkg/spi"
 	"github.com/docker/infrakit/pkg/spi/instance"
 )
@@ -69,8 +70,8 @@ func (p *Instance) ImplementedInterface() spi.InterfaceSpec {
 	return instance.InterfaceSpec
 }
 
-// Types returns the types exposed by this service (or kind/ category)
-func (p *Instance) Types() []string {
+// Objects returns the objects exposed by this service (or kind/ category)
+func (p *Instance) Objects() []rpc.Object {
 	types := []string{}
 	for k := range p.typedPlugins {
 		types = append(types, k)
@@ -79,7 +80,11 @@ func (p *Instance) Types() []string {
 		types = append(types, ".")
 	}
 	sort.Strings(types)
-	return types
+	objects := []rpc.Object{}
+	for _, t := range types {
+		objects = append(objects, rpc.Object{Name: t})
+	}
+	return objects
 }
 
 func (p *Instance) getPlugin(instanceType string) instance.Plugin {

--- a/pkg/rpc/internal/keyed.go
+++ b/pkg/rpc/internal/keyed.go
@@ -37,13 +37,13 @@ type Keyed struct {
 	listFunc func() (map[string]interface{}, error)
 }
 
-// Types returns the types exposed by this kind of RPC service
+// Objects returns the objects exposed by this kind of RPC service
 func (k *Keyed) Objects() []rpc.Object {
 	m, err := k.listFunc()
 	if err != nil {
 		return nil
 	}
-	log.Debug("Types", "map", m, "V", debugV)
+	log.Debug("Objects", "map", m, "V", debugV)
 	objs := []rpc.Object{}
 	for key := range m {
 		objs = append(objs, rpc.Object{Name: fmt.Sprintf("%v", key)})

--- a/pkg/rpc/internal/keyed.go
+++ b/pkg/rpc/internal/keyed.go
@@ -6,6 +6,7 @@ import (
 
 	logutil "github.com/docker/infrakit/pkg/log"
 	"github.com/docker/infrakit/pkg/plugin"
+	"github.com/docker/infrakit/pkg/rpc"
 )
 
 var log = logutil.New("module", "rpc/internal")
@@ -37,17 +38,17 @@ type Keyed struct {
 }
 
 // Types returns the types exposed by this kind of RPC service
-func (k *Keyed) Types() []string {
+func (k *Keyed) Objects() []rpc.Object {
 	m, err := k.listFunc()
 	if err != nil {
 		return nil
 	}
 	log.Debug("Types", "map", m, "V", debugV)
-	types := []string{}
+	objs := []rpc.Object{}
 	for key := range m {
-		types = append(types, fmt.Sprintf("%v", key))
+		objs = append(objs, rpc.Object{Name: fmt.Sprintf("%v", key)})
 	}
-	return types
+	return objs
 }
 
 // Do performs work calling the work function once the request resolves to an object

--- a/pkg/rpc/loadbalancer/service.go
+++ b/pkg/rpc/loadbalancer/service.go
@@ -4,6 +4,7 @@ import (
 	"net/http"
 
 	"github.com/docker/infrakit/pkg/plugin"
+	"github.com/docker/infrakit/pkg/rpc"
 	"github.com/docker/infrakit/pkg/rpc/internal"
 	"github.com/docker/infrakit/pkg/spi"
 	"github.com/docker/infrakit/pkg/spi/loadbalancer"
@@ -56,9 +57,9 @@ func (l4 *L4) ImplementedInterface() spi.InterfaceSpec {
 	return loadbalancer.InterfaceSpec
 }
 
-// Types returns the types exposed by this kind of RPC service
-func (l4 *L4) Types() []string {
-	return l4.keyed.Types()
+// Objects returns the objects exposed by this kind of RPC service
+func (l4 *L4) Objects() []rpc.Object {
+	return l4.keyed.Objects()
 }
 
 // Name returns the name of the load balancer

--- a/pkg/rpc/manager/service.go
+++ b/pkg/rpc/manager/service.go
@@ -5,6 +5,7 @@ import (
 	"net/url"
 
 	"github.com/docker/infrakit/pkg/manager"
+	"github.com/docker/infrakit/pkg/rpc"
 	"github.com/docker/infrakit/pkg/spi"
 	"github.com/docker/infrakit/pkg/types"
 )
@@ -24,9 +25,9 @@ func (p *Manager) ImplementedInterface() spi.InterfaceSpec {
 	return manager.InterfaceSpec
 }
 
-// Types returns the types exposed by this kind of RPC service
-func (p *Manager) Types() []string {
-	return []string{"."} // no types
+// Objects returns the objects exposed by this kind of RPC service
+func (p *Manager) Objects() []rpc.Object {
+	return []rpc.Object{{Name: "."}} // no objects
 }
 
 // IsLeaderRequest is the rpc request

--- a/pkg/rpc/metadata/rpc_test.go
+++ b/pkg/rpc/metadata/rpc_test.go
@@ -8,7 +8,6 @@ import (
 	"testing"
 
 	"github.com/docker/infrakit/pkg/plugin"
-	"github.com/docker/infrakit/pkg/rpc"
 	rpc_client "github.com/docker/infrakit/pkg/rpc/client"
 	rpc_server "github.com/docker/infrakit/pkg/rpc/server"
 	"github.com/docker/infrakit/pkg/spi/metadata"
@@ -100,10 +99,13 @@ func TestMetadataMultiPlugin(t *testing.T) {
 
 	rpcClient, err := rpc_client.NewHandshaker(socketPath)
 	require.NoError(t, err)
-	subs, err := rpcClient.Types()
+	subs, err := rpcClient.Hello()
 	require.NoError(t, err)
 
-	found := subs[rpc.InterfaceSpec(metadata.InterfaceSpec.Encode())]
+	found := []string{}
+	for _, f := range subs[metadata.InterfaceSpec] {
+		found = append(found, f.Name)
+	}
 	sort.Strings(found)
 	require.Equal(t, []string{"aws", "azure"}, found)
 

--- a/pkg/rpc/metadata/service.go
+++ b/pkg/rpc/metadata/service.go
@@ -5,6 +5,7 @@ import (
 	"sort"
 
 	"github.com/docker/infrakit/pkg/plugin"
+	"github.com/docker/infrakit/pkg/rpc"
 	"github.com/docker/infrakit/pkg/rpc/internal"
 	"github.com/docker/infrakit/pkg/spi"
 	"github.com/docker/infrakit/pkg/spi/metadata"
@@ -55,9 +56,9 @@ func (p *Metadata) ImplementedInterface() spi.InterfaceSpec {
 	return metadata.InterfaceSpec
 }
 
-// Types returns the types exposed by this kind of RPC service
-func (p *Metadata) Types() []string {
-	return p.keyed.Types()
+// Objects returns the objects exposed by this kind of RPC service
+func (p *Metadata) Objects() []rpc.Object {
+	return p.keyed.Objects()
 }
 
 // Keys returns a list of child nodes given a path.

--- a/pkg/rpc/metadata/updatable.go
+++ b/pkg/rpc/metadata/updatable.go
@@ -6,6 +6,7 @@ import (
 	"sort"
 
 	"github.com/docker/infrakit/pkg/plugin"
+	"github.com/docker/infrakit/pkg/rpc"
 	rpc_client "github.com/docker/infrakit/pkg/rpc/client"
 	"github.com/docker/infrakit/pkg/rpc/internal"
 	"github.com/docker/infrakit/pkg/spi"
@@ -57,9 +58,9 @@ func (u *Updatable) ImplementedInterface() spi.InterfaceSpec {
 	return metadata.UpdatableInterfaceSpec
 }
 
-// Types returns the types exposed by this kind of RPC service
-func (u *Updatable) Types() []string {
-	return u.keyed.Types()
+// Objects returns the objects exposed by this kind of RPC service
+func (u *Updatable) Objects() []rpc.Object {
+	return u.keyed.Objects()
 }
 
 // Keys returns a list of child nodes given a path.

--- a/pkg/rpc/resource/service.go
+++ b/pkg/rpc/resource/service.go
@@ -3,6 +3,7 @@ package resource
 import (
 	"net/http"
 
+	"github.com/docker/infrakit/pkg/rpc"
 	"github.com/docker/infrakit/pkg/spi"
 	"github.com/docker/infrakit/pkg/spi/resource"
 	"github.com/docker/infrakit/pkg/types"
@@ -39,9 +40,9 @@ func (p *Resource) ImplementedInterface() spi.InterfaceSpec {
 	return resource.InterfaceSpec
 }
 
-// Types returns the types exposed by this service (or kind/ category)
-func (p *Resource) Types() []string {
-	return []string{"."}
+// Objects returns the objects exposed by this service (or kind/ category)
+func (p *Resource) Objects() []rpc.Object {
+	return []rpc.Object{{Name: "."}}
 }
 
 // Commit is the rpc method to commit resources.

--- a/pkg/rpc/testing/handshake_test.go
+++ b/pkg/rpc/testing/handshake_test.go
@@ -6,6 +6,7 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/docker/infrakit/pkg/rpc"
 	"github.com/docker/infrakit/pkg/rpc/client"
 	"github.com/docker/infrakit/pkg/rpc/server"
 	"github.com/docker/infrakit/pkg/spi"
@@ -85,9 +86,9 @@ func (p *TestPlugin) ImplementedInterface() spi.InterfaceSpec {
 	return p.spec
 }
 
-// Types returns the types
-func (p *TestPlugin) Types() []string {
-	return []string{"."}
+// Objects returns the objects
+func (p *TestPlugin) Objects() []rpc.Object {
+	return []rpc.Object{{Name: "."}}
 }
 
 // EmptyMessage is an empty test message.

--- a/pkg/run/manager/manager.go
+++ b/pkg/run/manager/manager.go
@@ -268,12 +268,12 @@ func countMatches(list []string, found map[string]*plugin.Endpoint) int {
 				log.Error("Plugin not responding", "lookup", l, "endpoint", ep, "err", err)
 				continue
 			}
-			implements, err := hs.Implements()
+			objects, err := hs.Hello()
 			if err != nil {
 				log.Error("Bad handshake. Is this plugin running?", "lookup", l, "endpoint", ep)
 				continue
 			}
-			log.Debug("Scan found", "lookup", l, "endpoint", ep, "V", debugLoopV, "implements", implements)
+			log.Debug("Scan found", "lookup", l, "endpoint", ep, "V", debugLoopV, "implements", objects)
 			c++
 		}
 	}

--- a/pkg/spi/event/spi.go
+++ b/pkg/spi/event/spi.go
@@ -8,7 +8,7 @@ import (
 // InterfaceSpec is the current name and version of the Flavor API.
 var InterfaceSpec = spi.InterfaceSpec{
 	Name:    "Event",
-	Version: "0.1.0",
+	Version: "0.1.1",
 }
 
 // Plugin must be implemented for the object to be able to publish events.

--- a/pkg/spi/flavor/spi.go
+++ b/pkg/spi/flavor/spi.go
@@ -10,7 +10,7 @@ import (
 // InterfaceSpec is the current name and version of the Flavor API.
 var InterfaceSpec = spi.InterfaceSpec{
 	Name:    "Flavor",
-	Version: "0.1.0",
+	Version: "0.1.1",
 }
 
 // Health is an indication of whether the Flavor is functioning properly.

--- a/pkg/spi/group/spi.go
+++ b/pkg/spi/group/spi.go
@@ -9,7 +9,7 @@ import (
 // InterfaceSpec is the current name and version of the Group API.
 var InterfaceSpec = spi.InterfaceSpec{
 	Name:    "Group",
-	Version: "0.1.0",
+	Version: "0.1.1",
 }
 
 // AllocationMethod defines the type of allocation and supervision needed by a flavor's Group.

--- a/pkg/spi/instance/spi.go
+++ b/pkg/spi/instance/spi.go
@@ -8,7 +8,7 @@ import (
 // InterfaceSpec is the current name and version of the Instance API.
 var InterfaceSpec = spi.InterfaceSpec{
 	Name:    "Instance",
-	Version: "0.6.0",
+	Version: "0.6.1",
 }
 
 var (

--- a/pkg/spi/loadbalancer/spi.go
+++ b/pkg/spi/loadbalancer/spi.go
@@ -11,7 +11,7 @@ import (
 // InterfaceSpec is the current name and version of the L4 API.
 var InterfaceSpec = spi.InterfaceSpec{
 	Name:    "L4",
-	Version: "0.6.0",
+	Version: "0.6.1",
 }
 
 // Route is a description of a network target for a load balancer.

--- a/pkg/spi/metadata/spi.go
+++ b/pkg/spi/metadata/spi.go
@@ -9,13 +9,13 @@ var (
 	// InterfaceSpec is the current name and version of the Metadata API.
 	InterfaceSpec = spi.InterfaceSpec{
 		Name:    "Metadata",
-		Version: "0.1.0",
+		Version: "0.1.1",
 	}
 
 	// UpdatableInterfaceSpec is the current name and version of the Metadata API.
 	UpdatableInterfaceSpec = spi.InterfaceSpec{
 		Name:    "Updatable",
-		Version: "0.1.0",
+		Version: "0.1.1",
 	}
 )
 

--- a/pkg/spi/resource/spi.go
+++ b/pkg/spi/resource/spi.go
@@ -8,7 +8,7 @@ import (
 // InterfaceSpec is the current name and version of the Resource API.
 var InterfaceSpec = spi.InterfaceSpec{
 	Name:    "Resource",
-	Version: "0.1.0",
+	Version: "0.1.1",
 }
 
 // ID is the unique identifier for a collection of resources.

--- a/pkg/spi/stack/spi.go
+++ b/pkg/spi/stack/spi.go
@@ -8,7 +8,7 @@ import (
 // InterfaceSpec is the current name and version of the Instance API.
 var InterfaceSpec = spi.InterfaceSpec{
 	Name:    "Stack",
-	Version: "0.1.0",
+	Version: "0.1.1",
 }
 
 // Interface is a higher-level abstraction for all the groups, controllers, and plugins


### PR DESCRIPTION
This PR

  + Changes the handshake protocol to reduce roundtrip times.  2 roundtrips have been reduced to 1.
  + Add additional metadata about remote objects.
  + Increments the interface versions (minor)

Signed-off-by: David Chung <david.chung@docker.com>