### PR TITLE
Added Capability to run standalone commands against existing VM

### DIFF
--- a/pkg/x/vmwscript/cmd_parser.go
+++ b/pkg/x/vmwscript/cmd_parser.go
@@ -35,6 +35,10 @@ type VMConfig struct {
 		Username string `json:"guestUser,omitempty"`
 		Password string `json:"guestPass,omitempty"`
 	} `json:"guestCredentials,omitempty"`
+
+	// These are used for testing a command against a pre-existing virtual machine
+	Command string `json:"command,omitempty"`
+	VMName  string `json:"vmname,omitempty"`
 }
 
 // DeploymentTask - is passed to the vSphere API functions in order to be executed on a remote VM

--- a/pkg/x/vmwscript/readme.md
+++ b/pkg/x/vmwscript/readme.md
@@ -41,6 +41,9 @@ Flags:
       --templatePass string   The password for the specified user inside the VM template
       --templateUser string   A created user inside of the VM template
       --vcurl string          VMware vCenter URL, format https://user:pass@address/sdk [REQD]
+      --vmcommand string      A command passed as a string to be executed on the virtual machine specified with [--vmname]
+      --vmname string         The name of an existing virtual machine to run a command against
+      --vmsudouser string     A sudo user that the command will be executed
 ```
 
 ### Environment variables
@@ -54,6 +57,14 @@ export INFRAKIT_VSPHERE_VCHOST="vsphere01.lab"
 export INFRAKIT_VSPHERE_VCNETWORK="Internal Network (NAT)"
 export INFRAKIT_VSPHERE_VCURL="https://user@vsphere.local:pass@vCenter.lab/sdk"
 ```
+
+### Standalone usage
+
+The `vmwscript` utility has the capability to run commands against an already created and running virtual machine.
+
+**Example**: restarting Apache to pick up a new configuration
+
+`./infrakit x vmwscript --vmname=web01 --vmsudouser=root --vmcommand="systemctl restart httpd"`
 
 ### Deployment files
 


### PR DESCRIPTION
This adds the capability to run commands on an ad-hoc approach against an existing virtual machine with three new flags (no script needs passing)

      `--vmcommand string`      A command passed as a string to be executed on the virtual machine specified with [--vmname]
      `--vmname string`         The name of an existing virtual machine to run a command against
      `--vmsudouser string`     A sudo user that the command will be executed
  
  Signed-off-by: Dan Finneran <daniel.finneran@gmail.com>