### PR TITLE
ingress / enrollment controllers: make leadership lookup on-demand

### DIFF
--- a/pkg/controller/enrollment/controller.go
+++ b/pkg/controller/enrollment/controller.go
@@ -16,7 +16,7 @@ var (
 )
 
 // NewController returns a controller implementation
-func NewController(plugins func() discovery.Plugins, leader manager.Leadership,
+func NewController(plugins func() discovery.Plugins, leader func() manager.Leadership,
 	options enrollment.Options) controller.Controller {
 	return internal.NewController(
 		leader,
@@ -32,7 +32,7 @@ func NewController(plugins func() discovery.Plugins, leader manager.Leadership,
 }
 
 // NewTypedControllers return typed controllers
-func NewTypedControllers(plugins func() discovery.Plugins, leader manager.Leadership,
+func NewTypedControllers(plugins func() discovery.Plugins, leader func() manager.Leadership,
 	options enrollment.Options) func() (map[string]controller.Controller, error) {
 
 	return (internal.NewController(

--- a/pkg/controller/ingress/controller.go
+++ b/pkg/controller/ingress/controller.go
@@ -13,13 +13,13 @@ import (
 )
 
 // NewController returns a controller implementation
-func NewController(scope scope.Scope, leader manager.Leadership) controller.Controller {
+func NewController(scope scope.Scope, leader func() manager.Leadership) controller.Controller {
 	return internal.NewController(
 		leader,
 		// the constructor
 		func(spec types.Spec) (internal.Managed, error) {
 			return &managed{
-				Leadership: leader,
+				leader: leader,
 			}, nil
 		},
 		// the key function
@@ -31,7 +31,7 @@ func NewController(scope scope.Scope, leader manager.Leadership) controller.Cont
 
 // NewTypedControllers return typed controllers
 func NewTypedControllers(scope scope.Scope,
-	leader manager.Leadership) func() (map[string]controller.Controller, error) {
+	leader func() manager.Leadership) func() (map[string]controller.Controller, error) {
 
 	return (internal.NewController(
 		leader,

--- a/pkg/controller/ingress/fsm.go
+++ b/pkg/controller/ingress/fsm.go
@@ -1,6 +1,7 @@
 package ingress
 
 import (
+	"fmt"
 	"time"
 
 	"github.com/docker/infrakit/pkg/controller"
@@ -97,6 +98,16 @@ func (c *managed) defaultBehaviors(spec types.Spec) {
 	}
 }
 
+func (c *managed) isLeader() (is bool, err error) {
+	check := c.leader()
+	if check == nil {
+		err = fmt.Errorf("cannot determine leader status")
+		return
+	}
+	is, err = check.IsLeader()
+	return
+}
+
 func (c *managed) init(in types.Spec) (err error) {
 	if c.process != nil {
 		panic("this is not allowed")
@@ -182,7 +193,7 @@ func (c *managed) init(in types.Spec) (err error) {
 	c.poller = controller.Poll(
 		func() bool {
 
-			if mustTrue(c.IsLeader()) {
+			if mustTrue(c.isLeader()) {
 				c.stateMachine.Signal(lead)
 				return true
 			}

--- a/pkg/controller/ingress/managed.go
+++ b/pkg/controller/ingress/managed.go
@@ -22,17 +22,17 @@ import (
 var log = logutil.New("module", "controller/ingress")
 
 func newManaged(scp scope.Scope,
-	leader manager.Leadership) *managed {
+	leader func() manager.Leadership) *managed {
 	return &managed{
-		Leadership: leader,
-		scope:      scp,
+		leader: leader,
+		scope:  scp,
 	}
 }
 
 // managed is the entity that reconciles desired routes with loadbalancers
 type managed struct {
 	// Leader controls whether this ingress is active or not
-	manager.Leadership
+	leader func() manager.Leadership
 
 	// l4s is a function that get retrieve a map of L4 loadbalancers by name
 	l4s func() (map[ingress.Vhost]loadbalancer.L4, error)

--- a/pkg/rpc/client/handshake.go
+++ b/pkg/rpc/client/handshake.go
@@ -7,6 +7,18 @@ import (
 	"sync"
 )
 
+// IsErrInterfaceNotSupported returns true if the error is because the interface is not supported.
+func IsErrInterfaceNotSupported(err error) bool {
+	_, is := err.(errNotSupported)
+	return is
+}
+
+type errNotSupported spi.InterfaceSpec
+
+func (e errNotSupported) Error() string {
+	return fmt.Sprintf("Plugin does not support interface %v", spi.InterfaceSpec(e).Encode())
+}
+
 type handshakingClient struct {
 	client *client
 	iface  spi.InterfaceSpec
@@ -49,7 +61,7 @@ func (c *handshakingClient) handshake() error {
 			return err
 		}
 
-		err = fmt.Errorf("Plugin does not support interface %v", c.iface.Encode())
+		err = errNotSupported(c.iface)
 		for iface := range objects {
 			if iface.Name == c.iface.Name {
 				if iface.Version == c.iface.Version {

--- a/pkg/run/v0/enrollment/enrollment.go
+++ b/pkg/run/v0/enrollment/enrollment.go
@@ -34,20 +34,26 @@ var DefaultOptions = enrollment.Options{
 	DestroyOnTerminate: false,
 }
 
-func leadership(plugins func() discovery.Plugins) (manager.Leadership, error) {
+func leadership(plugins func() discovery.Plugins) manager.Leadership {
 	// Scan for a manager
 	pm, err := plugins().List()
 	if err != nil {
-		return nil, err
+		log.Error("Cannot list plugins", "err", err)
+		return nil
 	}
 
 	for _, endpoint := range pm {
 		rpcClient, err := client.New(endpoint.Address, manager.InterfaceSpec)
 		if err == nil {
-			return manager_rpc.Adapt(rpcClient), nil
+			return manager_rpc.Adapt(rpcClient)
+		}
+
+		if !client.IsErrInterfaceNotSupported(err) {
+			log.Error("Got error getting manager", "endpoint", endpoint, "err", err)
+			return nil
 		}
 	}
-	return nil, nil
+	return nil
 }
 
 // Run runs the plugin, blocking the current thread.  Error is returned immediately
@@ -63,14 +69,12 @@ func Run(scope scope.Scope, name plugin.Name,
 
 	log.Info("Decoded input", "config", options)
 
-	leader, err := leadership(scope.Plugins)
-	if err != nil {
-		return
-	}
-
 	transport.Name = name
 	impls = map[run.PluginCode]interface{}{
-		run.Controller: enrollment_controller.NewTypedControllers(scope.Plugins, leader, options),
+		run.Controller: enrollment_controller.NewTypedControllers(scope.Plugins,
+			func() manager.Leadership {
+				return leadership(scope.Plugins)
+			}, options),
 	}
 
 	return


### PR DESCRIPTION
Closes #781 

Previously in #781 the panic manifests when the controllers that depend on the `manager.Leadership` remote object failed to initialize properly.  This failure, in turn, was due to the manager (which implements the `manager.Leadership` interface) failed to initialize in time to respond to a RPC handshake from these controllers.  This can be seen as the RPC canceled / timeout error in the logs when either the ingress or enrollment controllers come up.

Further, the `manager` has dependency on `group` and its initialization depends on that plugin.  So we have a ordering problem: if the `group` plugin starts up *after* either `ingress` or `enrollment` controllers, the manager will not initialize properly in time to properly perform this handshake.   As a result, a panic is thrown when the user tries to commit a spec because the leadership interface was set to `nil`.

This PR 

  + Changes the lookup of leadership information to on-demand, instead of at initialization time when plugins that need it (the `ingress` and `enrollment` controllers).  This makes it possible to have plugins come up in arbitrary order.  
  + Adds a method for detection of errors other than "interface not supported" during handshake.   This makes it possible to detect the handshake timeout / cancellation error described above.

Signed-off-by: David Chung <david.chung@docker.com>