### PR TITLE
Map TCP to HTTPS if cert specified.

### DIFF
--- a/pkg/controller/ingress/swarm/listener.go
+++ b/pkg/controller/ingress/swarm/listener.go
@@ -48,8 +48,8 @@ func (l *listener) asRoute() loadbalancer.Route {
 			r.LoadBalancerProtocol = loadbalancer.HTTPS
 			r.Protocol = loadbalancer.HTTP // backend
 		case loadbalancer.TCP: // frontend lb protocol
-			r.LoadBalancerProtocol = loadbalancer.SSL
-			r.Protocol = loadbalancer.TCP // backend
+			r.LoadBalancerProtocol = loadbalancer.HTTPS
+			r.Protocol = loadbalancer.HTTP // backend
 		}
 	}
 	return r

--- a/pkg/controller/ingress/swarm/listener_test.go
+++ b/pkg/controller/ingress/swarm/listener_test.go
@@ -70,8 +70,8 @@ func TestListenerSSLCertNoPort(t *testing.T) {
 	require.Equal(t, &cert, l.CertASN())
 	require.Equal(t, []int{443}, l.CertPorts())
 	r = l.asRoute()
-	require.Equal(t, loadbalancer.TCP, r.Protocol)
-	require.Equal(t, loadbalancer.SSL, r.LoadBalancerProtocol)
+	require.Equal(t, loadbalancer.HTTP, r.Protocol)
+	require.Equal(t, loadbalancer.HTTPS, r.LoadBalancerProtocol)
 	require.Equal(t, &cert, r.Certificate)
 
 	// no cert so not SSL.
@@ -156,7 +156,8 @@ func TestListenerSSLCertWithPorts(t *testing.T) {
 	require.Equal(t, &asn, l.CertASN())
 	require.Equal(t, []int{443}, l.CertPorts())
 	r = l.asRoute()
-	require.Equal(t, loadbalancer.TCP, r.Protocol)
+	// TCP with cert gets mapped to HTTP
+	require.Equal(t, loadbalancer.HTTP, r.Protocol)
 	require.Equal(t, asn, *r.Certificate)
 
 	// cert but no port, assume port 443


### PR DESCRIPTION
Switch from mapping TCP/TCP frontend/backend protocols to SSL/TCP when
specifying a cert instead to HTTPS/HTTP.

Signed-off-by: Craig Yamamoto <craigyam@us.ibm.com>