### PR TITLE
Handle manager failover during terraform provision

### DIFF
--- a/pkg/provider/ibmcloud/client/softlayerclient.go
+++ b/pkg/provider/ibmcloud/client/softlayerclient.go
@@ -1,14 +1,14 @@
 package client
 
 import (
+	"github.com/softlayer/softlayer-go/datatypes"
 	"github.com/softlayer/softlayer-go/services"
 	"github.com/softlayer/softlayer-go/session"
 )
 
 // SoftlayerClient for all SL API calls
 type SoftlayerClient struct {
-	sess    *session.Session
-	account services.Account
+	sess *session.Session
 }
 
 // GetClient returns a SoftlayerClient instance
@@ -16,7 +16,6 @@ func GetClient(user, apiKey string) *SoftlayerClient {
 	client := &SoftlayerClient{
 		sess: session.New(user, apiKey),
 	}
-	client.account = services.GetAccountService(client.sess)
 	return client
 }
 
@@ -45,4 +44,13 @@ func (c *SoftlayerClient) GetAllowedStorageVirtualGuests(storageID int) ([]int, 
 		result = append(result, *r.Id)
 	}
 	return result, nil
+}
+
+// GetVirtualGuests gets all VMs
+func (c *SoftlayerClient) GetVirtualGuests(username, apiKey string, mask *string) (resp []datatypes.Virtual_Guest, err error) {
+	acct := services.GetAccountService(c.sess)
+	if mask != nil {
+		acct = acct.Mask(*mask)
+	}
+	return acct.GetVirtualGuests()
 }

--- a/pkg/provider/terraform/instance/plugin.go
+++ b/pkg/provider/terraform/instance/plugin.go
@@ -161,17 +161,8 @@ func (p *plugin) processImport(importOpts *ImportOptions) error {
 
 	// Define the functions for import and import the VM
 	fns := importFns{
-		tfShow: p.doTerraformShow,
-		tfImport: func(resType TResourceType, resName, id string) error {
-			command := exec.Command(fmt.Sprintf("terraform import %v.%v %s", resType, resName, id)).
-				InheritEnvs(true).
-				WithEnvs(p.envs...).
-				WithDir(p.Dir)
-			if err := command.WithStdout(os.Stdout).WithStderr(os.Stdout).Start(); err != nil {
-				return err
-			}
-			return command.Wait()
-		},
+		tfShow:     p.doTerraformShow,
+		tfImport:   p.doTerraformImport,
 		tfShowInst: p.doTerraformShowForInstance,
 		tfClean:    p.cleanupFailedImport,
 	}
@@ -1772,4 +1763,16 @@ func determineFinalPropsForImport(res *ImportResource) {
 		}
 	}
 	res.FinalProps = finalProps
+}
+
+// doTerraformImport shells out to run `terraform import`
+func (p *plugin) doTerraformImport(resType TResourceType, resName, id string) error {
+	command := exec.Command(fmt.Sprintf("terraform import %v.%v %s", resType, resName, id)).
+		InheritEnvs(true).
+		WithEnvs(p.envs...).
+		WithDir(p.Dir)
+	if err := command.WithStdout(os.Stdout).WithStderr(os.Stdout).Start(); err != nil {
+		return err
+	}
+	return command.Wait()
 }

--- a/pkg/provider/terraform/instance/softlayer.go
+++ b/pkg/provider/terraform/instance/softlayer.go
@@ -3,8 +3,25 @@ package instance
 import (
 	"fmt"
 	"strings"
+
+	"github.com/docker/infrakit/pkg/provider/ibmcloud/client"
+	"github.com/softlayer/softlayer-go/datatypes"
+
+	log "github.com/Sirupsen/logrus"
 )
 
+const (
+	// SoftlayerUsernameEnvVar contains the env var name that the Softlayer terraform
+	// provider expects for the Softlayer username
+	SoftlayerUsernameEnvVar = "SOFTLAYER_USERNAME"
+
+	// SoftlayerAPIKeyEnvVar contains the env var name that the Softlayer terraform
+	// provider expects for the Softlayer API key
+	SoftlayerAPIKeyEnvVar = "SOFTLAYER_API_KEY"
+)
+
+// mergeLabelsIntoTagSlice combines the tags slice and the labels map into a string slice
+// since Softlayer tags are simply strings
 func mergeLabelsIntoTagSlice(tags []interface{}, labels map[string]string) []string {
 	m := map[string]string{}
 	for _, l := range tags {
@@ -35,4 +52,71 @@ func mergeLabelsIntoTagSlice(tags []interface{}, labels map[string]string) []str
 		}
 	}
 	return lines
+}
+
+// GetIBMCloudVMByTag queries Softlayer for VMs that match all of the given tags. Returns
+// the single VM ID that matches or nil if there are no matches.
+func GetIBMCloudVMByTag(username, apiKey string, tags []string) (*int, error) {
+	c := client.GetClient(username, apiKey)
+	mask := "id;hostname;tagReferences"
+	vms, err := c.GetVirtualGuests(username, apiKey, &mask)
+	if err != nil {
+		return nil, err
+	}
+	return getUniqueVMByTags(vms, tags)
+}
+
+// getUniqueVMByTags returns the single VM ID that matches or nil if there are no matches.
+func getUniqueVMByTags(vms []datatypes.Virtual_Guest, tags []string) (*int, error) {
+	// Filter by tags
+	filterVMsByTags(&vms, tags)
+	// No match
+	if len(vms) == 0 {
+		log.Infof("Detected 0 existing VMs with tags: %v", tags)
+		return nil, nil
+	}
+	// Exactly 1 match
+	if len(vms) == 1 {
+		var name string
+		if vms[0].Hostname != nil {
+			name = *vms[0].Hostname
+		}
+		if vms[0].Id == nil {
+			return nil, fmt.Errorf("VM '%v' missing ID", name)
+		}
+		log.Infof("Existing VM %v with ID %v matches tags: %v", name, *vms[0].Id, tags)
+		return vms[0].Id, nil
+	}
+	// More than 1 match
+	ids := []int{}
+	for _, vm := range vms {
+		ids = append(ids, *vm.Id)
+	}
+	return nil, fmt.Errorf("Only a single VM should match tags, but VMs %v match tags: %v", ids, tags)
+}
+
+// filterVMsByTags removes all VM slice entries that do not contain all of the
+// given tags
+func filterVMsByTags(vms *[]datatypes.Virtual_Guest, tags []string) {
+	matches := []datatypes.Virtual_Guest{}
+	for _, vm := range *vms {
+		allTagsMatch := true
+		for _, tag := range tags {
+			tagMatch := false
+			for _, tagRef := range vm.TagReferences {
+				if *tagRef.Tag.Name == tag {
+					tagMatch = true
+					break
+				}
+			}
+			if !tagMatch {
+				allTagsMatch = false
+				break
+			}
+		}
+		if allTagsMatch {
+			matches = append(matches, vm)
+		}
+	}
+	*vms = matches
 }

--- a/pkg/provider/terraform/instance/softlayer_test.go
+++ b/pkg/provider/terraform/instance/softlayer_test.go
@@ -1,0 +1,181 @@
+package instance
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/softlayer/softlayer-go/datatypes"
+	"github.com/stretchr/testify/require"
+)
+
+func TestMergeLabelsIntoTagSliceEmpty(t *testing.T) {
+	result := mergeLabelsIntoTagSlice([]interface{}{}, map[string]string{})
+	require.Equal(t, []string{}, result)
+}
+
+func TestMergeLabelsIntoTagSliceTagsOnly(t *testing.T) {
+	result := mergeLabelsIntoTagSlice(
+		[]interface{}{
+			"tag1:val1",
+			"tag2:val2",
+		},
+		map[string]string{},
+	)
+	require.Len(t, result, 2)
+	require.Contains(t, result, "tag1:val1")
+	require.Contains(t, result, "tag2:val2")
+}
+
+func TestMergeLabelsIntoTagSliceLabelsOnly(t *testing.T) {
+	result := mergeLabelsIntoTagSlice(
+		[]interface{}{},
+		map[string]string{
+			"label1": "val1",
+			"label2": "val2",
+		},
+	)
+	require.Len(t, result, 2)
+	require.Contains(t, result, "label1:val1")
+	require.Contains(t, result, "label2:val2")
+}
+
+func TestMergeLabelsIntoTagSlice(t *testing.T) {
+	result := mergeLabelsIntoTagSlice(
+		[]interface{}{
+			"tag1:val1",
+			"tag2:val2",
+		},
+		map[string]string{
+			"label1": "val1",
+			"label2": "val2",
+		},
+	)
+	require.Len(t, result, 4)
+	require.Contains(t, result, "tag1:val1")
+	require.Contains(t, result, "tag2:val2")
+	require.Contains(t, result, "label1:val1")
+	require.Contains(t, result, "label2:val2")
+}
+
+func TestFilterVMsByTagsEmpty(t *testing.T) {
+	vms := []datatypes.Virtual_Guest{}
+	filterVMsByTags(&vms, []string{})
+	require.Equal(t, []datatypes.Virtual_Guest{}, vms)
+}
+
+func TestGetUniqueVMByTagsEmpty(t *testing.T) {
+	id, err := getUniqueVMByTags([]datatypes.Virtual_Guest{}, []string{})
+	require.NoError(t, err)
+	require.Nil(t, id)
+}
+
+func TestGetUniqueVMByTagsOneMatch(t *testing.T) {
+	vmID := 123
+	vmTagName := "some-tag"
+	vmTag := datatypes.Tag{Name: &vmTagName}
+	vms := []datatypes.Virtual_Guest{{Id: &vmID, TagReferences: []datatypes.Tag_Reference{{Tag: &vmTag}}}}
+	id, err := getUniqueVMByTags(vms, []string{vmTagName})
+	require.NoError(t, err)
+	require.Equal(t, vmID, *id)
+}
+
+func TestGetUniqueVMByTagsOneMatchNilID(t *testing.T) {
+	vmTagName := "some-tag"
+	vmHostname := "some-hostname"
+	vmTag := datatypes.Tag{Name: &vmTagName}
+	vms := []datatypes.Virtual_Guest{
+		{
+			Hostname:      &vmHostname,
+			TagReferences: []datatypes.Tag_Reference{{Tag: &vmTag}},
+		},
+	}
+	id, err := getUniqueVMByTags(vms, []string{vmTagName})
+	require.Equal(t, "VM 'some-hostname' missing ID", err.Error())
+	require.Nil(t, id)
+}
+
+func TestGetUniqueVMByTagsTwoMatches(t *testing.T) {
+	vmID1 := 123
+	vmID2 := 234
+	vmTagName := "some-tag"
+	vmTag := datatypes.Tag{Name: &vmTagName}
+	vms := []datatypes.Virtual_Guest{
+		{Id: &vmID1, TagReferences: []datatypes.Tag_Reference{{Tag: &vmTag}}},
+		{Id: &vmID2, TagReferences: []datatypes.Tag_Reference{{Tag: &vmTag}}},
+	}
+	id, err := getUniqueVMByTags(vms, []string{vmTagName})
+	require.Equal(t,
+		fmt.Sprintf("Only a single VM should match tags, but VMs %v match tags: %v", []int{vmID1, vmID2}, []string{vmTagName}),
+		err.Error())
+	require.Nil(t, id)
+}
+
+// getVMs is a utility function to get datatypes.Virtual_Guest with tags
+func getVMs() []datatypes.Virtual_Guest {
+	vmID0 := 0
+	vmID1 := 1
+	vmID2 := 2
+	vmID3 := 3
+	tag1Name := "tag1"
+	tag1 := datatypes.Tag{Name: &tag1Name}
+	tag2Name := "tag2"
+	tag2 := datatypes.Tag{Name: &tag2Name}
+	tag3Name := "tag3"
+	tag3 := datatypes.Tag{Name: &tag3Name}
+	vms := []datatypes.Virtual_Guest{
+		{
+			TagReferences: []datatypes.Tag_Reference{},
+			Id:            &vmID0,
+		},
+		{
+			TagReferences: []datatypes.Tag_Reference{{Tag: &tag1}},
+			Id:            &vmID1,
+		},
+		{
+			TagReferences: []datatypes.Tag_Reference{{Tag: &tag1}, {Tag: &tag2}},
+			Id:            &vmID2,
+		},
+		{
+			TagReferences: []datatypes.Tag_Reference{{Tag: &tag1}, {Tag: &tag2}, {Tag: &tag3}},
+			Id:            &vmID3,
+		},
+	}
+	return vms
+}
+
+func TestFilterVMsByTags(t *testing.T) {
+	// No tags given, everything matches
+	vms := getVMs()
+	filterVMsByTags(&vms, []string{})
+	require.Len(t, vms, 4)
+	require.Equal(t, 0, *vms[0].Id)
+	require.Equal(t, 1, *vms[1].Id)
+	require.Equal(t, 2, *vms[2].Id)
+	require.Equal(t, 3, *vms[3].Id)
+	// Empty tag, nothing matches
+	vms = getVMs()
+	filterVMsByTags(&vms, []string{""})
+	require.Len(t, vms, 0)
+	// 1 tag matches
+	vms = getVMs()
+	filterVMsByTags(&vms, []string{"tag1"})
+	require.Len(t, vms, 3)
+	require.Equal(t, 1, *vms[0].Id)
+	require.Equal(t, 2, *vms[1].Id)
+	require.Equal(t, 3, *vms[2].Id)
+	// 2 tags match
+	vms = getVMs()
+	filterVMsByTags(&vms, []string{"tag1", "tag2"})
+	require.Len(t, vms, 2)
+	require.Equal(t, 2, *vms[0].Id)
+	require.Equal(t, 3, *vms[1].Id)
+	// 3 tags match
+	vms = getVMs()
+	filterVMsByTags(&vms, []string{"tag1", "tag2", "tag3"})
+	require.Len(t, vms, 1)
+	require.Equal(t, 3, *vms[0].Id)
+	// A tag that doesn't match
+	vms = getVMs()
+	filterVMsByTags(&vms, []string{"tag1", "foo"})
+	require.Len(t, vms, 0)
+}


### PR DESCRIPTION
In the terraform instance plugin an orphaned resource `tf.json` file can exist for 2 different reasons:
1. Resource has been removed out-of-band from Infrakit, in this case the resource in the terraform state file will be removed during a `terraform refresh` operation.
2. Infrakit failed over to a different manager during a `terraform apply`, in this case the state file is **not** updated because the apply never finished (terraform only updates at the end of a provision -- nothing is updating _during_ a provision).

In order to differentiate between these 2 cases we need to get a list of existing resources **before** and **after** we execute `terraform refresh`.

When we detect a orphan, we can simply remove the file if the resource previously existed and is not removed (case 1 above). However, if the resource did not exist, then we need to:
1. Query the backend cloud for VM with the unique tags
2. If a VM is found then import it into terraform
3. If no VM is found then prune the `tf.json` file

This allows us to complete an in-progress provision when management fails over (or if the container is restarted for whatever reason during a provision).

The downside of this solution is that is requires platform-specific updates to perform the backend query; this commit contains the implementation for IBM Cloud only.