### PR TITLE
Update logging level for ingress and enrollment controllers

### DIFF
--- a/pkg/controller/enrollment/sync.go
+++ b/pkg/controller/enrollment/sync.go
@@ -165,7 +165,12 @@ func (l *enroller) sync() error {
 		instance.Descriptions(enrolled), enrolledKeyFunc,
 	)
 
-	log.Info("Computed delta", "add", add, "remove", remove)
+	// Use Info logging only when making deltas
+	logFn := log.Debug
+	if len(add) > 0 || len(remove) > 0 {
+		logFn = log.Info
+	}
+	logFn("Computed delta", "add", add, "remove", remove)
 
 	instancePlugin, err := l.getInstancePlugin(l.properties.Instance.Plugin)
 	if err != nil {

--- a/pkg/controller/ingress/l4.go
+++ b/pkg/controller/ingress/l4.go
@@ -18,7 +18,8 @@ func configureL4(elb loadbalancer.L4, desired []loadbalancer.Route, options type
 	}
 	log.Debug("describe L4", "routes", routes)
 
-	log.Info("Listeners to sync with L4:", "desired", desired)
+	log.Debug("Listeners to sync with L4", "desired", desired)
+
 	toCreate := []loadbalancer.Route{}
 	toChange := []loadbalancer.Route{}
 	toRemove := []loadbalancer.Route{}
@@ -58,13 +59,17 @@ func configureL4(elb loadbalancer.L4, desired []loadbalancer.Route, options type
 				Certificate:          cert,
 			})
 		} else {
-			log.Info("keeping", "protocol", lbProtocol, "instanceProtocol", instanceProtocol, "port", lbPort, "instancePort", instancePort)
+			log.Debug("keeping", "protocol", lbProtocol, "instanceProtocol", instanceProtocol, "port", lbPort, "instancePort", instancePort)
 		}
 	}
 
-	log.Info("listeners to create:", "list", toCreate)
-	log.Info("listeners to change:", "list", toChange)
-	log.Info("listeners to remove:", "list", toRemove)
+	logFn := log.Debug
+	if len(toCreate) > 0 || len(toChange) > 0 || len(toRemove) > 0 {
+		logFn = log.Info
+	}
+	logFn("listeners to create:", "list", toCreate)
+	logFn("listeners to change:", "list", toChange)
+	logFn("listeners to remove:", "list", toRemove)
 
 	// Now we have a list of targets to create
 	for _, l := range toCreate {

--- a/pkg/controller/ingress/swarm/init.go
+++ b/pkg/controller/ingress/swarm/init.go
@@ -74,7 +74,7 @@ func (h *handler) Routes(properties *types.Any,
 		return nil, err
 	}
 
-	log.Info("Connected to Docker", "client", dockerClient)
+	log.Debug("Connected to Docker", "client", dockerClient)
 	h.dockerClient = dockerClient
 
 	routes, err := NewServiceRoutes(dockerClient).

--- a/pkg/controller/ingress/swarm/routes.go
+++ b/pkg/controller/ingress/swarm/routes.go
@@ -171,7 +171,7 @@ func (p *Routes) RoutesFromServices(services []swarm.Service) (map[ingress.Vhost
 // List will return all the known routes for this Docker swarm of matching services.
 func (p *Routes) List() (map[ingress.Vhost][]loadbalancer.Route, error) {
 
-	log.Info("Listing services from swarm")
+	log.Debug("Listing services from swarm")
 
 	ctx := context.Background()
 	services, err := p.client.ServiceList(ctx, types.ServiceListOptions{})

--- a/pkg/fsm/set.go
+++ b/pkg/fsm/set.go
@@ -97,7 +97,7 @@ func (s *Set) Signal(signal Signal, instance ID, optionalData ...interface{}) er
 		data = optionalData[0]
 	}
 
-	log.Info("Signal", "set", s.options.Name, "signal", signal, "instance", instance)
+	log.Debug("Signal", "set", s.options.Name, "signal", signal, "instance", instance)
 	s.events <- &event{instance: instance, signal: signal, data: data}
 	return nil
 }


### PR DESCRIPTION
The default `Info` level messages are very noisey. This commit updates most of the message to `Debug`.

A lot of the messages contain the delta information and, where there actually are deltas, these are useful at an `Info` level; logic was added to log them at `Info` when there is something useful.

Also changes the log level to `Debug` for:
- FSM `set.go` Signal code
- Swarm ingress controller `dockerClient` info