### PR TITLE
Add health monitor path label support.

### DIFF
--- a/pkg/controller/ingress/swarm/init.go
+++ b/pkg/controller/ingress/swarm/init.go
@@ -38,6 +38,9 @@ type Spec struct {
 
 	// CertificateLabel is the label on swarm services that we look for to get the certificate id.
 	CertificateLabel *string
+
+	// HealthMonitorPathLabel is the label on swarm services that we look for to get the url path for a health monitor.
+	HealthMonitorPathLabel *string
 }
 
 type handler struct {
@@ -80,6 +83,7 @@ func (h *handler) Routes(properties *types.Any,
 	routes, err := NewServiceRoutes(dockerClient).
 		SetOptions(options).
 		SetCertLabel(spec.CertificateLabel).
+		SetHealthMonitorPathLabel(spec.HealthMonitorPathLabel).
 		Build()
 	if err != nil {
 		return nil, err

--- a/pkg/controller/ingress/swarm/init_test.go
+++ b/pkg/controller/ingress/swarm/init_test.go
@@ -13,6 +13,7 @@ import (
 func TestParseSpec(t *testing.T) {
 
 	certLabel := "certLabel"
+	healthPathLabel := "healthLabel"
 
 	properties := ingress.Properties{
 		{
@@ -24,7 +25,8 @@ func TestParseSpec(t *testing.T) {
 						Docker: Docker(docker.ConnectInfo{
 							Host: "/var/run/docker.sock",
 						}),
-						CertificateLabel: &certLabel,
+						CertificateLabel:       &certLabel,
+						HealthMonitorPathLabel: &healthPathLabel,
 					},
 				),
 			},
@@ -45,4 +47,5 @@ func TestParseSpec(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, "/var/run/docker.sock", spec.Docker.Host)
 	require.Equal(t, certLabel, *spec.CertificateLabel)
+	require.Equal(t, healthPathLabel, *spec.HealthMonitorPathLabel)
 }

--- a/pkg/controller/ingress/swarm/listener_test.go
+++ b/pkg/controller/ingress/swarm/listener_test.go
@@ -9,8 +9,8 @@ import (
 )
 
 func TestListener(t *testing.T) {
-	var emptyCert *string
-	l, err := newListener("foo", 30000, "http://:80", emptyCert)
+	var emptyCert, emptyHealthPath *string
+	l, err := newListener("foo", 30000, "http://:80", emptyCert, emptyHealthPath)
 	require.NoError(t, err)
 
 	require.Equal(t, loadbalancer.HTTP, l.protocol())
@@ -19,7 +19,7 @@ func TestListener(t *testing.T) {
 	require.Equal(t, "foo", l.Service)
 	require.Equal(t, HostNotSpecified, l.host())
 
-	l, err = newListener("foo", 30000, "http://", emptyCert)
+	l, err = newListener("foo", 30000, "http://", emptyCert, emptyHealthPath)
 	require.NoError(t, err)
 
 	require.Equal(t, loadbalancer.HTTP, l.protocol())
@@ -28,7 +28,7 @@ func TestListener(t *testing.T) {
 	require.Equal(t, "foo", l.Service)
 	require.Equal(t, HostNotSpecified, l.host())
 
-	l, err = newListener("foo", 30000, "http://localswarm:8080", emptyCert)
+	l, err = newListener("foo", 30000, "http://localswarm:8080", emptyCert, emptyHealthPath)
 	require.NoError(t, err)
 
 	require.Equal(t, loadbalancer.HTTP, l.protocol())
@@ -41,9 +41,11 @@ func TestListener(t *testing.T) {
 func TestListenerSSLCertNoPort(t *testing.T) {
 	var emptyCert *string
 	cert := "asn:blah"
+	healthPath := "/health"
+	healthPathPort := "/health@443"
 
 	// has cert and port is 443, so it should be SSL.
-	l, err := newListener("foo", 30000, "tcp://:443", &cert)
+	l, err := newListener("foo", 30000, "tcp://:443", &cert, &healthPathPort)
 	require.NoError(t, err)
 
 	require.Equal(t, loadbalancer.SSL, l.protocol())
@@ -56,10 +58,11 @@ func TestListenerSSLCertNoPort(t *testing.T) {
 	r := l.asRoute()
 	require.Equal(t, loadbalancer.SSL, r.Protocol)
 	require.Equal(t, &cert, r.Certificate)
+	require.Equal(t, &healthPath, r.HealthMonitorPath)
 
 	// has cert but since port wasn't specified, it defaults to 443
 	// since port isn't 443, then this is not SSL.
-	l, err = newListener("foo", 30000, "tcp://:444", &cert)
+	l, err = newListener("foo", 30000, "tcp://:444", &cert, &healthPathPort)
 	require.NoError(t, err)
 
 	require.Equal(t, loadbalancer.TCP, l.protocol())
@@ -73,9 +76,10 @@ func TestListenerSSLCertNoPort(t *testing.T) {
 	require.Equal(t, loadbalancer.TCP, r.Protocol)
 	require.Equal(t, loadbalancer.TCP, r.LoadBalancerProtocol)
 	require.Equal(t, (*string)(nil), r.Certificate)
+	require.Equal(t, (*string)(nil), r.HealthMonitorPath)
 
 	// no cert so not SSL.
-	l, err = newListener("foo", 30000, "tcp://:443", emptyCert)
+	l, err = newListener("foo", 30000, "tcp://:443", emptyCert, &healthPathPort)
 	require.NoError(t, err)
 
 	require.Equal(t, loadbalancer.TCP, l.protocol())
@@ -89,6 +93,7 @@ func TestListenerSSLCertNoPort(t *testing.T) {
 	require.Equal(t, loadbalancer.TCP, r.Protocol)
 	require.Equal(t, loadbalancer.TCP, r.LoadBalancerProtocol) // no cert
 	require.Equal(t, emptyCert, r.Certificate)
+	require.Equal(t, &healthPath, r.HealthMonitorPath)
 }
 
 func TestListenerSSLCertWithPorts(t *testing.T) {
@@ -99,9 +104,15 @@ func TestListenerSSLCertWithPorts(t *testing.T) {
 	certEmptyPorts := asn + "@"
 	certHTTPSPort := asn + "@HTTPS:443"
 	certHTTPSPortSSLPORT := asn + "@HTTPS:443,444"
+	healthPath := "/health"
+	healthPathPort1 := healthPath + "@443"
+	healthPathPort2 := healthPath + "@442"
+	healthPathPort3 := healthPath + "@444"
+	healthPathTwoPorts := healthPath + "@443,442"
+	healthPathEmptyPorts := healthPath + "@"
 
 	// has cert and port is 443, so it should be SSL.
-	l, err := newListener("foo", 30000, "tcp://:443", &certOnePort)
+	l, err := newListener("foo", 30000, "tcp://:443", &certOnePort, &healthPathPort1)
 	require.NoError(t, err)
 
 	require.Equal(t, loadbalancer.SSL, l.protocol())
@@ -115,9 +126,11 @@ func TestListenerSSLCertWithPorts(t *testing.T) {
 	require.Equal(t, loadbalancer.SSL, r.Protocol)
 	require.Equal(t, loadbalancer.SSL, r.LoadBalancerProtocol)
 	require.Equal(t, asn, *r.Certificate)
+	// Health port matches actual
+	require.Equal(t, &healthPath, r.HealthMonitorPath)
 
 	// has cert with port 442, this should be SSL.
-	l, err = newListener("foo", 30000, "tcp://:442", &certOnePort2)
+	l, err = newListener("foo", 30000, "tcp://:442", &certOnePort2, &healthPathPort2)
 	require.NoError(t, err)
 
 	require.Equal(t, loadbalancer.SSL, l.protocol())
@@ -130,9 +143,11 @@ func TestListenerSSLCertWithPorts(t *testing.T) {
 	r = l.asRoute()
 	require.Equal(t, loadbalancer.SSL, r.Protocol)
 	require.Equal(t, asn, *r.Certificate)
+	// Health port matches actual
+	require.Equal(t, &healthPath, r.HealthMonitorPath)
 
 	// cert has 2 ports, 442 is one of them, assume SSL
-	l, err = newListener("foo", 30000, "tcp://:442", &certTwoPorts)
+	l, err = newListener("foo", 30000, "tcp://:442", &certTwoPorts, &healthPathTwoPorts)
 	require.NoError(t, err)
 
 	require.Equal(t, loadbalancer.SSL, l.protocol())
@@ -145,9 +160,11 @@ func TestListenerSSLCertWithPorts(t *testing.T) {
 	r = l.asRoute()
 	require.Equal(t, loadbalancer.SSL, r.Protocol)
 	require.Equal(t, asn, *r.Certificate)
+	// Health port matches one of the ports
+	require.Equal(t, &healthPath, r.HealthMonitorPath)
 
 	// cert but no port, assume port 443, this is 442 so loadbalancer.TCP not SSL
-	l, err = newListener("foo", 30000, "tcp://:442", &certEmptyPorts)
+	l, err = newListener("foo", 30000, "tcp://:442", &certEmptyPorts, &healthPathEmptyPorts)
 	require.NoError(t, err)
 
 	require.Equal(t, loadbalancer.TCP, l.protocol())
@@ -160,9 +177,11 @@ func TestListenerSSLCertWithPorts(t *testing.T) {
 	r = l.asRoute()
 	require.Equal(t, loadbalancer.TCP, r.Protocol)
 	require.Equal(t, (*string)(nil), r.Certificate)
+	// Health port makes no assumptions, if no matches returns nothing
+	require.Equal(t, (*string)(nil), r.HealthMonitorPath)
 
 	// cert but no port, assume port 443
-	l, err = newListener("foo", 30000, "tcp://:443", &certEmptyPorts)
+	l, err = newListener("foo", 30000, "tcp://:443", &certEmptyPorts, &healthPathEmptyPorts)
 	require.NoError(t, err)
 
 	require.Equal(t, loadbalancer.SSL, l.protocol())
@@ -175,9 +194,11 @@ func TestListenerSSLCertWithPorts(t *testing.T) {
 	r = l.asRoute()
 	require.Equal(t, loadbalancer.SSL, r.Protocol)
 	require.Equal(t, asn, *r.Certificate)
+	// Health port makes no assumptions, if no matches returns nothing
+	require.Equal(t, (*string)(nil), r.HealthMonitorPath)
 
 	// cert but HTTPS port, verify it
-	l, err = newListener("foo", 30000, "tcp://:443", &certHTTPSPort)
+	l, err = newListener("foo", 30000, "tcp://:443", &certHTTPSPort, &healthPathPort1)
 	require.NoError(t, err)
 
 	require.Equal(t, loadbalancer.HTTP, l.protocol())
@@ -192,9 +213,10 @@ func TestListenerSSLCertWithPorts(t *testing.T) {
 	require.Equal(t, loadbalancer.HTTP, r.Protocol)
 	require.Equal(t, loadbalancer.HTTPS, r.LoadBalancerProtocol)
 	require.Equal(t, asn, *r.Certificate)
+	require.Equal(t, &healthPath, r.HealthMonitorPath)
 
 	// cert but HTTPS port and SSL port (no schema specified), verify SSL
-	l, err = newListener("foo", 30000, "tcp://:444", &certHTTPSPortSSLPORT)
+	l, err = newListener("foo", 30000, "tcp://:444", &certHTTPSPortSSLPORT, &healthPathPort3)
 	require.NoError(t, err)
 
 	require.Equal(t, loadbalancer.SSL, l.protocol())
@@ -207,9 +229,10 @@ func TestListenerSSLCertWithPorts(t *testing.T) {
 	r = l.asRoute()
 	require.Equal(t, loadbalancer.SSL, r.Protocol)
 	require.Equal(t, asn, *r.Certificate)
+	require.Equal(t, &healthPath, r.HealthMonitorPath)
 
 	// cert but HTTPS port and SSL port (no schema specified), verify unspecified port is TCP
-	l, err = newListener("foo", 30000, "tcp://:8080", &certHTTPSPortSSLPORT)
+	l, err = newListener("foo", 30000, "tcp://:8080", &certHTTPSPortSSLPORT, &healthPathPort1)
 	require.NoError(t, err)
 
 	require.Equal(t, loadbalancer.TCP, l.protocol())
@@ -222,6 +245,7 @@ func TestListenerSSLCertWithPorts(t *testing.T) {
 	r = l.asRoute()
 	require.Equal(t, loadbalancer.TCP, r.Protocol)
 	require.Equal(t, (*string)(nil), r.Certificate)
+	require.Equal(t, (*string)(nil), r.HealthMonitorPath)
 }
 
 func TestImpliedSwarmPortToUrl(t *testing.T) {
@@ -347,7 +371,7 @@ func TestListenersToPublishImplicitMapping(t *testing.T) {
 	s := swarm.Service{}
 	s.Spec.Name = "web1"
 
-	l := listenersFromLabel(s, LabelExternalLoadBalancerSpec, "")
+	l := listenersFromLabel(s, LabelExternalLoadBalancerSpec, "", "")
 	require.Equal(t, 0, len(l))
 	require.NotNil(t, l)
 
@@ -355,7 +379,7 @@ func TestListenersToPublishImplicitMapping(t *testing.T) {
 		LabelExternalLoadBalancerSpec: "http://:8080",
 	}
 	s.Endpoint.Ports = []swarm.PortConfig{} // no exposed ports
-	l = listenersFromLabel(s, LabelExternalLoadBalancerSpec, "")
+	l = listenersFromLabel(s, LabelExternalLoadBalancerSpec, "", "")
 	require.NotNil(t, l)
 	require.Equal(t, 1, len(l))
 	require.Equal(t, "web1", l[0].Service)
@@ -370,7 +394,7 @@ func TestListenersToPublishImplicitMapping(t *testing.T) {
 		LabelExternalLoadBalancerSpec: "http://",
 	}
 	s.Endpoint.Ports = []swarm.PortConfig{} // no exposed ports
-	l = listenersFromLabel(s, LabelExternalLoadBalancerSpec, "")
+	l = listenersFromLabel(s, LabelExternalLoadBalancerSpec, "", "")
 	require.NotNil(t, l)
 	require.Equal(t, 1, len(l))
 	require.Equal(t, "web1", l[0].Service)
@@ -385,7 +409,7 @@ func TestListenersToPublishImplicitMapping(t *testing.T) {
 		LabelExternalLoadBalancerSpec: "https://app1.domain.com",
 	}
 	s.Endpoint.Ports = []swarm.PortConfig{} // no exposed ports
-	l = listenersFromLabel(s, LabelExternalLoadBalancerSpec, "")
+	l = listenersFromLabel(s, LabelExternalLoadBalancerSpec, "", "")
 	require.NotNil(t, l)
 	require.Equal(t, 1, len(l))
 	require.Equal(t, "web1", l[0].Service)
@@ -400,7 +424,7 @@ func TestListenersToPublishImplicitMapping(t *testing.T) {
 		LabelExternalLoadBalancerSpec: "tcp://app1.domain.com:2375",
 	}
 	s.Endpoint.Ports = []swarm.PortConfig{} // no exposed ports
-	l = listenersFromLabel(s, LabelExternalLoadBalancerSpec, "")
+	l = listenersFromLabel(s, LabelExternalLoadBalancerSpec, "", "")
 	require.NotNil(t, l)
 	require.Equal(t, 1, len(l))
 	require.Equal(t, "web1", l[0].Service)
@@ -415,7 +439,7 @@ func TestListenersToPublishImplicitMapping(t *testing.T) {
 		LabelExternalLoadBalancerSpec: "tcp://app1.domain.com:2375, https://",
 	}
 	s.Endpoint.Ports = []swarm.PortConfig{} // no exposed ports
-	l = listenersFromLabel(s, LabelExternalLoadBalancerSpec, "")
+	l = listenersFromLabel(s, LabelExternalLoadBalancerSpec, "", "")
 	require.NotNil(t, l)
 	require.Equal(t, 2, len(l))
 	require.Equal(t, "web1", l[0].Service)
@@ -436,14 +460,14 @@ func TestListenersToPublishExplicitMapping(t *testing.T) {
 	s := swarm.Service{}
 	s.Spec.Name = "web1"
 
-	l := listenersFromLabel(s, LabelExternalLoadBalancerSpec, "")
+	l := listenersFromLabel(s, LabelExternalLoadBalancerSpec, "", "")
 	require.Equal(t, 0, len(l))
 	require.NotNil(t, l)
 
 	s.Spec.Labels = map[string]string{
 		LabelExternalLoadBalancerSpec: "30000=http://:8080",
 	}
-	l = listenersFromLabel(s, LabelExternalLoadBalancerSpec, "")
+	l = listenersFromLabel(s, LabelExternalLoadBalancerSpec, "", "")
 	require.NotNil(t, l)
 	require.Equal(t, 1, len(l))
 	require.Equal(t, "web1", l[0].Service)
@@ -456,7 +480,7 @@ func TestListenersToPublishExplicitMapping(t *testing.T) {
 	s.Spec.Labels = map[string]string{
 		LabelExternalLoadBalancerSpec: "30000=https://, 4040=tcp://foo.com:4040",
 	}
-	l = listenersFromLabel(s, LabelExternalLoadBalancerSpec, "")
+	l = listenersFromLabel(s, LabelExternalLoadBalancerSpec, "", "")
 	require.NotNil(t, l)
 	require.Equal(t, 2, len(l))
 	require.Equal(t, "web1", l[0].Service)
@@ -478,7 +502,7 @@ func TestListenersFromExposedPorts(t *testing.T) {
 	s := swarm.Service{}
 	s.Spec.Name = "web1"
 
-	l := listenersFromExposedPorts(s, "emptyLabel")
+	l := listenersFromExposedPorts(s, "emptyLabel", "emptyLabel")
 	require.Equal(t, 0, len(l))
 	require.NotNil(t, l)
 
@@ -507,7 +531,7 @@ func TestListenersFromExposedPorts(t *testing.T) {
 		},
 	}
 
-	l = listenersFromExposedPorts(s, "emptyLabel")
+	l = listenersFromExposedPorts(s, "emptyLabel", "emptyLabel")
 	require.Equal(t, 0, len(l))
 	require.NotNil(t, l)
 
@@ -540,7 +564,7 @@ func TestListenersFromExposedPorts(t *testing.T) {
 		},
 	}
 
-	l = listenersFromExposedPorts(s, "emptyLabel")
+	l = listenersFromExposedPorts(s, "emptyLabel", "emptyLabel")
 	require.Equal(t, 1, len(l))
 	require.NotNil(t, l)
 

--- a/pkg/controller/ingress/swarm/routes_test.go
+++ b/pkg/controller/ingress/swarm/routes_test.go
@@ -134,6 +134,8 @@ func TestRunRoutes(t *testing.T) {
 
 	certLabel := "certLabel"
 	certID := "certID"
+	healthLabel := "certLabel"
+	healthPath := "healthPath"
 
 	services := []swarm.Service{
 		{
@@ -143,6 +145,7 @@ func TestRunRoutes(t *testing.T) {
 					Labels: map[string]string{
 						"docker.editions.proxy.port": "80/http",
 						certLabel:                    certID,
+						healthLabel:                  healthPath,
 					},
 				},
 			},
@@ -168,6 +171,7 @@ func TestRunRoutes(t *testing.T) {
 
 	routes, err := NewServiceRoutes(client).
 		SetCertLabel(&certLabel).
+		SetHealthMonitorPathLabel(&healthLabel).
 		AddRule("proxy",
 
 			MatchSpecLabels(map[string]string{

--- a/pkg/controller/ingress/swarm/services.go
+++ b/pkg/controller/ingress/swarm/services.go
@@ -32,7 +32,7 @@ func toVhostRoutes(listeners map[string][]*listener) map[ingress.Vhost][]loadbal
 }
 
 func externalLoadBalancerListenersFromServices(services []swarm.Service,
-	matchByLabels bool, lbSpecLabel, certLabel string) map[string][]*listener {
+	matchByLabels bool, lbSpecLabel, certLabel, healthLabel string) map[string][]*listener {
 
 	// group the listeners by hostname.  hostname maps to a ELB somewhere else.
 	listeners := map[string][]*listener{}
@@ -47,7 +47,7 @@ func externalLoadBalancerListenersFromServices(services []swarm.Service,
 
 		if matchByLabels {
 			// Now go through the list that we need to publish and match up the exposed ports
-			for _, publish := range listenersFromLabel(s, lbSpecLabel, certLabel) {
+			for _, publish := range listenersFromLabel(s, lbSpecLabel, certLabel, healthLabel) {
 
 				if sp, has := exposedPorts[int(publish.SwarmPort)]; has {
 
@@ -79,7 +79,7 @@ func externalLoadBalancerListenersFromServices(services []swarm.Service,
 		}
 
 		// Publish all exposed is always on
-		for _, l := range listenersFromExposedPorts(s, certLabel) {
+		for _, l := range listenersFromExposedPorts(s, certLabel, healthLabel) {
 			addListenerToHostMap(listeners, l)
 		}
 

--- a/pkg/spi/loadbalancer/spi.go
+++ b/pkg/spi/loadbalancer/spi.go
@@ -30,6 +30,9 @@ type Route struct {
 
 	// Certificate is the certificate used by the load balancer.
 	Certificate *string
+
+	// HealthMonitorPath is the url path used by the route health monitor
+	HealthMonitorPath *string
 }
 
 // Validate validates the data herein. If necessary, some data values will be mutated as needed.


### PR DESCRIPTION
The ibmcloud provider load balancer requires support for a label to set the health monitor health check url.  This goes along with the existing support for certs when creating the route in the ibmcloud loadbalancer.  When an HTTP/HTTPS route is added, a health monitor with a default health check url of / is created.  If the service that publishes the port does not respond to the check on /, the route is disabled by the load balancer.  To allow setting the url, a label needs to be added.
Set `HealthMonitorPathLabel` in the yaml to the label you wish to use. ie:
```
RouteSources:
      swarm:
        Host: unix:///var/run/docker.sock
        CertificateLabel: lb-cert-label
        HealthMonitorPathLabel: lb-health-path
```
On the `docker service create`, specify the label:
```
docker service create --network ingress --name test-service --publish 4444:80 --publish 3333:25 --label lb-cert-label=my-cert@HTTPS:4444,HTTPS:3333 --label lb-health-path=/healthcheck@4444,/someother@3333 nginx
```
The format of the label is a comma separated list:
`<label>=<path>@<port>,<path>@<port>`
or
`<label>=<path>@<port1>,<port2>`
to apply the same path to multiple ports.