### PR TITLE
Group controller should not destroy the instance itself is running on

### DIFF
--- a/pkg/plugin/group/group.go
+++ b/pkg/plugin/group/group.go
@@ -36,8 +36,8 @@ type FlavorPluginLookup func(plugin_base.Name) (flavor.Plugin, error)
 // The LogicalID is optional.  It is set when we want to make sure a self-managing cluster manager
 // that is running this group plugin doesn't end up terminating itself during a rolling update.
 func NewGroupPlugin(
-	instancePlugins func(n plugin_base.Name) (instance.Plugin, error),
-	flavorPlugins func(n plugin_base.Name) (flavor.Plugin, error),
+	instancePlugins InstancePluginLookup,
+	flavorPlugins FlavorPluginLookup,
 	options group_types.Options) group.Plugin {
 
 	return &plugin{

--- a/pkg/plugin/group/group.go
+++ b/pkg/plugin/group/group.go
@@ -17,8 +17,9 @@ import (
 )
 
 const (
-	groupTag  = "infrakit.group"
-	configTag = "infrakit.config_sha"
+	groupTag     = "infrakit.group"
+	configTag    = "infrakit.config_sha"
+	logicalIDTag = "infrakit.logical_id"
 
 	debugV = logutil.V(300)
 )
@@ -32,22 +33,28 @@ type InstancePluginLookup func(plugin_base.Name) (instance.Plugin, error)
 type FlavorPluginLookup func(plugin_base.Name) (flavor.Plugin, error)
 
 // NewGroupPlugin creates a new group plugin.
+// The LogicalID is optional.  It is set when we want to make sure a self-managing cluster manager
+// that is running this group plugin doesn't end up terminating itself during a rolling update.
 func NewGroupPlugin(
-	instancePlugins InstancePluginLookup,
-	flavorPlugins FlavorPluginLookup,
-	pollInterval time.Duration,
-	maxParallelNum uint) group.Plugin {
+	instancePlugins func(n plugin_base.Name) (instance.Plugin, error),
+	flavorPlugins func(n plugin_base.Name) (flavor.Plugin, error),
+	options group_types.Options) group.Plugin {
 
 	return &plugin{
 		instancePlugins: instancePlugins,
 		flavorPlugins:   flavorPlugins,
-		pollInterval:    pollInterval,
-		maxParallelNum:  maxParallelNum,
+		options:         options,
+		pollInterval:    options.PollInterval.Duration(),
+		maxParallelNum:  options.MaxParallelNum,
 		groups:          groups{byID: map[group.ID]*groupContext{}},
+		self:            options.Self,
 	}
 }
 
 type plugin struct {
+	options group_types.Options
+
+	self            *instance.LogicalID
 	instancePlugins InstancePluginLookup
 	flavorPlugins   FlavorPluginLookup
 	pollInterval    time.Duration
@@ -64,6 +71,8 @@ func (p *plugin) CommitGroup(config group.Spec, pretend bool) (string, error) {
 	if err != nil {
 		return "", err
 	}
+
+	settings.self = p.self // need this logicalID of the running node to prevent destroying self.
 
 	log.Info("Committing", "groupID", config.ID, "pretend", pretend)
 

--- a/pkg/plugin/group/state.go
+++ b/pkg/plugin/group/state.go
@@ -22,6 +22,7 @@ type Supervisor interface {
 }
 
 type groupSettings struct {
+	self           *instance.LogicalID
 	instancePlugin instance.Plugin
 	flavorPlugin   flavor.Plugin
 	config         types.Spec

--- a/pkg/plugin/group/types/types.go
+++ b/pkg/plugin/group/types/types.go
@@ -10,12 +10,31 @@ import (
 	"github.com/docker/infrakit/pkg/plugin"
 	"github.com/docker/infrakit/pkg/run/depends"
 	"github.com/docker/infrakit/pkg/spi/group"
-	//	"github.com/docker/infrakit/pkg/spi/instance"
+	"github.com/docker/infrakit/pkg/spi/instance"
 	"github.com/docker/infrakit/pkg/types"
 )
 
 func init() {
 	depends.Register("group", types.InterfaceSpec(group.InterfaceSpec), ResolveDependencies)
+}
+
+// Options capture the options for starting up the group controller.
+type Options struct {
+
+	// Self is set when the controller is part of a group that can be updated.
+	Self *instance.LogicalID
+
+	// PollInterval is the frequency for syncing the state
+	PollInterval types.Duration
+
+	// MaxParallelNum is the max number of parallel instance operation. Default =0 (no limit)
+	MaxParallelNum uint
+
+	// PollIntervalGroupSpec polls for group spec at this interval to update the metadata paths
+	PollIntervalGroupSpec types.Duration
+
+	// PollIntervalGroupDetail polls for group details at this interval to update the metadata paths
+	PollIntervalGroupDetail types.Duration
 }
 
 // ResolveDependencies returns a list of dependencies by parsing the opaque Properties blob.

--- a/pkg/types/number.go
+++ b/pkg/types/number.go
@@ -1,0 +1,14 @@
+package types
+
+import (
+	"strconv"
+)
+
+// MustParseUint parses a string into an uint.  Panics if not correct format
+func MustParseUint(s string) uint {
+	v, err := strconv.Atoi(s)
+	if err != nil {
+		panic(err)
+	}
+	return uint(v)
+}


### PR DESCRIPTION
This PR is the first step in addressing #783 by making sure that the group controller doesn't destroy the instance it itself is running on during a rolling update.

  + The group controller can now start with an env variable (or set in Options) - `INFRAKIT_GROUP_SELF_LOGICAL_ID` that specifies the 'self' logical ID.  This logical ID is compared with the logical ID associated with a node during rolling update to prevent self-termination.
  + The self logical ID is optional.  If specified, the group controller will always put itself in the "desired" list of nodes, thus preventing a replacement via termination and re-provision.  This will allow rolling update code of other nodes to run to completion on this node, barring any outages.
  + Once the rolling update is complete, the leader will be asked to failover to a recently updated node.  This new leader will then detect that another node other itself is outdated and complete the rolling update by terminating and re-provisioning that node.  This leadership hand-off will be coordinated by the stack / manager as this mechanism is backend-specific.
  + Logical ID, if provided, will be written as a label now.
  + Small code refactor to move Options to the controller package.  (pkg/plugin/group/types)


Signed-off-by: David Chung <david.chung@docker.com>