### PR TITLE
Update the softlayer go version.

### DIFF
--- a/pkg/provider/ibmcloud/client/softlayerclient.go
+++ b/pkg/provider/ibmcloud/client/softlayerclient.go
@@ -14,7 +14,7 @@ type SoftlayerClient struct {
 // GetClient returns a SoftlayerClient instance
 func GetClient(user, apiKey string) *SoftlayerClient {
 	client := &SoftlayerClient{
-		sess: session.New(user, apiKey),
+		sess: session.New(user, apiKey).SetRetries(3),
 	}
 	return client
 }

--- a/pkg/provider/ibmcloud/plugin/loadbalancer/lb.go
+++ b/pkg/provider/ibmcloud/plugin/loadbalancer/lb.go
@@ -88,7 +88,7 @@ func NewIBMCloudLBPlugin(username, apikey, lbName, lbUUID string) (loadbalancer.
 	}
 
 	// Create the session object and get the services object once
-	lb.session = session.New(lb.softlayerUsername, lb.softlayerAPIKey, softLayerEndpointURL)
+	lb.session = session.New(lb.softlayerUsername, lb.softlayerAPIKey, softLayerEndpointURL).SetRetries(3)
 	lb.lbService = services.GetNetworkLBaaSLoadBalancerService(lb.session)
 	lb.certService = services.GetSecurityCertificateService(lb.session)
 	lb.lbListenerService = services.GetNetworkLBaaSListenerService(lb.session)

--- a/vendor.conf
+++ b/vendor.conf
@@ -108,7 +108,7 @@ github.com/rneugeba/iso9660wrap                         ecec696
 github.com/ryanuber/go-glob                             256dc444b735e061061cf46c809487313d5b0065
 github.com/satori/go.uuid                               v1.1.0
 github.com/sergi/go-diff/diffmatchpatch                 feef008
-github.com/softlayer/softlayer-go                       ba0eaed
+github.com/softlayer/softlayer-go                       879af59bc16beebd3caadd3b842c9b2d522a65a4
 github.com/spacemonkeygo/httpsig                        6732593
 github.com/spiegela/gorackhd                            de12976d778d18841ab3b16899af215fb277e96b
 github.com/spf13/afero                                  06b7e5f

--- a/vendor/github.com/softlayer/softlayer-go/README.md
+++ b/vendor/github.com/softlayer/softlayer-go/README.md
@@ -278,6 +278,16 @@ import "github.com/softlayer/softlayer-go/session"
 session.Logger = log.New(os.Stderr, "[CUSTOMIZED] ", log.LstdFlags)
 ```
 
+You can also tell the session to retry the api requests if there is a timeout error:
+
+```go
+// Specify how many times to retry the request, the request timeout, and how much time to wait
+// between retries.
+services.GetVirtualGuestService(
+	sess.SetTimeout(900).SetRetries(2).SetRetryWait(3)
+).GetObject(...)
+```
+
 ### Password-based authentication
 
 Password-based authentication (via requesting a token from the API) is

--- a/vendor/github.com/softlayer/softlayer-go/datatypes/account.go
+++ b/vendor/github.com/softlayer/softlayer-go/datatypes/account.go
@@ -245,8 +245,8 @@ type Account struct {
 	// Private template group objects (parent and children) and the shared template group objects (parent only) for an account.
 	BlockDeviceTemplateGroups []Virtual_Guest_Block_Device_Template_Group `json:"blockDeviceTemplateGroups,omitempty" xmlrpc:"blockDeviceTemplateGroups,omitempty"`
 
-	// This field is deprecated and should not be used.
-	BlueIdAuthenticationRequiredFlag *bool `json:"blueIdAuthenticationRequiredFlag,omitempty" xmlrpc:"blueIdAuthenticationRequiredFlag,omitempty"`
+	// The Bluemix account link associated with this SoftLayer account, if one exists.
+	BluemixAccountLink *Account_Link_Bluemix `json:"bluemixAccountLink,omitempty" xmlrpc:"bluemixAccountLink,omitempty"`
 
 	// Returns true if this account is linked to IBM Bluemix, false if not.
 	BluemixLinkedFlag *bool `json:"bluemixLinkedFlag,omitempty" xmlrpc:"bluemixLinkedFlag,omitempty"`
@@ -262,6 +262,9 @@ type Account struct {
 
 	// The brand keyName.
 	BrandKeyName *string `json:"brandKeyName,omitempty" xmlrpc:"brandKeyName,omitempty"`
+
+	// The Business Partner details for the account. Country Enterprise Code, Channel ID, and Segment ID.
+	BusinessPartner *Account_Partner_Business `json:"businessPartner,omitempty" xmlrpc:"businessPartner,omitempty"`
 
 	// Indicating whether this account can order additional Vlans.
 	CanOrderAdditionalVlansFlag *bool `json:"canOrderAdditionalVlansFlag,omitempty" xmlrpc:"canOrderAdditionalVlansFlag,omitempty"`
@@ -1091,6 +1094,9 @@ type Account struct {
 	// Indicates whether newly created users under this account will be associated with IBMid via an email requiring a response, or not.
 	RequireSilentIBMidUserCreation *bool `json:"requireSilentIBMidUserCreation,omitempty" xmlrpc:"requireSilentIBMidUserCreation,omitempty"`
 
+	// The Reseller level of the account.
+	ResellerLevel *int `json:"resellerLevel,omitempty" xmlrpc:"resellerLevel,omitempty"`
+
 	// A count of an account's associated top-level resource groups.
 	ResourceGroupCount *uint `json:"resourceGroupCount,omitempty" xmlrpc:"resourceGroupCount,omitempty"`
 
@@ -1888,6 +1894,11 @@ type Account_Historical_Report struct {
 }
 
 // no documentation yet
+type Account_Internal_Ibm struct {
+	Entity
+}
+
+// no documentation yet
 type Account_Link struct {
 	Entity
 
@@ -2310,6 +2321,23 @@ type Account_Note_Type struct {
 
 	// no documentation yet
 	ValueExpression *string `json:"valueExpression,omitempty" xmlrpc:"valueExpression,omitempty"`
+}
+
+// The SoftLayer_Account_Partner_Business data type contains specific information concerning an Account's relationship with Business Partner Data, in the form of the Account's Country Experience Identifier (CEID), Channel ID, and Segment ID.
+type Account_Partner_Business struct {
+	Entity
+
+	// The SoftLayer customer account associated with this business partner data.
+	Account *Account `json:"account,omitempty" xmlrpc:"account,omitempty"`
+
+	// The Channel ID associated with the Account.
+	ChannelId *int `json:"channelId,omitempty" xmlrpc:"channelId,omitempty"`
+
+	// The Country Enterprise Code associated with the Account.
+	CountryEnterpriseCode *string `json:"countryEnterpriseCode,omitempty" xmlrpc:"countryEnterpriseCode,omitempty"`
+
+	// The Segment ID associated with the Account.
+	SegmentId *int `json:"segmentId,omitempty" xmlrpc:"segmentId,omitempty"`
 }
 
 // no documentation yet

--- a/vendor/github.com/softlayer/softlayer-go/datatypes/billing.go
+++ b/vendor/github.com/softlayer/softlayer-go/datatypes/billing.go
@@ -1375,11 +1375,17 @@ type Billing_Item_Network_Firewall struct {
 // The SoftLayer_Billing_Item_Network_Firewall_Module_Context data type describes the billing items related to VLAN Firewalls.
 type Billing_Item_Network_Firewall_Module_Context struct {
 	Billing_Item
+
+	// The total public outbound bandwidth for this firewall for the current billing cycle.
+	BillingCyclePublicUsageOut *Float64 `json:"billingCyclePublicUsageOut,omitempty" xmlrpc:"billingCyclePublicUsageOut,omitempty"`
 }
 
 // A SoftLayer_Billing_Item_Network_Interconnect represents the [[SoftLayer_Billing_Item|billing item]] related to a network interconnect instance.
 type Billing_Item_Network_Interconnect struct {
 	Billing_Item
+
+	// The interconnect tenant that the billing item is associated with.
+	Resource *Network_Interconnect_Tenant `json:"resource,omitempty" xmlrpc:"resource,omitempty"`
 }
 
 // A SoftLayer_Billing_Item_Network_LoadBalancer represents the [[SoftLayer_Billing_Item|billing item]] related to a single [[SoftLayer_Network_LoadBalancer|load balancer]] instance.
@@ -1989,6 +1995,9 @@ type Billing_Order_Item struct {
 
 	// no documentation yet
 	ParentId *int `json:"parentId,omitempty" xmlrpc:"parentId,omitempty"`
+
+	// The SoftLayer_Product_Package_Preset related to this order item.
+	Preset *Product_Package_Preset `json:"preset,omitempty" xmlrpc:"preset,omitempty"`
 
 	// The id for the preset configuration ordered.
 	PresetId *int `json:"presetId,omitempty" xmlrpc:"presetId,omitempty"`

--- a/vendor/github.com/softlayer/softlayer-go/datatypes/configuration.go
+++ b/vendor/github.com/softlayer/softlayer-go/datatypes/configuration.go
@@ -112,11 +112,17 @@ type Configuration_Storage_Group_Order struct {
 type Configuration_Storage_Group_Template_Group struct {
 	Entity
 
+	// The disk controller for the array.
+	DiskControllerIndex *int `json:"diskControllerIndex,omitempty" xmlrpc:"diskControllerIndex,omitempty"`
+
 	// Flag to use all available space.
 	Grow *bool `json:"grow,omitempty" xmlrpc:"grow,omitempty"`
 
 	// Comma delimited integers of drive indexes for the array. This can also be the string 'all' to specify all drives in the server
 	HardDrivesString *string `json:"hardDrivesString,omitempty" xmlrpc:"hardDrivesString,omitempty"`
+
+	// Comma delimited integers of drive indexes for hot spares on the array.
+	HotSpareDrivesString *string `json:"hotSpareDrivesString,omitempty" xmlrpc:"hotSpareDrivesString,omitempty"`
 
 	// The order of the arrays in the template.
 	OrderIndex *int `json:"orderIndex,omitempty" xmlrpc:"orderIndex,omitempty"`

--- a/vendor/github.com/softlayer/softlayer-go/datatypes/container.go
+++ b/vendor/github.com/softlayer/softlayer-go/datatypes/container.go
@@ -186,6 +186,80 @@ type Container_Account_Historical_Summary_Uptime struct {
 	Container_Account_Historical_Summary
 }
 
+// Contains data required to both request a new IaaS account for active IBM employees and review pending requests. Fields used exclusively in the review process are scrubbed of user input.
+type Container_Account_Internal_Ibm_Request struct {
+	Entity
+
+	// Purpose of the internal IBM account chosen from the list of available
+	AccountType *string `json:"accountType,omitempty" xmlrpc:"accountType,omitempty"`
+
+	// If no address information is available in BluePages, will use this
+	Address1 *string `json:"address1,omitempty" xmlrpc:"address1,omitempty"`
+
+	// If no address information is available in BluePages, will use this
+	Address2 *string `json:"address2,omitempty" xmlrpc:"address2,omitempty"`
+
+	// If no address information is available in BluePages, will use this
+	City *string `json:"city,omitempty" xmlrpc:"city,omitempty"`
+
+	// Name of the company displayed on the IaaS account
+	CompanyName *string `json:"companyName,omitempty" xmlrpc:"companyName,omitempty"`
+
+	// If no address information is available in BluePages, will use this
+	Country *string `json:"country,omitempty" xmlrpc:"country,omitempty"`
+
+	// True if the request has been denied by either the IaaS team or the
+	DeniedFlag *bool `json:"deniedFlag,omitempty" xmlrpc:"deniedFlag,omitempty"`
+
+	// Department within the division which will be changed during cost recovery.
+	DepartmentCode *string `json:"departmentCode,omitempty" xmlrpc:"departmentCode,omitempty"`
+
+	// Division code used for cost recovery. This field is populated
+	DivisionCode *string `json:"divisionCode,omitempty" xmlrpc:"divisionCode,omitempty"`
+
+	// Country assigned to the division for cost recovery. This field is populated
+	DivisionCountry *string `json:"divisionCountry,omitempty" xmlrpc:"divisionCountry,omitempty"`
+
+	// Account owner's IBM email address. Must be a discoverable email
+	EmailAddress *string `json:"emailAddress,omitempty" xmlrpc:"emailAddress,omitempty"`
+
+	// Applicant's first name, as provided by IBM BluePages API.
+	FirstName *string `json:"firstName,omitempty" xmlrpc:"firstName,omitempty"`
+
+	// Applicant's last name, as provided by IBM BluePages API.
+	LastName *string `json:"lastName,omitempty" xmlrpc:"lastName,omitempty"`
+
+	// APPROVED if the request has been approved by the first-line manager,
+	ManagerApprovalStatus *string `json:"managerApprovalStatus,omitempty" xmlrpc:"managerApprovalStatus,omitempty"`
+
+	// True for accounts intended to be multi-tenant and false otherwise
+	MultiTenantFlag *bool `json:"multiTenantFlag,omitempty" xmlrpc:"multiTenantFlag,omitempty"`
+
+	// Account owner's primary phone number. If no phone number is available
+	OfficePhone *string `json:"officePhone,omitempty" xmlrpc:"officePhone,omitempty"`
+
+	// Bluemix PaaS 32 digit hexadecimal account id being automatically linked
+	PaasAccountId *string `json:"paasAccountId,omitempty" xmlrpc:"paasAccountId,omitempty"`
+
+	// If no address information is available in BluePages, will use this
+	PostalCode *string `json:"postalCode,omitempty" xmlrpc:"postalCode,omitempty"`
+
+	// Stated purpose of the new account this request would create
+	Purpose *string `json:"purpose,omitempty" xmlrpc:"purpose,omitempty"`
+
+	// Division's security SME's email address, if available
+	SecuritySubjectMatterExpertEmail *string `json:"securitySubjectMatterExpertEmail,omitempty" xmlrpc:"securitySubjectMatterExpertEmail,omitempty"`
+
+	// Division's security SME's name, if available
+	SecuritySubjectMatterExpertName *string `json:"securitySubjectMatterExpertName,omitempty" xmlrpc:"securitySubjectMatterExpertName,omitempty"`
+
+	// Division's security SME's phone, if available
+	SecuritySubjectMatterExpertPhone *string `json:"securitySubjectMatterExpertPhone,omitempty" xmlrpc:"securitySubjectMatterExpertPhone,omitempty"`
+
+	// If no address information is available in BluePages, will use this
+	State *string `json:"state,omitempty" xmlrpc:"state,omitempty"`
+}
+
 // no documentation yet
 type Container_Account_Payment_Method_CreditCard struct {
 	Entity
@@ -750,6 +824,17 @@ type Container_Collection_Locale_StateCode struct {
 	ShortName *string `json:"shortName,omitempty" xmlrpc:"shortName,omitempty"`
 }
 
+// This container is used to hold VAT information.
+type Container_Collection_Locale_VatCountryCodeAndFormat struct {
+	Entity
+
+	// no documentation yet
+	CountryCode *string `json:"countryCode,omitempty" xmlrpc:"countryCode,omitempty"`
+
+	// no documentation yet
+	Regex *string `json:"regex,omitempty" xmlrpc:"regex,omitempty"`
+}
+
 // no documentation yet
 type Container_Disk_Image_Capture_Template struct {
 	Entity
@@ -1234,6 +1319,12 @@ type Container_Hardware_Pool_Details struct {
 	Entity
 
 	// no documentation yet
+	PendingOrders *int `json:"pendingOrders,omitempty" xmlrpc:"pendingOrders,omitempty"`
+
+	// no documentation yet
+	PendingTransactions *int `json:"pendingTransactions,omitempty" xmlrpc:"pendingTransactions,omitempty"`
+
+	// no documentation yet
 	PoolDescription *string `json:"poolDescription,omitempty" xmlrpc:"poolDescription,omitempty"`
 
 	// no documentation yet
@@ -1264,6 +1355,9 @@ type Container_Hardware_Pool_Details struct {
 // no documentation yet
 type Container_Hardware_Pool_Details_Router struct {
 	Entity
+
+	// no documentation yet
+	PoolThreshold *int `json:"poolThreshold,omitempty" xmlrpc:"poolThreshold,omitempty"`
 
 	// no documentation yet
 	RouterId *int `json:"routerId,omitempty" xmlrpc:"routerId,omitempty"`
@@ -1600,6 +1694,9 @@ type Container_Network_CdnMarketplace_Configuration_Input struct {
 	BucketName *string `json:"bucketName,omitempty" xmlrpc:"bucketName,omitempty"`
 
 	// no documentation yet
+	CacheKeyQueryRule *string `json:"cacheKeyQueryRule,omitempty" xmlrpc:"cacheKeyQueryRule,omitempty"`
+
+	// no documentation yet
 	CertificateType *string `json:"certificateType,omitempty" xmlrpc:"certificateType,omitempty"`
 
 	// no documentation yet
@@ -1662,6 +1759,9 @@ type Container_Network_CdnMarketplace_Configuration_Mapping struct {
 	BucketName *string `json:"bucketName,omitempty" xmlrpc:"bucketName,omitempty"`
 
 	// no documentation yet
+	CacheKeyQueryRule *string `json:"cacheKeyQueryRule,omitempty" xmlrpc:"cacheKeyQueryRule,omitempty"`
+
+	// no documentation yet
 	CertificateType *string `json:"certificateType,omitempty" xmlrpc:"certificateType,omitempty"`
 
 	// no documentation yet
@@ -1721,7 +1821,13 @@ type Container_Network_CdnMarketplace_Configuration_Mapping_Path struct {
 	BucketName *string `json:"bucketName,omitempty" xmlrpc:"bucketName,omitempty"`
 
 	// no documentation yet
+	CacheKeyQueryRule *string `json:"cacheKeyQueryRule,omitempty" xmlrpc:"cacheKeyQueryRule,omitempty"`
+
+	// no documentation yet
 	FileExtension *string `json:"fileExtension,omitempty" xmlrpc:"fileExtension,omitempty"`
+
+	// no documentation yet
+	Header *string `json:"header,omitempty" xmlrpc:"header,omitempty"`
 
 	// no documentation yet
 	HttpPort *int `json:"httpPort,omitempty" xmlrpc:"httpPort,omitempty"`
@@ -1730,7 +1836,7 @@ type Container_Network_CdnMarketplace_Configuration_Mapping_Path struct {
 	HttpsPort *int `json:"httpsPort,omitempty" xmlrpc:"httpsPort,omitempty"`
 
 	// no documentation yet
-	MappingUniqueId *int `json:"mappingUniqueId,omitempty" xmlrpc:"mappingUniqueId,omitempty"`
+	MappingUniqueId *string `json:"mappingUniqueId,omitempty" xmlrpc:"mappingUniqueId,omitempty"`
 
 	// no documentation yet
 	Origin *string `json:"origin,omitempty" xmlrpc:"origin,omitempty"`
@@ -3054,7 +3160,7 @@ type Container_Product_Order struct {
 	// The URL to which PayPal redirects browser after checkout has been canceled before completion of a payment.
 	CancelUrl *string `json:"cancelUrl,omitempty" xmlrpc:"cancelUrl,omitempty"`
 
-	// Added by Gopherlayer. This hints to the API what kind of product order this is.
+	// Added by softlayer-go. This hints to the API what kind of product order this is.
 	ComplexType *string `json:"complexType,omitempty" xmlrpc:"complexType,omitempty"`
 
 	// User-specified description to identify a particular order container. This is useful if you have a multi-configuration order (multiple <code>orderContainers</code>) and you want to be able to easily determine one from another. Populating this value may be helpful if an exception is thrown when placing an order and it's tied to a specific order container.
@@ -3539,6 +3645,28 @@ type Container_Product_Order_Network_ContentDelivery_Account_Upgrade struct {
 	CdnAccountId *string `json:"cdnAccountId,omitempty" xmlrpc:"cdnAccountId,omitempty"`
 }
 
+// This is the datatype that needs to be populated and sent to SoftLayer_Product_Order::placeOrder. This datatype has everything required to place a CDN Service order with SoftLayer.
+type Container_Product_Order_Network_ContentDelivery_Service struct {
+	Container_Product_Order
+}
+
+// This is the datatype that needs to be populated and sent to SoftLayer_Product_Order::placeOrder when purchasing a Network Interconnect.
+type Container_Product_Order_Network_Interconnect struct {
+	Container_Product_Order
+
+	// The BGP ASN.
+	BgpAsn *string `json:"bgpAsn,omitempty" xmlrpc:"bgpAsn,omitempty"`
+
+	// The [[SoftLayer_Network_DirectLink_Location]] for this order, ID must be provided.
+	InterconnectLocation *Network_DirectLink_Location `json:"interconnectLocation,omitempty" xmlrpc:"interconnectLocation,omitempty"`
+
+	// A name to identify this Direct Link resource.
+	Name *string `json:"name,omitempty" xmlrpc:"name,omitempty"`
+
+	// Optional network identifier for this link.
+	NetworkIdentifier *string `json:"networkIdentifier,omitempty" xmlrpc:"networkIdentifier,omitempty"`
+}
+
 // This is the default container type for network load balancer orders.
 type Container_Product_Order_Network_LoadBalancer struct {
 	Container_Product_Order
@@ -3565,6 +3693,9 @@ type Container_Product_Order_Network_LoadBalancer_AsAService struct {
 
 	// The [[SoftLayer_Network_Subnet]]s where this Load Balancer will be provisioned.
 	Subnets []Network_Subnet `json:"subnets,omitempty" xmlrpc:"subnets,omitempty"`
+
+	// Specify if this load balancer uses system IP pool (true, default) or customer's (null|false) public subnet to allocate IP addresses.
+	UseSystemPublicIpPool *bool `json:"useSystemPublicIpPool,omitempty" xmlrpc:"useSystemPublicIpPool,omitempty"`
 }
 
 // This is the datatype that needs to be populated and sent to SoftLayer_Product_Order::placeOrder. This datatype has everything required to place a global load balancer order with SoftLayer.
@@ -3635,6 +3766,14 @@ type Container_Product_Order_Network_Protection_Firewall_Dedicated struct {
 
 	// generic properties.
 	VlanId *int `json:"vlanId,omitempty" xmlrpc:"vlanId,omitempty"`
+}
+
+// This is the datatype that needs to be populated and sent to SoftLayer_Product_Order::placeOrder. This datatype has everything required to place an order with SoftLayer.
+type Container_Product_Order_Network_Protection_Firewall_Dedicated_Upgrade struct {
+	Container_Product_Order_Network_Protection_Firewall_Dedicated
+
+	// no documentation yet
+	FirewallId *int `json:"firewallId,omitempty" xmlrpc:"firewallId,omitempty"`
 }
 
 // This is the datatype that needs to be populated and sent to SoftLayer_Product_Order::placeOrder. This datatype has everything required to place an order for Storage as a Service.
@@ -3753,19 +3892,28 @@ type Container_Product_Order_Network_Storage_MassDataMigration_Request struct {
 	// The shipping address city
 	City *string `json:"city,omitempty" xmlrpc:"city,omitempty"`
 
+	// Name of the company device is being shipped to
+	CompanyName *string `json:"companyName,omitempty" xmlrpc:"companyName,omitempty"`
+
 	// Cloud Object Storage Account ID for the data offload destination
 	CosAccountId *string `json:"cosAccountId,omitempty" xmlrpc:"cosAccountId,omitempty"`
 
 	// Cloud Object Storage Bucket for the data offload destination
 	CosBucketName *string `json:"cosBucketName,omitempty" xmlrpc:"cosBucketName,omitempty"`
 
-	// Default Gateway used for pre-provisioning the Eth3 port on the MDMS device
-	Eth3DefaultGateway *string `json:"eth3DefaultGateway,omitempty" xmlrpc:"eth3DefaultGateway,omitempty"`
+	// Default Gateway used for preconfiguring the Eth1 port on the MDMS device to access the user interface
+	Eth1DefaultGateway *string `json:"eth1DefaultGateway,omitempty" xmlrpc:"eth1DefaultGateway,omitempty"`
 
-	// Netmask used for pre-provisioning the Eth3 port on the MDMS device
+	// Netmask used for preconfiguring the Eth1 port on the MDMS device to access the user interface
+	Eth1Netmask *string `json:"eth1Netmask,omitempty" xmlrpc:"eth1Netmask,omitempty"`
+
+	// Static IP Address used for preconfiguring the Eth1 port on the MDMS device to access the user interface
+	Eth1StaticIp *string `json:"eth1StaticIp,omitempty" xmlrpc:"eth1StaticIp,omitempty"`
+
+	// Netmask used for preconfiguring the Eth3 port on the MDMS device to enable data transfer
 	Eth3Netmask *string `json:"eth3Netmask,omitempty" xmlrpc:"eth3Netmask,omitempty"`
 
-	// Static IP Address used for pre-provisioning the Eth3 port on the MDMS device
+	// Static IP Address used for preconfiguring the Eth3 port on the MDMS device to enable data transfer
 	Eth3StaticIp *string `json:"eth3StaticIp,omitempty" xmlrpc:"eth3StaticIp,omitempty"`
 
 	// The e-mails of the MDMS key contacts
@@ -3776,6 +3924,9 @@ type Container_Product_Order_Network_Storage_MassDataMigration_Request struct {
 
 	// The phone numbers of the MDMS key contacts
 	KeyContactPhoneNumbers []string `json:"keyContactPhoneNumbers,omitempty" xmlrpc:"keyContactPhoneNumbers,omitempty"`
+
+	// The roles of the MDMS key contacts
+	KeyContactRoles []string `json:"keyContactRoles,omitempty" xmlrpc:"keyContactRoles,omitempty"`
 
 	// The shipping address postal code
 	PostalCode *string `json:"postalCode,omitempty" xmlrpc:"postalCode,omitempty"`
@@ -4562,6 +4713,9 @@ type Container_User_Customer_External_Binding struct {
 	// The unique token that is created by an external authentication request.
 	AuthenticationToken *string `json:"authenticationToken,omitempty" xmlrpc:"authenticationToken,omitempty"`
 
+	// Added by softlayer-go. This hints to the API what kind of binding this is.
+	ComplexType *string `json:"complexType,omitempty" xmlrpc:"complexType,omitempty"`
+
 	// The OpenID Connect access token which provides access to a resource by the OpenID Connect provider.
 	OpenIdConnectAccessToken *string `json:"openIdConnectAccessToken,omitempty" xmlrpc:"openIdConnectAccessToken,omitempty"`
 
@@ -4573,6 +4727,12 @@ type Container_User_Customer_External_Binding struct {
 
 	// Your SoftLayer customer portal user's portal password.
 	Password *string `json:"password,omitempty" xmlrpc:"password,omitempty"`
+
+	// A second security code that is only required if your credential has become unsynchronized.
+	SecondSecurityCode *string `json:"secondSecurityCode,omitempty" xmlrpc:"secondSecurityCode,omitempty"`
+
+	// The security code used to validate a VeriSign credential.
+	SecurityCode *string `json:"securityCode,omitempty" xmlrpc:"securityCode,omitempty"`
 
 	// The answer to your security question.
 	SecurityQuestionAnswer *string `json:"securityQuestionAnswer,omitempty" xmlrpc:"securityQuestionAnswer,omitempty"`
@@ -5036,6 +5196,20 @@ type Container_Virtual_Guest_Configuration struct {
 
 	//
 	// <div style="width: 200%">
+	//
+	//
+	// Available flavor options.
+	//
+	//
+	// The <code>supplementalCreateObjectOptions.flavorKeyName</code> value in the template is an identifier for a particular core, ram, and primary disk configuration.
+	//
+	//
+	// When providing a <code>supplementalCreateObjectOptions.flavorKeyName</code> option the core, ram, and primary disk options are not needed. If those options are provided they are validated against the flavor.
+	// </div>
+	Flavors []Container_Virtual_Guest_Configuration_Option `json:"flavors,omitempty" xmlrpc:"flavors,omitempty"`
+
+	//
+	// <div style="width: 200%">
 	// Available memory options.
 	//
 	//
@@ -5078,18 +5252,6 @@ type Container_Virtual_Guest_Configuration struct {
 
 	//
 	// <div style="width: 200%">
-	// Available pre-defined configuration options.
-	//
-	//
-	// The <code>supplementalCreateObjectOptions.presetConfigurationKeyName</code> value in the template is an identifier for a particular pre-defined configuration. When provided exactly as shown in the template, that pre-defined configuration will be used.
-	//
-	//
-	// When providing a <code>supplementalCreateObjectOptions.presetConfigurationKeyName</code> option the other options relating to the configuration are still required and should be set according to the related pre-defined option.
-	// </div>
-	PresetConfigurations []Container_Virtual_Guest_Configuration_Option `json:"presetConfigurations,omitempty" xmlrpc:"presetConfigurations,omitempty"`
-
-	//
-	// <div style="width: 200%">
 	// Available processor options.
 	//
 	//
@@ -5104,12 +5266,12 @@ type Container_Virtual_Guest_Configuration_Option struct {
 	Entity
 
 	//
-	// Provides hourly and monthly costs (if either are applicable), and a description of the option.
-	ItemPrice *Product_Item_Price `json:"itemPrice,omitempty" xmlrpc:"itemPrice,omitempty"`
+	// Provides a description of a pre-defined configuration with monthly and hourly costs.
+	Flavor *Product_Package_Preset `json:"flavor,omitempty" xmlrpc:"flavor,omitempty"`
 
 	//
-	// Provides a description of a pre-defined configuration with monthly and hourly costs.
-	PresetConfiguration *Product_Package_Preset `json:"presetConfiguration,omitempty" xmlrpc:"presetConfiguration,omitempty"`
+	// Provides hourly and monthly costs (if either are applicable), and a description of the option.
+	ItemPrice *Product_Item_Price `json:"itemPrice,omitempty" xmlrpc:"itemPrice,omitempty"`
 
 	//
 	// Provides a fragment of the request with the properties and values that must be sent when creating a computing instance with the option.

--- a/vendor/github.com/softlayer/softlayer-go/datatypes/hardware.go
+++ b/vendor/github.com/softlayer/softlayer-go/datatypes/hardware.go
@@ -24,6 +24,9 @@ package datatypes
 type Hardware struct {
 	Entity
 
+	// Determine if hardware object has Software Guard Extension (SGX) enabled.
+	SGXEnabled *bool `json:"SGXEnabled,omitempty" xmlrpc:"SGXEnabled,omitempty"`
+
 	// The account associated with a piece of hardware.
 	Account *Account `json:"account,omitempty" xmlrpc:"account,omitempty"`
 
@@ -137,6 +140,9 @@ type Hardware struct {
 
 	// The name of the datacenter in which a piece of hardware resides.
 	DatacenterName *string `json:"datacenterName,omitempty" xmlrpc:"datacenterName,omitempty"`
+
+	// Number of day(s) a server have been in spare pool.
+	DaysInSparePool *int `json:"daysInSparePool,omitempty" xmlrpc:"daysInSparePool,omitempty"`
 
 	// A piece of hardware's local network domain name.
 	Domain *string `json:"domain,omitempty" xmlrpc:"domain,omitempty"`
@@ -738,6 +744,9 @@ type Hardware_Component struct {
 	// A count of a components sub components. Devices that are usually integrated or in some way attached to a component.
 	ChildrenCount *uint `json:"childrenCount,omitempty" xmlrpc:"childrenCount,omitempty"`
 
+	// A component's Revision.
+	ComponentRevision *string `json:"componentRevision,omitempty" xmlrpc:"componentRevision,omitempty"`
+
 	// A count of
 	DownlinkHardwareComponentCount *uint `json:"downlinkHardwareComponentCount,omitempty" xmlrpc:"downlinkHardwareComponentCount,omitempty"`
 
@@ -807,6 +816,9 @@ type Hardware_Component struct {
 	// A RAID controllers RAID mode.
 	RaidMode *string `json:"raidMode,omitempty" xmlrpc:"raidMode,omitempty"`
 
+	// The component revision designation.
+	Revision *Hardware_Component_Revision `json:"revision,omitempty" xmlrpc:"revision,omitempty"`
+
 	// The component serial number.
 	SerialNumber *string `json:"serialNumber,omitempty" xmlrpc:"serialNumber,omitempty"`
 
@@ -865,6 +877,75 @@ type Hardware_Component_DriveController struct {
 	Hardware_Component
 }
 
+// no documentation yet
+type Hardware_Component_Firmware struct {
+	Entity
+
+	// no documentation yet
+	BuildDate *Time `json:"buildDate,omitempty" xmlrpc:"buildDate,omitempty"`
+
+	// no documentation yet
+	CreateDate *Time `json:"createDate,omitempty" xmlrpc:"createDate,omitempty"`
+
+	// The Hardware Component Model this Firmware applies to.
+	HardwareComponentModel *Hardware_Component_Model `json:"hardwareComponentModel,omitempty" xmlrpc:"hardwareComponentModel,omitempty"`
+
+	// no documentation yet
+	HardwareComponentModelId *int `json:"hardwareComponentModelId,omitempty" xmlrpc:"hardwareComponentModelId,omitempty"`
+
+	// no documentation yet
+	Id *int `json:"id,omitempty" xmlrpc:"id,omitempty"`
+
+	// no documentation yet
+	IsQualified *int `json:"isQualified,omitempty" xmlrpc:"isQualified,omitempty"`
+
+	// no documentation yet
+	ReleaseNotes *string `json:"releaseNotes,omitempty" xmlrpc:"releaseNotes,omitempty"`
+
+	// no documentation yet
+	Version *string `json:"version,omitempty" xmlrpc:"version,omitempty"`
+}
+
+// The SoftLayer_Hardware_Component_Firmware_Attribute data type contains general information for a hardware model's firmware.
+type Hardware_Component_Firmware_Attribute struct {
+	Entity
+
+	// A hardware component firmware attribute's associated [[SoftLayer_Hardware_Component_Firmware|firmware]].
+	Firmware *Hardware_Component_Firmware `json:"firmware,omitempty" xmlrpc:"firmware,omitempty"`
+
+	// A hardware component firmware attribute's firmware Id.
+	FirmwareId *int `json:"firmwareId,omitempty" xmlrpc:"firmwareId,omitempty"`
+
+	// A hardware component firmware attribute's Id.
+	Id *int `json:"id,omitempty" xmlrpc:"id,omitempty"`
+
+	// A hardware component firmware attribute's associated [[SoftLayer_Hardware_Component_Firmware_Attribute_Type|type]].
+	Type *Hardware_Component_Firmware_Attribute_Type `json:"type,omitempty" xmlrpc:"type,omitempty"`
+
+	// A hardware component firmware attribute's type Id.
+	TypeId *int `json:"typeId,omitempty" xmlrpc:"typeId,omitempty"`
+
+	// A hardware component firmware attribute's value.
+	Value *string `json:"value,omitempty" xmlrpc:"value,omitempty"`
+}
+
+// The SoftLayer_Hardware_Component_Firmware_Attribute_Type data type defines attribute types for a hardware component model's firmware.
+type Hardware_Component_Firmware_Attribute_Type struct {
+	Entity
+
+	// The description for the date that a hardware component attribute type's [[SoftLayer_Hardware_Component_Attribute|Attribute]] contains.
+	Description *string `json:"description,omitempty" xmlrpc:"description,omitempty"`
+
+	// A hardware component firmware attribute type's Id.
+	Id *int `json:"id,omitempty" xmlrpc:"id,omitempty"`
+
+	// A hardware component firmware attribute type's unique name.
+	KeyName *string `json:"keyName,omitempty" xmlrpc:"keyName,omitempty"`
+
+	// A hardware component firmware attribute type's name.
+	Name *string `json:"name,omitempty" xmlrpc:"name,omitempty"`
+}
+
 // The SoftLayer_Hardware_Component_HardDrive data type abstracts information related to a hard drive.
 type Hardware_Component_HardDrive struct {
 	Hardware_Component
@@ -915,6 +996,15 @@ type Hardware_Component_Model struct {
 
 	// A colon delimited list of hardware component model attributes.
 	Description *string `json:"description,omitempty" xmlrpc:"description,omitempty"`
+
+	// A count of
+	FirmwareCount *uint `json:"firmwareCount,omitempty" xmlrpc:"firmwareCount,omitempty"`
+
+	// no documentation yet
+	FirmwareQuantity *uint `json:"firmwareQuantity,omitempty" xmlrpc:"firmwareQuantity,omitempty"`
+
+	// no documentation yet
+	Firmwares []Hardware_Component_Firmware `json:"firmwares,omitempty" xmlrpc:"firmwares,omitempty"`
 
 	// A hardware component model's physical components in inventory.
 	HardwareComponents []Hardware_Component `json:"hardwareComponents,omitempty" xmlrpc:"hardwareComponents,omitempty"`
@@ -1307,6 +1397,32 @@ type Hardware_Component_RemoteManagement_User struct {
 
 	// The username used for this remote management command.
 	Username *string `json:"username,omitempty" xmlrpc:"username,omitempty"`
+}
+
+// no documentation yet
+type Hardware_Component_Revision struct {
+	Entity
+
+	// The firmware build date
+	BiosDate *Time `json:"biosDate,omitempty" xmlrpc:"biosDate,omitempty"`
+
+	// The Firmware installed on this record's Hardware Component.
+	Firmware *Hardware_Component_Firmware `json:"firmware,omitempty" xmlrpc:"firmware,omitempty"`
+
+	// no documentation yet
+	FirmwareVersionId *int `json:"firmwareVersionId,omitempty" xmlrpc:"firmwareVersionId,omitempty"`
+
+	// The Hardware Component this revision record applies to.
+	HardwareComponent *Hardware_Component `json:"hardwareComponent,omitempty" xmlrpc:"hardwareComponent,omitempty"`
+
+	// no documentation yet
+	HardwareComponentId *int `json:"hardwareComponentId,omitempty" xmlrpc:"hardwareComponentId,omitempty"`
+
+	// no documentation yet
+	Id *int `json:"id,omitempty" xmlrpc:"id,omitempty"`
+
+	// The firmware revision
+	Revision *string `json:"revision,omitempty" xmlrpc:"revision,omitempty"`
 }
 
 // The SoftLayer_Hardware_Component_SecurityDevice is used to determine the security devices attached to the hardware component.

--- a/vendor/github.com/softlayer/softlayer-go/datatypes/locale.go
+++ b/vendor/github.com/softlayer/softlayer-go/datatypes/locale.go
@@ -64,6 +64,9 @@ type Locale_Country struct {
 
 	// States that belong to this country.
 	States []Locale_StateProvince `json:"states,omitempty" xmlrpc:"states,omitempty"`
+
+	// no documentation yet
+	VatIdRegex *string `json:"vatIdRegex,omitempty" xmlrpc:"vatIdRegex,omitempty"`
 }
 
 // This object represents a state or province for a country.

--- a/vendor/github.com/softlayer/softlayer-go/datatypes/network.go
+++ b/vendor/github.com/softlayer/softlayer-go/datatypes/network.go
@@ -1003,6 +1003,12 @@ type Network_Bandwidth_Version1_Usage_Detail_Type struct {
 // The SoftLayer_Network_CdnMarketplace_Account data type models an individual CDN account. CDN accounts contain the SoftLayer account ID of the customer, the vendor ID the account belongs to, the customer ID provided by the vendor, and a CDN account's status.
 type Network_CdnMarketplace_Account struct {
 	Entity
+
+	// SoftLayer account to which the CDN account belongs.
+	Account *Account `json:"account,omitempty" xmlrpc:"account,omitempty"`
+
+	// An associated parent billing item which is active.
+	BillingItem *Billing_Item `json:"billingItem,omitempty" xmlrpc:"billingItem,omitempty"`
 }
 
 // This data type models a purge event that occurs in caching server. It contains a reference to a mapping configuration, the path to execute the purge on, the status of the purge, and flag that enables saving the purge information for future use.
@@ -1016,15 +1022,6 @@ type Network_CdnMarketplace_Configuration_Cache_TimeToLive struct {
 
 	// date record is created
 	CreateDate *Time `json:"createDate,omitempty" xmlrpc:"createDate,omitempty"`
-
-	// id of TTL record
-	Id *int `json:"id,omitempty" xmlrpc:"id,omitempty"`
-
-	// id of mapping record the TTL references
-	MappingId *int `json:"mappingId,omitempty" xmlrpc:"mappingId,omitempty"`
-
-	// last date method is modified
-	ModifyDate *Time `json:"modifyDate,omitempty" xmlrpc:"modifyDate,omitempty"`
 
 	// Path where purge will be executed after TTL
 	Path *string `json:"path,omitempty" xmlrpc:"path,omitempty"`
@@ -1581,6 +1578,43 @@ type Network_Customer_Subnet_IpAddress struct {
 	Translations []Network_Tunnel_Module_Context_Address_Translation `json:"translations,omitempty" xmlrpc:"translations,omitempty"`
 }
 
+// The SoftLayer_Network_DirectLink_CloudExchangeProvider presents a structure containing attributes of a Direct Link Cloud exchange provider.
+type Network_DirectLink_CloudExchangeProvider struct {
+	Entity
+
+	// no documentation yet
+	Id *int `json:"id,omitempty" xmlrpc:"id,omitempty"`
+
+	// no documentation yet
+	Name *string `json:"name,omitempty" xmlrpc:"name,omitempty"`
+}
+
+// The SoftLayer_Network_DirectLink_Location presents a structure containing attributes of a Direct Link location, and its related object SoftLayer location.
+type Network_DirectLink_Location struct {
+	Entity
+
+	// The Direct Link specific location owner for POP/DC facilities. Like Equinix, Pacnet, Verizon etc.
+	BuildingColocationOwner *string `json:"buildingColocationOwner,omitempty" xmlrpc:"buildingColocationOwner,omitempty"`
+
+	// The Id of Direct Link cloud exchange provider.
+	CloudExchangeProvider *Network_DirectLink_CloudExchangeProvider `json:"cloudExchangeProvider,omitempty" xmlrpc:"cloudExchangeProvider,omitempty"`
+
+	// The unique identifier of a Direct Link location.
+	Id *int `json:"id,omitempty" xmlrpc:"id,omitempty"`
+
+	// Specifies if The Direct Link specific location has Redundancy:secondary XCR availability.
+	IsRedundantXcr *bool `json:"isRedundantXcr,omitempty" xmlrpc:"isRedundantXcr,omitempty"`
+
+	// The location of Direct Link facility.
+	Location *Location `json:"location,omitempty" xmlrpc:"location,omitempty"`
+
+	// The Direct Link specific location ie. Data Center & Network POP facility. Refer to location object Like Dallas in US, London in England etc.
+	LocationId *int `json:"locationId,omitempty" xmlrpc:"locationId,omitempty"`
+
+	// The Direct Link Market location used in Direct Link Order. Like Europe, North America, Asia pacific etc.
+	MarketGeography *string `json:"marketGeography,omitempty" xmlrpc:"marketGeography,omitempty"`
+}
+
 // The SoftLayer_Network_Firewall_AccessControlList data type contains general information relating to a single SoftLayer firewall access to controll list. This is the object which ties the running rules to a specific context. Use the [[SoftLayer Network Firewall Template]] service to pull SoftLayer recommended rule set templates. Use the [[SoftLayer Network Firewall Update Request]] service to submit a firewall update request.
 type Network_Firewall_AccessControlList struct {
 	Entity
@@ -1850,6 +1884,9 @@ type Network_Gateway struct {
 	// The firewall associated with this gateway, if any.
 	NetworkFirewall *Network_Vlan_Firewall `json:"networkFirewall,omitempty" xmlrpc:"networkFirewall,omitempty"`
 
+	// Whether or not there is a firewall associated with this gateway.
+	NetworkFirewallFlag *bool `json:"networkFirewallFlag,omitempty" xmlrpc:"networkFirewallFlag,omitempty"`
+
 	// A gateway's network space. Currently, only 'private'  or 'both' is allowed. When this value is 'private', it is a backend gateway only. Otherwise, it is a gateway for both frontend and backend traffic.
 	NetworkSpace *string `json:"networkSpace,omitempty" xmlrpc:"networkSpace,omitempty"`
 
@@ -1953,12 +1990,80 @@ type Network_Gateway_Vlan struct {
 	NetworkVlanId *int `json:"networkVlanId,omitempty" xmlrpc:"networkVlanId,omitempty"`
 }
 
+// no documentation yet
+type Network_Interconnect_Tenant struct {
+	Entity
+
+	// Specifies ASN used for BGP.
+	BgpAsn *int `json:"bgpAsn,omitempty" xmlrpc:"bgpAsn,omitempty"`
+
+	// The billing item for a network interconnect.
+	BillingItem *Billing_Item_Network_Interconnect `json:"billingItem,omitempty" xmlrpc:"billingItem,omitempty"`
+
+	// no documentation yet
+	CreateDate *Time `json:"createDate,omitempty" xmlrpc:"createDate,omitempty"`
+
+	// no documentation yet
+	DatacenterName *string `json:"datacenterName,omitempty" xmlrpc:"datacenterName,omitempty"`
+
+	// no documentation yet
+	ErrorMessage *string `json:"errorMessage,omitempty" xmlrpc:"errorMessage,omitempty"`
+
+	// The Direct Link connectivity to all SoftLayer data centers if globalRoutingFlag = 1 and local connectivity if globalRoutingFlag = 0.
+	GlobalRoutingFlag *bool `json:"globalRoutingFlag,omitempty" xmlrpc:"globalRoutingFlag,omitempty"`
+
+	// no documentation yet
+	Id *int `json:"id,omitempty" xmlrpc:"id,omitempty"`
+
+	// Link speed of a Direct Link connection.
+	LinkSpeed *int `json:"linkSpeed,omitempty" xmlrpc:"linkSpeed,omitempty"`
+
+	// IP address (v4 or v6) of "near" router serial interface. No check/update of IP Address table.
+	LocalIpAddress *string `json:"localIpAddress,omitempty" xmlrpc:"localIpAddress,omitempty"`
+
+	// no documentation yet
+	ModifyDate *Time `json:"modifyDate,omitempty" xmlrpc:"modifyDate,omitempty"`
+
+	// Specifies the Interconnect connection name.
+	Name *string `json:"name,omitempty" xmlrpc:"name,omitempty"`
+
+	// This field will have the ticket id if the tenant workflow fails
+	Note *string `json:"note,omitempty" xmlrpc:"note,omitempty"`
+
+	// Link speed of a Direct Link connection on Equinix Side.
+	PeerLinkSpeed *int `json:"peerLinkSpeed,omitempty" xmlrpc:"peerLinkSpeed,omitempty"`
+
+	// Specifies redundant connection is available if 1.
+	RedundancyFlag *bool `json:"redundancyFlag,omitempty" xmlrpc:"redundancyFlag,omitempty"`
+
+	// no documentation yet
+	RemoteIpAddress *string `json:"remoteIpAddress,omitempty" xmlrpc:"remoteIpAddress,omitempty"`
+
+	// Service key for Interconnect connection.
+	ServiceKey *string `json:"serviceKey,omitempty" xmlrpc:"serviceKey,omitempty"`
+
+	// The direct link connection status. IN_PROGRESS, PROVISIONING, CONNECTION_UP, CONNECTION_DOWN
+	Status *string `json:"status,omitempty" xmlrpc:"status,omitempty"`
+
+	// no documentation yet
+	VendorName *string `json:"vendorName,omitempty" xmlrpc:"vendorName,omitempty"`
+
+	// no documentation yet
+	VlanId *int `json:"vlanId,omitempty" xmlrpc:"vlanId,omitempty"`
+
+	// no documentation yet
+	ZoneName *string `json:"zoneName,omitempty" xmlrpc:"zoneName,omitempty"`
+}
+
 // The SoftLayer_Network_LBaaS_HealthMonitor type presents a structure containing attributes of a health monitor object associated with load balancer instance. Note that the relationship between backend (pool) and health monitor is N-to-1, especially that the pools object associated with a health monitor must have the same pair of protocol and port. Example: frontend FA: http, 80   - backend BA: tcp, 3456 - healthmonitor HM_tcp3456 frontend FB: https, 443 - backend BB: tcp, 3456 - healthmonitor HM_tcp3456 In above example both backends BA and BB share the same healthmonitor HM_tcp3456
 type Network_LBaaS_HealthMonitor struct {
 	Entity
 
 	// no documentation yet
 	CreateDate *Time `json:"createDate,omitempty" xmlrpc:"createDate,omitempty"`
+
+	// no documentation yet
+	Id *int `json:"id,omitempty" xmlrpc:"id,omitempty"`
 
 	// no documentation yet
 	Interval *int `json:"interval,omitempty" xmlrpc:"interval,omitempty"`
@@ -1997,6 +2102,9 @@ type Network_LBaaS_Listener struct {
 
 	// no documentation yet
 	DefaultPool *Network_LBaaS_Pool `json:"defaultPool,omitempty" xmlrpc:"defaultPool,omitempty"`
+
+	// no documentation yet
+	Id *int `json:"id,omitempty" xmlrpc:"id,omitempty"`
 
 	// Specifies when the listener was updated previously.
 	ModifyDate *Time `json:"modifyDate,omitempty" xmlrpc:"modifyDate,omitempty"`
@@ -2043,7 +2151,7 @@ type Network_LBaaS_LoadBalancer struct {
 	HealthMonitors []Network_LBaaS_HealthMonitor `json:"healthMonitors,omitempty" xmlrpc:"healthMonitors,omitempty"`
 
 	// no documentation yet
-	IpAddress *Network_Subnet_IpAddress `json:"ipAddress,omitempty" xmlrpc:"ipAddress,omitempty"`
+	Id *int `json:"id,omitempty" xmlrpc:"id,omitempty"`
 
 	// Specifies if a load balancer is public=1 or private=0.
 	IsPublic *int `json:"isPublic,omitempty" xmlrpc:"isPublic,omitempty"`
@@ -2077,6 +2185,9 @@ type Network_LBaaS_LoadBalancer struct {
 
 	// The provisioning status of a load balancer.
 	ProvisioningStatus *string `json:"provisioningStatus,omitempty" xmlrpc:"provisioningStatus,omitempty"`
+
+	// Specifies if a load balancer is using
+	UseSystemPublicIpPool *int `json:"useSystemPublicIpPool,omitempty" xmlrpc:"useSystemPublicIpPool,omitempty"`
 
 	// The UUID of a load balancer.
 	Uuid *string `json:"uuid,omitempty" xmlrpc:"uuid,omitempty"`
@@ -2154,9 +2265,15 @@ type Network_LBaaS_LoadBalancerServerInstanceInfo struct {
 	Weight *int `json:"weight,omitempty" xmlrpc:"weight,omitempty"`
 }
 
-// SoftLayer_Network_LBaaS_LoadBalancerStatistics is a collection of metrics retrieved from a load balancer instance. The available metrics are: <ul> <li>Total number of current sessions</li> <li>Total number of error requests</li> <li>Total number of received packets</li> <li>Total number of transmitted packets</li> <li>Total number of accepted/alive connections</li> <li>Request rate</li> <li>Number of members down</li> <li>NUmber of members up</li> <li>Throughput</li> <li>Connection rate</li> </ul>
+// SoftLayer_Network_LBaaS_LoadBalancerStatistics is a collection of metrics retrieved from a load balancer instance. The available metrics are: <ul> <li>NUmber of members up</li> <li>Number of members down</li> <li>Total number of active connections</li> <li>Throughput</li> <li>Data processed by month</li> <li>Connection rate</li> </ul>
 type Network_LBaaS_LoadBalancerStatistics struct {
 	Entity
+
+	// Number of connections seen at the
+	ConnectionRate *int `json:"connectionRate,omitempty" xmlrpc:"connectionRate,omitempty"`
+
+	// Data processed by month is the total of bin and bout
+	DataProcessedByMonth *int `json:"dataProcessedByMonth,omitempty" xmlrpc:"dataProcessedByMonth,omitempty"`
 
 	// Number of members in DOWN health state
 	NumberOfMembersDown *int `json:"numberOfMembersDown,omitempty" xmlrpc:"numberOfMembersDown,omitempty"`
@@ -2164,11 +2281,11 @@ type Network_LBaaS_LoadBalancerStatistics struct {
 	// Number of members in UP health state
 	NumberOfMembersUp *int `json:"numberOfMembersUp,omitempty" xmlrpc:"numberOfMembersUp,omitempty"`
 
-	// Number of total established connections
-	TotalConnections *int `json:"totalConnections,omitempty" xmlrpc:"totalConnections,omitempty"`
+	// Throughput measures the total number of bits
+	Throughput *Float64 `json:"throughput,omitempty" xmlrpc:"throughput,omitempty"`
 
-	// Number of total current sessions
-	TotalCurrentSessions *int `json:"totalCurrentSessions,omitempty" xmlrpc:"totalCurrentSessions,omitempty"`
+	// Number of total active established connections
+	TotalConnections *int `json:"totalConnections,omitempty" xmlrpc:"totalConnections,omitempty"`
 }
 
 // The SoftLayer_Network_LBaaS_Member represents the backend member for a load balancer. It can be either a virtual server or a bare metal machine.
@@ -2180,6 +2297,9 @@ type Network_LBaaS_Member struct {
 
 	// Specifies when a load balancers
 	CreateDate *Time `json:"createDate,omitempty" xmlrpc:"createDate,omitempty"`
+
+	// no documentation yet
+	Id *int `json:"id,omitempty" xmlrpc:"id,omitempty"`
 
 	// Specifies when a load balancers
 	ModifyDate *Time `json:"modifyDate,omitempty" xmlrpc:"modifyDate,omitempty"`
@@ -3037,8 +3157,6 @@ type Network_Regional_Internet_Registry struct {
 	Name *string `json:"name,omitempty" xmlrpc:"name,omitempty"`
 }
 
-// This is a Beta release of the Security Group feature. The use of this feature is restricted to select users. When the Beta period is over, security groups will be available for all users. Contact sgbeta@us.ibm.com using 'Security Groups' in the subject line with any questions.
-//
 // The SoftLayer_Network_SecurityGroup data type contains general information for a single security group. A security group contains a set of IP filter [[SoftLayer_Network_SecurityGroup_Rule (type)|rules]] that define how to handle incoming (ingress) and outgoing (egress) traffic to both the public and private interfaces of a virtual server instance and a set of [[SoftLayer_Virtual_Network_SecurityGroup_NetworkComponentBinding (type)|bindings]] to associate virtual guest network components with the security group.
 type Network_SecurityGroup struct {
 	Entity
@@ -3087,6 +3205,9 @@ type Network_SecurityGroup_OrderBinding struct {
 	// The unique ID for a security group, order, binding
 	Id *int `json:"id,omitempty" xmlrpc:"id,omitempty"`
 
+	// The order associated with the binding
+	Order *Billing_Order `json:"order,omitempty" xmlrpc:"order,omitempty"`
+
 	// The ID of the order associated with the security group.
 	OrderId *int `json:"orderId,omitempty" xmlrpc:"orderId,omitempty"`
 
@@ -3095,6 +3216,14 @@ type Network_SecurityGroup_OrderBinding struct {
 
 	// The ID of the security group that is associated with the order.
 	SecurityGroupId *int `json:"securityGroupId,omitempty" xmlrpc:"securityGroupId,omitempty"`
+}
+
+// The SoftLayer_Network_SecurityGroup_Request data type contains the ID of a specific request sent to the API. This ID is used to identify specific calls to attach and detach network components, as well as add, edit, and remove security group rules.
+type Network_SecurityGroup_Request struct {
+	Entity
+
+	// The unique ID for a request.
+	Id *string `json:"id,omitempty" xmlrpc:"id,omitempty"`
 }
 
 // The SoftLayer_Network_SecurityGroup_Rule data type contains general information for a single rule that belongs to a [[SoftLayer_Network_SecurityGroup|security group]]. By default, all traffic (both inbound and  outbound) to a virtual server instance is blocked. Security group rules are permissive, and define the allowed incoming (ingress) and outgoing (egress) traffic to both the public and private interfaces of a  virtual server instance. The order of rules within a security group does not matter and priority always falls to the least restrictive rule.
@@ -3761,11 +3890,17 @@ type Network_Storage_Allowed_Host struct {
 
 	// no documentation yet
 	ResourceTableName *string `json:"resourceTableName,omitempty" xmlrpc:"resourceTableName,omitempty"`
+
+	// Connections to a target with a source IP in this subnet prefix are allowed.
+	SourceSubnet *string `json:"sourceSubnet,omitempty" xmlrpc:"sourceSubnet,omitempty"`
 }
 
 // no documentation yet
 type Network_Storage_Allowed_Host_Hardware struct {
 	Network_Storage_Allowed_Host
+
+	// The SoftLayer_Account object which this SoftLayer_Network_Storage_Allowed_Host belongs to.
+	Account *Account `json:"account,omitempty" xmlrpc:"account,omitempty"`
 
 	// The SoftLayer_Hardware object which this SoftLayer_Network_Storage_Allowed_Host is referencing.
 	Resource *Hardware `json:"resource,omitempty" xmlrpc:"resource,omitempty"`
@@ -3775,6 +3910,9 @@ type Network_Storage_Allowed_Host_Hardware struct {
 type Network_Storage_Allowed_Host_IpAddress struct {
 	Network_Storage_Allowed_Host
 
+	// The SoftLayer_Account object which this SoftLayer_Network_Storage_Allowed_Host belongs to.
+	Account *Account `json:"account,omitempty" xmlrpc:"account,omitempty"`
+
 	// The SoftLayer_Network_Subnet_IpAddress object which this SoftLayer_Network_Storage_Allowed_Host is referencing.
 	Resource *Network_Subnet_IpAddress `json:"resource,omitempty" xmlrpc:"resource,omitempty"`
 }
@@ -3783,6 +3921,9 @@ type Network_Storage_Allowed_Host_IpAddress struct {
 type Network_Storage_Allowed_Host_Subnet struct {
 	Network_Storage_Allowed_Host
 
+	// The SoftLayer_Account object which this SoftLayer_Network_Storage_Allowed_Host belongs to.
+	Account *Account `json:"account,omitempty" xmlrpc:"account,omitempty"`
+
 	// The SoftLayer_Network_Subnet object which this SoftLayer_Network_Storage_Allowed_Host is referencing.
 	Resource *Network_Subnet `json:"resource,omitempty" xmlrpc:"resource,omitempty"`
 }
@@ -3790,6 +3931,9 @@ type Network_Storage_Allowed_Host_Subnet struct {
 // no documentation yet
 type Network_Storage_Allowed_Host_VirtualGuest struct {
 	Network_Storage_Allowed_Host
+
+	// The SoftLayer_Account object which this SoftLayer_Network_Storage_Allowed_Host belongs to.
+	Account *Account `json:"account,omitempty" xmlrpc:"account,omitempty"`
 
 	// The SoftLayer_Virtual_Guest object which this SoftLayer_Network_Storage_Allowed_Host is referencing.
 	Resource *Virtual_Guest `json:"resource,omitempty" xmlrpc:"resource,omitempty"`
@@ -4188,6 +4332,214 @@ type Network_Storage_Iscsi_OS_Type struct {
 	Name *string `json:"name,omitempty" xmlrpc:"name,omitempty"`
 }
 
+// no documentation yet
+type Network_Storage_MassDataMigration_CrossRegion_Country_Xref struct {
+	Entity
+
+	// SoftLayer_Locale_Country Id.
+	Country *Locale_Country `json:"country,omitempty" xmlrpc:"country,omitempty"`
+
+	// no documentation yet
+	CountryId *int `json:"countryId,omitempty" xmlrpc:"countryId,omitempty"`
+
+	// no documentation yet
+	Id *int `json:"id,omitempty" xmlrpc:"id,omitempty"`
+
+	// Location Group ID of CleverSafe cross region.
+	LocationGroup *Location_Group `json:"locationGroup,omitempty" xmlrpc:"locationGroup,omitempty"`
+
+	// no documentation yet
+	LocationGroupId *int `json:"locationGroupId,omitempty" xmlrpc:"locationGroupId,omitempty"`
+}
+
+// The SoftLayer_Network_Storage_MassDataMigration_Request data type contains information on a single Mass Data Migration request. Creation of these requests is limited to SoftLayer customers through the SoftLayer Customer Portal.
+type Network_Storage_MassDataMigration_Request struct {
+	Entity
+
+	// The account to which the request belongs.
+	Account *Account `json:"account,omitempty" xmlrpc:"account,omitempty"`
+
+	// The account id of the request.
+	AccountId *int `json:"accountId,omitempty" xmlrpc:"accountId,omitempty"`
+
+	// A count of the active tickets that are attached to the MDMS request.
+	ActiveTicketCount *uint `json:"activeTicketCount,omitempty" xmlrpc:"activeTicketCount,omitempty"`
+
+	// The active tickets that are attached to the MDMS request.
+	ActiveTickets []Ticket `json:"activeTickets,omitempty" xmlrpc:"activeTickets,omitempty"`
+
+	// The customer address where the device is shipped to.
+	Address *Account_Address `json:"address,omitempty" xmlrpc:"address,omitempty"`
+
+	// The address id of address assigned to this request.
+	AddressId *int `json:"addressId,omitempty" xmlrpc:"addressId,omitempty"`
+
+	// An associated parent billing item which is active. Includes billing items which are scheduled to be cancelled in the future.
+	BillingItem *Billing_Item `json:"billingItem,omitempty" xmlrpc:"billingItem,omitempty"`
+
+	// The employee user who created the request.
+	CreateEmployee *User_Employee `json:"createEmployee,omitempty" xmlrpc:"createEmployee,omitempty"`
+
+	// The customer user who created the request.
+	CreateUser *User_Customer `json:"createUser,omitempty" xmlrpc:"createUser,omitempty"`
+
+	// The create user id of the request.
+	CreateUserId *int `json:"createUserId,omitempty" xmlrpc:"createUserId,omitempty"`
+
+	// The device configurations.
+	DeviceConfiguration *Network_Storage_MassDataMigration_Request_DeviceConfiguration `json:"deviceConfiguration,omitempty" xmlrpc:"deviceConfiguration,omitempty"`
+
+	// The end date of the request.
+	EndDate *Time `json:"endDate,omitempty" xmlrpc:"endDate,omitempty"`
+
+	// The unique id of the request.
+	Id *int `json:"id,omitempty" xmlrpc:"id,omitempty"`
+
+	// A count of the key contacts for this requests.
+	KeyContactCount *uint `json:"keyContactCount,omitempty" xmlrpc:"keyContactCount,omitempty"`
+
+	// The key contacts for this requests.
+	KeyContacts []Network_Storage_MassDataMigration_Request_KeyContact `json:"keyContacts,omitempty" xmlrpc:"keyContacts,omitempty"`
+
+	// The employee who last modified the request.
+	ModifyEmployee *User_Employee `json:"modifyEmployee,omitempty" xmlrpc:"modifyEmployee,omitempty"`
+
+	// The customer user who last modified the request.
+	ModifyUser *User_Customer `json:"modifyUser,omitempty" xmlrpc:"modifyUser,omitempty"`
+
+	// The modify user id of the request.
+	ModifyUserId *int `json:"modifyUserId,omitempty" xmlrpc:"modifyUserId,omitempty"`
+
+	// The unique id of the request.
+	Name *string `json:"name,omitempty" xmlrpc:"name,omitempty"`
+
+	// A count of the shipments of the request.
+	ShipmentCount *uint `json:"shipmentCount,omitempty" xmlrpc:"shipmentCount,omitempty"`
+
+	// The shipments of the request.
+	Shipments []Account_Shipment `json:"shipments,omitempty" xmlrpc:"shipments,omitempty"`
+
+	// The start date of the request.
+	StartDate *Time `json:"startDate,omitempty" xmlrpc:"startDate,omitempty"`
+
+	// The status of the request.
+	Status *Network_Storage_MassDataMigration_Request_Status `json:"status,omitempty" xmlrpc:"status,omitempty"`
+
+	// The status id of the request.
+	StatusId *int `json:"statusId,omitempty" xmlrpc:"statusId,omitempty"`
+
+	// A count of all tickets that are attached to the mass data migration request.
+	TicketCount *uint `json:"ticketCount,omitempty" xmlrpc:"ticketCount,omitempty"`
+
+	// All tickets that are attached to the mass data migration request.
+	Tickets []Ticket `json:"tickets,omitempty" xmlrpc:"tickets,omitempty"`
+}
+
+// The SoftLayer_Network_Storage_MassDataMigration_Request_DeviceConfiguration data type contains settings such networking, COS account, which needs to be configured on device for a Mass Data Migration Request.
+type Network_Storage_MassDataMigration_Request_DeviceConfiguration struct {
+	Entity
+
+	// The account id.
+	CosAccountId *int `json:"cosAccountId,omitempty" xmlrpc:"cosAccountId,omitempty"`
+
+	// The Cloud Object Storage bucket.
+	CosBucket *string `json:"cosBucket,omitempty" xmlrpc:"cosBucket,omitempty"`
+
+	// The eth1 gateway for connecting to private network in datacenter.
+	Eth1Gateway *string `json:"eth1Gateway,omitempty" xmlrpc:"eth1Gateway,omitempty"`
+
+	// The eth1 IP address for connecting to private network in datacenter.
+	Eth1IpAddress *string `json:"eth1IpAddress,omitempty" xmlrpc:"eth1IpAddress,omitempty"`
+
+	// The eth1 netmask for connecting to private network in datacenter.
+	Eth1Netmask *string `json:"eth1Netmask,omitempty" xmlrpc:"eth1Netmask,omitempty"`
+
+	// The eth3 gateway for connecting to private network at customer's location.
+	Eth3Gateway *string `json:"eth3Gateway,omitempty" xmlrpc:"eth3Gateway,omitempty"`
+
+	// The eth3 IP address for connecting to private network at customer location.
+	Eth3IpAddress *string `json:"eth3IpAddress,omitempty" xmlrpc:"eth3IpAddress,omitempty"`
+
+	// The eth3 netmask for connecting to private network in at customer's location.
+	Eth3Netmask *string `json:"eth3Netmask,omitempty" xmlrpc:"eth3Netmask,omitempty"`
+
+	// The unique id of the request status.
+	Id *int `json:"id,omitempty" xmlrpc:"id,omitempty"`
+
+	// The password for configuring network share.
+	Password *string `json:"password,omitempty" xmlrpc:"password,omitempty"`
+
+	// The pool lock password for configuring network share.
+	PoolLockPassword *string `json:"poolLockPassword,omitempty" xmlrpc:"poolLockPassword,omitempty"`
+
+	// The request this device configurations belongs to.
+	Request *Network_Storage_MassDataMigration_Request `json:"request,omitempty" xmlrpc:"request,omitempty"`
+
+	// The request id.
+	RequestId *int `json:"requestId,omitempty" xmlrpc:"requestId,omitempty"`
+
+	// The name of network share.
+	ShareName *string `json:"shareName,omitempty" xmlrpc:"shareName,omitempty"`
+
+	// The storage account to use for this request.
+	StorageAccount *Network_Storage_Hub_Cleversafe_Account `json:"storageAccount,omitempty" xmlrpc:"storageAccount,omitempty"`
+
+	// The username for configuring network share.
+	Username *string `json:"username,omitempty" xmlrpc:"username,omitempty"`
+}
+
+// The SoftLayer_Network_Storage_MassDataMigration_Request_KeyContact data type contains name, email, and phone for key contact at customer location who will handle Mass Data Migration.
+type Network_Storage_MassDataMigration_Request_KeyContact struct {
+	Entity
+
+	// The request this key contact belongs to.
+	Account *Account `json:"account,omitempty" xmlrpc:"account,omitempty"`
+
+	// An account number that is linked to a KeyContact.
+	AccountId *int `json:"accountId,omitempty" xmlrpc:"accountId,omitempty"`
+
+	// The date a KeyContact was created.
+	CreateDate *Time `json:"createDate,omitempty" xmlrpc:"createDate,omitempty"`
+
+	// KeyContact's Email Id.
+	Email *string `json:"email,omitempty" xmlrpc:"email,omitempty"`
+
+	// The unique id of the key contact.
+	Id *int `json:"id,omitempty" xmlrpc:"id,omitempty"`
+
+	// The date a KeyContact was last modified.
+	ModifyDate *Time `json:"modifyDate,omitempty" xmlrpc:"modifyDate,omitempty"`
+
+	// KeyContact's Name.
+	Name *string `json:"name,omitempty" xmlrpc:"name,omitempty"`
+
+	// A phone number assigned to a KeyContact.
+	Phone *string `json:"phone,omitempty" xmlrpc:"phone,omitempty"`
+
+	// The request this key contact belongs to.
+	Request *Network_Storage_MassDataMigration_Request `json:"request,omitempty" xmlrpc:"request,omitempty"`
+
+	// A request id that is linked to a KeyContact.
+	RequestId *int `json:"requestId,omitempty" xmlrpc:"requestId,omitempty"`
+}
+
+// The SoftLayer_Network_Storage_MassDataMigration_Request_Status data type contains general information relating to the statuses to which a Mass Data Migration Request may be set.
+type Network_Storage_MassDataMigration_Request_Status struct {
+	Entity
+
+	// The description of the request status.
+	Description *string `json:"description,omitempty" xmlrpc:"description,omitempty"`
+
+	// The unique id of the request status.
+	Id *int `json:"id,omitempty" xmlrpc:"id,omitempty"`
+
+	// The unique keyname of the request status.
+	KeyName *string `json:"keyName,omitempty" xmlrpc:"keyName,omitempty"`
+
+	// The name of the request status.
+	Name *string `json:"name,omitempty" xmlrpc:"name,omitempty"`
+}
+
 // The SoftLayer_Network_Storage_Nas contains general information regarding a NAS Storage service such as account id, username, password, maximum capacity, Storage's product type and capacity.
 type Network_Storage_Nas struct {
 	Network_Storage
@@ -4577,9 +4929,6 @@ type Network_Subnet struct {
 
 	// A bitmask in dotted-quad format that is used to separate a subnet's network address from it's host addresses. This performs the same function as the ''cidr'' property, but is expressed in a string format.
 	Netmask *string `json:"netmask,omitempty" xmlrpc:"netmask,omitempty"`
-
-	// A subnet's associated network component.
-	NetworkComponent *Network_Component `json:"networkComponent,omitempty" xmlrpc:"networkComponent,omitempty"`
 
 	// The upstream network component firewall.
 	NetworkComponentFirewall *Network_Component_Firewall `json:"networkComponentFirewall,omitempty" xmlrpc:"networkComponentFirewall,omitempty"`
@@ -5503,14 +5852,35 @@ type Network_Vlan struct {
 type Network_Vlan_Firewall struct {
 	Entity
 
+	// no documentation yet
+	AccountId *int `json:"accountId,omitempty" xmlrpc:"accountId,omitempty"`
+
 	// A flag to indicate if the firewall is in administrative bypass mode. In other words, no rules are being applied to the traffic coming through.
 	AdministrativeBypassFlag *string `json:"administrativeBypassFlag,omitempty" xmlrpc:"administrativeBypassFlag,omitempty"`
+
+	// A firewall's allotted bandwidth (measured in GB).
+	BandwidthAllocation *Float64 `json:"bandwidthAllocation,omitempty" xmlrpc:"bandwidthAllocation,omitempty"`
+
+	// The raw bandwidth usage data for the current billing cycle. One object will be returned for each network this firewall is attached to.
+	BillingCycleBandwidthUsage []Network_Bandwidth_Usage `json:"billingCycleBandwidthUsage,omitempty" xmlrpc:"billingCycleBandwidthUsage,omitempty"`
+
+	// A count of the raw bandwidth usage data for the current billing cycle. One object will be returned for each network this firewall is attached to.
+	BillingCycleBandwidthUsageCount *uint `json:"billingCycleBandwidthUsageCount,omitempty" xmlrpc:"billingCycleBandwidthUsageCount,omitempty"`
+
+	// The raw private bandwidth usage data for the current billing cycle.
+	BillingCyclePrivateBandwidthUsage *Network_Bandwidth_Usage `json:"billingCyclePrivateBandwidthUsage,omitempty" xmlrpc:"billingCyclePrivateBandwidthUsage,omitempty"`
+
+	// The raw public bandwidth usage data for the current billing cycle.
+	BillingCyclePublicBandwidthUsage *Network_Bandwidth_Usage `json:"billingCyclePublicBandwidthUsage,omitempty" xmlrpc:"billingCyclePublicBandwidthUsage,omitempty"`
 
 	// The billing item for a Hardware Firewall (Dedicated).
 	BillingItem *Billing_Item `json:"billingItem,omitempty" xmlrpc:"billingItem,omitempty"`
 
 	// Administrative bypass request status.
 	BypassRequestStatus *string `json:"bypassRequestStatus,omitempty" xmlrpc:"bypassRequestStatus,omitempty"`
+
+	// An object that provides commonly used bandwidth summary components for the current billing cycle.
+	CurrentBandwidthSummary *Metric_Tracking_Object_Bandwidth_Summary `json:"currentBandwidthSummary,omitempty" xmlrpc:"currentBandwidthSummary,omitempty"`
 
 	// Whether or not this firewall can be directly logged in to.
 	CustomerManagedFlag *bool `json:"customerManagedFlag,omitempty" xmlrpc:"customerManagedFlag,omitempty"`
@@ -5530,6 +5900,12 @@ type Network_Vlan_Firewall struct {
 	// The credentials to log in to a firewall device. This is only present for dedicated appliances.
 	ManagementCredentials *Software_Component_Password `json:"managementCredentials,omitempty" xmlrpc:"managementCredentials,omitempty"`
 
+	// A firewall's metric tracking object.
+	MetricTrackingObject *Metric_Tracking_Object `json:"metricTrackingObject,omitempty" xmlrpc:"metricTrackingObject,omitempty"`
+
+	// The metric tracking object ID for this firewall.
+	MetricTrackingObjectId *int `json:"metricTrackingObjectId,omitempty" xmlrpc:"metricTrackingObjectId,omitempty"`
+
 	// A count of the update requests made for this firewall.
 	NetworkFirewallUpdateRequestCount *uint `json:"networkFirewallUpdateRequestCount,omitempty" xmlrpc:"networkFirewallUpdateRequestCount,omitempty"`
 
@@ -5548,8 +5924,17 @@ type Network_Vlan_Firewall struct {
 	// The VLAN objects that a firewall is associated with and protecting.
 	NetworkVlans []Network_Vlan `json:"networkVlans,omitempty" xmlrpc:"networkVlans,omitempty"`
 
+	// Whether the bandwidth usage for this firewall for the current billing cycle exceeds the allocation.
+	OverBandwidthAllocationFlag *int `json:"overBandwidthAllocationFlag,omitempty" xmlrpc:"overBandwidthAllocationFlag,omitempty"`
+
 	// A firewall's primary IP address. This field will be the IP shown when doing network traces and reverse DNS and is a read-only property.
 	PrimaryIpAddress *string `json:"primaryIpAddress,omitempty" xmlrpc:"primaryIpAddress,omitempty"`
+
+	// Whether the bandwidth usage for this firewall for the current billing cycle is projected to exceed the allocation.
+	ProjectedOverBandwidthAllocationFlag *int `json:"projectedOverBandwidthAllocationFlag,omitempty" xmlrpc:"projectedOverBandwidthAllocationFlag,omitempty"`
+
+	// The projected public outbound bandwidth for this firewall for the current billing cycle.
+	ProjectedPublicBandwidthUsage *Float64 `json:"projectedPublicBandwidthUsage,omitempty" xmlrpc:"projectedPublicBandwidthUsage,omitempty"`
 
 	// A count of the currently running rule set of this network component firewall.
 	RuleCount *uint `json:"ruleCount,omitempty" xmlrpc:"ruleCount,omitempty"`
@@ -5562,6 +5947,9 @@ type Network_Vlan_Firewall struct {
 
 	// no documentation yet
 	TagReferences []Tag_Reference `json:"tagReferences,omitempty" xmlrpc:"tagReferences,omitempty"`
+
+	// A firewall's associated upgrade request object, if any.
+	UpgradeRequest *Product_Upgrade_Request `json:"upgradeRequest,omitempty" xmlrpc:"upgradeRequest,omitempty"`
 }
 
 // A SoftLayer_Network_Component_Firewall_Rule object type represents a currently running firewall rule and contains relative information. Use the [[SoftLayer Network Firewall Update Request]] service to submit a firewall update request. Use the [[SoftLayer Network Firewall Template]] service to pull SoftLayer recommended rule set templates.

--- a/vendor/github.com/softlayer/softlayer-go/datatypes/product.go
+++ b/vendor/github.com/softlayer/softlayer-go/datatypes/product.go
@@ -111,11 +111,17 @@ type Product_Item struct {
 	// An item's special billing type, if applicable.
 	BillingType *string `json:"billingType,omitempty" xmlrpc:"billingType,omitempty"`
 
-	// An item's included products. Some items have other items included in them that we specifically detail. They are here called Bundled Items. An example is Plesk unlimited. It as a bundled item labeled 'SiteBuilder'. These are the SoftLayer_Product_Item_Bundles objects.
+	// An item's included product item references. Some items have other items included in them that we specifically detail. They are here called Bundled Items. An example is Plesk unlimited. It as a bundled item labeled 'SiteBuilder'. These are the SoftLayer_Product_Item_Bundles objects. See the SoftLayer_Product_Item::bundleItems property for bundle of SoftLayer_Product_Item of objects.
 	Bundle []Product_Item_Bundles `json:"bundle,omitempty" xmlrpc:"bundle,omitempty"`
 
-	// A count of an item's included products. Some items have other items included in them that we specifically detail. They are here called Bundled Items. An example is Plesk unlimited. It as a bundled item labeled 'SiteBuilder'. These are the SoftLayer_Product_Item_Bundles objects.
+	// A count of an item's included product item references. Some items have other items included in them that we specifically detail. They are here called Bundled Items. An example is Plesk unlimited. It as a bundled item labeled 'SiteBuilder'. These are the SoftLayer_Product_Item_Bundles objects. See the SoftLayer_Product_Item::bundleItems property for bundle of SoftLayer_Product_Item of objects.
 	BundleCount *uint `json:"bundleCount,omitempty" xmlrpc:"bundleCount,omitempty"`
+
+	// A count of an item's included products. Some items have other items included in them that we specifically detail. They are here called Bundled Items. An example is Plesk unlimited. It as a bundled item labeled 'SiteBuilder'. These are the SoftLayer_Product_Item objects.
+	BundleItemCount *uint `json:"bundleItemCount,omitempty" xmlrpc:"bundleItemCount,omitempty"`
+
+	// An item's included products. Some items have other items included in them that we specifically detail. They are here called Bundled Items. An example is Plesk unlimited. It as a bundled item labeled 'SiteBuilder'. These are the SoftLayer_Product_Item objects.
+	BundleItems []Product_Item `json:"bundleItems,omitempty" xmlrpc:"bundleItems,omitempty"`
 
 	// Some Product Items have capacity information such as RAM and bandwidth, and others. This provides the numerical representation of the capacity given in the description of this product item.
 	Capacity *Float64 `json:"capacity,omitempty" xmlrpc:"capacity,omitempty"`
@@ -601,6 +607,9 @@ type Product_Item_Price struct {
 	// This flag is used by the [[SoftLayer_Hardware::getUpgradeItems|getUpgradeItems]] method to indicate if a product price is used for the current billing item.
 	CurrentPriceFlag *bool `json:"currentPriceFlag,omitempty" xmlrpc:"currentPriceFlag,omitempty"`
 
+	// Signifies pricing that is only available on a dedicated host virtual server order.
+	DedicatedHostInstanceFlag *bool `json:"dedicatedHostInstanceFlag,omitempty" xmlrpc:"dedicatedHostInstanceFlag,omitempty"`
+
 	// Whether this price defines a software license for its product item.
 	DefinedSoftwareLicenseFlag *bool `json:"definedSoftwareLicenseFlag,omitempty" xmlrpc:"definedSoftwareLicenseFlag,omitempty"`
 
@@ -666,6 +675,9 @@ type Product_Item_Price struct {
 	// A list of preset configurations this price is used in.'
 	PresetConfigurations []Product_Package_Preset_Configuration `json:"presetConfigurations,omitempty" xmlrpc:"presetConfigurations,omitempty"`
 
+	// The type keyname of this price which can be STANDARD or TIERED.
+	PriceType *string `json:"priceType,omitempty" xmlrpc:"priceType,omitempty"`
+
 	// The pricing location group that this price is applicable for. Prices that have a pricing location group will only be available for ordering with the locations specified on the location group.
 	PricingLocationGroup *Location_Group_Pricing `json:"pricingLocationGroup,omitempty" xmlrpc:"pricingLocationGroup,omitempty"`
 
@@ -692,6 +704,9 @@ type Product_Item_Price struct {
 
 	// Used for ordering items on sales orders.
 	Sort *int `json:"sort,omitempty" xmlrpc:"sort,omitempty"`
+
+	// The minimum threshold for which this tiered usage price begins to apply.  The unit for the price is defined by the item to which this belongs, see [[SoftLayer_Product_Item::$units]].
+	TierMinimumThreshold *int `json:"tierMinimumThreshold,omitempty" xmlrpc:"tierMinimumThreshold,omitempty"`
 
 	// The rate for a usage based item
 	UsageRate *Float64 `json:"usageRate,omitempty" xmlrpc:"usageRate,omitempty"`
@@ -1008,6 +1023,12 @@ type Product_Order struct {
 // The SoftLayer_Product_Package data type contains information about packages from which orders can be generated. Packages contain general information regarding what is in them, where they are currently sold, availability, and pricing.
 type Product_Package struct {
 	Entity
+
+	// A count of the preset configurations available only for the authenticated account and this package.
+	AccountRestrictedActivePresetCount *uint `json:"accountRestrictedActivePresetCount,omitempty" xmlrpc:"accountRestrictedActivePresetCount,omitempty"`
+
+	// The preset configurations available only for the authenticated account and this package.
+	AccountRestrictedActivePresets []Product_Package_Preset `json:"accountRestrictedActivePresets,omitempty" xmlrpc:"accountRestrictedActivePresets,omitempty"`
 
 	// The results from this call are similar to [[SoftLayer_Product_Package/getCategories|getCategories]], but these ONLY include account-restricted prices. Not all accounts have restricted pricing.
 	AccountRestrictedCategories []Product_Item_Category `json:"accountRestrictedCategories,omitempty" xmlrpc:"accountRestrictedCategories,omitempty"`

--- a/vendor/github.com/softlayer/softlayer-go/datatypes/ticket.go
+++ b/vendor/github.com/softlayer/softlayer-go/datatypes/ticket.go
@@ -386,6 +386,20 @@ type Ticket_Attachment_Manual_Payment struct {
 }
 
 // no documentation yet
+type Ticket_Attachment_Network_Storage_Mass_Data_Migration struct {
+	Ticket_Attachment
+
+	// The Mass Data Migration request that is attached to a ticket.
+	Request *Network_Storage_MassDataMigration_Request `json:"request,omitempty" xmlrpc:"request,omitempty"`
+
+	// no documentation yet
+	RequestId *int `json:"requestId,omitempty" xmlrpc:"requestId,omitempty"`
+
+	// The Mass Data Migration request that is attached to a ticket.
+	Resource *Network_Storage_MassDataMigration_Request `json:"resource,omitempty" xmlrpc:"resource,omitempty"`
+}
+
+// no documentation yet
 type Ticket_Attachment_Scheduled_Action struct {
 	Ticket_Attachment
 
@@ -394,6 +408,9 @@ type Ticket_Attachment_Scheduled_Action struct {
 
 	// The internal identifier of a scheduled action transaction that is attached to a ticket.
 	RunDate *Time `json:"runDate,omitempty" xmlrpc:"runDate,omitempty"`
+
+	// no documentation yet
+	ScheduledAction *Provisioning_Version1_Transaction `json:"scheduledAction,omitempty" xmlrpc:"scheduledAction,omitempty"`
 
 	// no documentation yet
 	Transaction *Provisioning_Version1_Transaction `json:"transaction,omitempty" xmlrpc:"transaction,omitempty"`

--- a/vendor/github.com/softlayer/softlayer-go/datatypes/user.go
+++ b/vendor/github.com/softlayer/softlayer-go/datatypes/user.go
@@ -654,6 +654,9 @@ type User_Customer_Invitation struct {
 	ExpirationDate *Time `json:"expirationDate,omitempty" xmlrpc:"expirationDate,omitempty"`
 
 	// no documentation yet
+	IbmIdUsername *string `json:"ibmIdUsername,omitempty" xmlrpc:"ibmIdUsername,omitempty"`
+
+	// no documentation yet
 	Id *int `json:"id,omitempty" xmlrpc:"id,omitempty"`
 
 	// no documentation yet

--- a/vendor/github.com/softlayer/softlayer-go/datatypes/virtual.go
+++ b/vendor/github.com/softlayer/softlayer-go/datatypes/virtual.go
@@ -829,6 +829,9 @@ type Virtual_Guest_Block_Device_Template_Group struct {
 	// The total disk space of all images in a image template group.
 	BlockDevicesDiskSpaceTotal *Float64 `json:"blockDevicesDiskSpaceTotal,omitempty" xmlrpc:"blockDevicesDiskSpaceTotal,omitempty"`
 
+	// A flag indicating that customer is providing the software licenses.
+	ByolFlag *bool `json:"byolFlag,omitempty" xmlrpc:"byolFlag,omitempty"`
+
 	// The image template groups that are clones of an image template group.
 	Children []Virtual_Guest_Block_Device_Template_Group `json:"children,omitempty" xmlrpc:"children,omitempty"`
 
@@ -1145,14 +1148,14 @@ type Virtual_Guest_Status struct {
 type Virtual_Guest_SupplementalCreateObjectOptions struct {
 	Entity
 
+	// When set the startCpus and maxMemory are defined by the flavor. If the flavor includes local storage blockDevice 0 is also defined by the flavor. When startCpus, maxMemory, or blockDevice 0 are also provided on the template object they are validated against the flavor provided.
+	FlavorKeyName *string `json:"flavorKeyName,omitempty" xmlrpc:"flavorKeyName,omitempty"`
+
 	// When explicitly set to true, createObject(s) will fail unless the order is started automatically. This can be used by automated systems to fail an order that might otherwise require manual approval. For multi-guest orders via [[SoftLayer_Virtual_Guest/createObjects|createObjects]], this value must be the exact same for every item.
 	ImmediateApprovalOnlyFlag *bool `json:"immediateApprovalOnlyFlag,omitempty" xmlrpc:"immediateApprovalOnlyFlag,omitempty"`
 
 	// URI of the script to be downloaded and executed after installation is complete. This can be different for each virtual guest when multiple are sent to [[SoftLayer_Virtual_Guest/createObjects|createObjects]].
 	PostInstallScriptUri *string `json:"postInstallScriptUri,omitempty" xmlrpc:"postInstallScriptUri,omitempty"`
-
-	// When set the configuration defined by this preset overrides the related options set on the template.
-	PresetConfigurationKeyName *string `json:"presetConfigurationKeyName,omitempty" xmlrpc:"presetConfigurationKeyName,omitempty"`
 }
 
 // SoftLayer_Virtual_Guest_Type models the type of a [[SoftLayer_Virtual_Guest]] (PUBLIC | DEDICATED | PRIVATE)

--- a/vendor/github.com/softlayer/softlayer-go/services/account.go
+++ b/vendor/github.com/softlayer/softlayer-go/services/account.go
@@ -143,6 +143,20 @@ func (r Account) CreateUser(templateObject *datatypes.User_Customer, password *s
 	return
 }
 
+// disableEuLocalizedProcessing will disable the EU localized processing flag on the account. Disabling the flag allows personnel and systems in non-EU countries to perform processing activities on the account's systems and data.
+func (r Account) DisableEuLocalizedProcessing() (err error) {
+	var resp datatypes.Void
+	err = r.Session.DoRequest("SoftLayer_Account", "disableEuLocalizedProcessing", nil, &r.Options, &resp)
+	return
+}
+
+// enableEuLocalizedProcessing will enable the EU localized processing flag on the account. This flag indicates that an account should have all resources located in EU compliant datacenters.
+func (r Account) EnableEuLocalizedProcessing() (err error) {
+	var resp datatypes.Void
+	err = r.Session.DoRequest("SoftLayer_Account", "enableEuLocalizedProcessing", nil, &r.Options, &resp)
+	return
+}
+
 // Retrieve An email address that is responsible for abuse and legal inquiries on behalf of an account. For instance, new legal and abuse tickets are sent to this address.
 func (r Account) GetAbuseEmail() (resp string, err error) {
 	err = r.Session.DoRequest("SoftLayer_Account", "getAbuseEmail", nil, &r.Options, &resp)
@@ -485,9 +499,9 @@ func (r Account) GetBlockDeviceTemplateGroups() (resp []datatypes.Virtual_Guest_
 	return
 }
 
-// Retrieve This field is deprecated and should not be used.
-func (r Account) GetBlueIdAuthenticationRequiredFlag() (resp bool, err error) {
-	err = r.Session.DoRequest("SoftLayer_Account", "getBlueIdAuthenticationRequiredFlag", nil, &r.Options, &resp)
+// Retrieve The Bluemix account link associated with this SoftLayer account, if one exists.
+func (r Account) GetBluemixAccountLink() (resp datatypes.Account_Link_Bluemix, err error) {
+	err = r.Session.DoRequest("SoftLayer_Account", "getBluemixAccountLink", nil, &r.Options, &resp)
 	return
 }
 
@@ -512,6 +526,12 @@ func (r Account) GetBrandAccountFlag() (resp bool, err error) {
 // Retrieve The brand keyName.
 func (r Account) GetBrandKeyName() (resp string, err error) {
 	err = r.Session.DoRequest("SoftLayer_Account", "getBrandKeyName", nil, &r.Options, &resp)
+	return
+}
+
+// Retrieve The Business Partner details for the account. Country Enterprise Code, Channel ID, and Segment ID.
+func (r Account) GetBusinessPartner() (resp datatypes.Account_Partner_Business, err error) {
+	err = r.Session.DoRequest("SoftLayer_Account", "getBusinessPartner", nil, &r.Options, &resp)
 	return
 }
 
@@ -952,7 +972,7 @@ func (r Account) GetIscsiNetworkStorage() (resp []datatypes.Network_Storage, err
 	return
 }
 
-// no documentation yet
+// Computes the number of available public secondary IP addresses, aligned to a subnet size.
 func (r Account) GetLargestAllowedSubnetCidr(numberOfHosts *int, locationId *int) (resp int, err error) {
 	params := []interface{}{
 		numberOfHosts,
@@ -2022,6 +2042,17 @@ func (r Account) SetAbuseEmails(emails []string) (resp bool, err error) {
 	return
 }
 
+// Set the total number of servers that are to be maintained in the given pool. When a server is ordered a new server will be put in the pool to replace the server that was removed to fill an order to maintain the desired pool availability quantity.
+func (r Account) SetManagedPoolQuantity(poolKeyName *string, backendRouter *string, quantity *int) (resp []byte, err error) {
+	params := []interface{}{
+		poolKeyName,
+		backendRouter,
+		quantity,
+	}
+	err = r.Session.DoRequest("SoftLayer_Account", "setManagedPoolQuantity", params, &r.Options, &resp)
+	return
+}
+
 // Set the flag that enables or disables automatic private network VLAN spanning for a SoftLayer customer account. Enabling VLAN spanning allows an account's servers to talk on the same broadcast domain even if they reside within different private vlans.
 func (r Account) SetVlanSpan(enabled *bool) (resp bool, err error) {
 	params := []interface{}{
@@ -2049,7 +2080,7 @@ func (r Account) UpdateVpnUsersForResource(objectId *int, objectType *string) (r
 	return
 }
 
-// This method will validate the following account fields. Included are the allowed characters for each field. Email Address*: letters, numbers, space, period, dash, parenthesis, exclamation point, at sign, ampersand, colon, comma, underscore, apostrophe, octothorpe. Company Name*: alphabet, numbers, space, period, dash, octothorpe, forward slash, backward slash, comma, colon, at sign, ampersand, underscore, apostrophe, parenthesis, exclamation point. (Note: may not contain an email address) First Name*: alphabet, space, period, dash, comma, apostrophe. Last Name*: alphabet, space, period, dash, comma, apostrophe. Address 1*: alphabet, numbers, space, period, dash, octothorpe, forward slash, backward slash, comma, colon, at sign, ampersand, underscore, apostrophe. Address 2: alphabet, numbers, space, period, dash, octothorpe, forward slash, backward slash, comma, colon, at sign, ampersand, underscore, apostrophe. City*: alphabet, space, period, dash, apostrophe. State*: Required if country is US or Canada. Must be valid two-letter state code for that country. Postal Code*: alphabet, numbers, dash, space. Country*: alphabet, numbers. Office Phone*: alphabet, numbers, space, period, dash, parenthesis, plus sign. Alternate Phone: alphabet, numbers, space, period, dash, parenthesis, plus sign. Fax Phone: alphabet, numbers, space, period, dash, parenthesis, plus sign.
+// This method will validate the following account fields. Included are the allowed characters for each field.<br> <strong>Email Address<sup>*</sup>:</strong> letters, numbers, space, period, dash, parenthesis, exclamation point, at sign, ampersand, colon, comma, underscore, apostrophe, octothorpe.<br><br> <strong>Company Name<sup>*</sup>:</strong> alphabet, numbers, space, period, dash, octothorpe, forward slash, backward slash, comma, colon, at sign, ampersand, underscore, apostrophe, parenthesis, exclamation point. (Note: may not contain an email address)<br> <strong>First Name<sup>*</sup>:</strong> alphabet, space, period, dash, comma, apostrophe.<br> <strong>Last Name<sup>*</sup>:</strong> alphabet, space, period, dash, comma, apostrophe.<br> <strong>Address 1<sup>*</sup>:</strong> alphabet, numbers, space, period, dash, octothorpe, forward slash, backward slash, comma, colon, at sign, ampersand, underscore, apostrophe.<br> <strong>Address 2:</strong> alphabet, numbers, space, period, dash, octothorpe, forward slash, backward slash, comma, colon, at sign, ampersand, underscore, apostrophe.<br> <strong>City<sup>*</sup>:</strong> alphabet, space, period, dash, apostrophe.<br> <strong>State<sup>*</sup>:</strong> Required if country is US or Canada. Must be valid Alpha-2 ISO 3166-1 state code for that country.<br> <strong>Postal Code<sup>*</sup>:</strong> alphabet, numbers, dash, space.<br> <strong>Country<sup>*</sup>:</strong> alphabet, numbers. Must be valid Alpha-2 ISO 3166-1 country code.<br> <strong>Office Phone<sup>*</sup>:</strong> alphabet, numbers, space, period, dash, parenthesis, plus sign.<br> <strong>Alternate Phone:</strong> alphabet, numbers, space, period, dash, parenthesis, plus sign.<br> <strong>Fax Phone:</strong> alphabet, numbers, space, period, dash, parenthesis, plus sign.<br>
 // * denotes a required field.
 func (r Account) Validate(account *datatypes.Account) (resp []string, err error) {
 	params := []interface{}{
@@ -2874,6 +2905,112 @@ func (r Account_Historical_Report) GetUrlUptimeGraphData(configurationValueId *i
 }
 
 // no documentation yet
+type Account_Internal_Ibm struct {
+	Session *session.Session
+	Options sl.Options
+}
+
+// GetAccountInternalIbmService returns an instance of the Account_Internal_Ibm SoftLayer service
+func GetAccountInternalIbmService(sess *session.Session) Account_Internal_Ibm {
+	return Account_Internal_Ibm{Session: sess}
+}
+
+func (r Account_Internal_Ibm) Id(id int) Account_Internal_Ibm {
+	r.Options.Id = &id
+	return r
+}
+
+func (r Account_Internal_Ibm) Mask(mask string) Account_Internal_Ibm {
+	if !strings.HasPrefix(mask, "mask[") && (strings.Contains(mask, "[") || strings.Contains(mask, ",")) {
+		mask = fmt.Sprintf("mask[%s]", mask)
+	}
+
+	r.Options.Mask = mask
+	return r
+}
+
+func (r Account_Internal_Ibm) Filter(filter string) Account_Internal_Ibm {
+	r.Options.Filter = filter
+	return r
+}
+
+func (r Account_Internal_Ibm) Limit(limit int) Account_Internal_Ibm {
+	r.Options.Limit = &limit
+	return r
+}
+
+func (r Account_Internal_Ibm) Offset(offset int) Account_Internal_Ibm {
+	r.Options.Offset = &offset
+	return r
+}
+
+// Validates request and, if the request is approved, returns a list of allowed uses for an automatically created IBMer IaaS account.
+func (r Account_Internal_Ibm) GetAccountTypes() (resp []string, err error) {
+	err = r.Session.DoRequest("SoftLayer_Account_Internal_Ibm", "getAccountTypes", nil, &r.Options, &resp)
+	return
+}
+
+// Gets the URL used to perform manager validation.
+func (r Account_Internal_Ibm) GetAuthorizationUrl(requestId *int) (resp string, err error) {
+	params := []interface{}{
+		requestId,
+	}
+	err = r.Session.DoRequest("SoftLayer_Account_Internal_Ibm", "getAuthorizationUrl", params, &r.Options, &resp)
+	return
+}
+
+// Exchanges a code for a token during manager validation.
+func (r Account_Internal_Ibm) GetEmployeeAccessToken(unverifiedAuthenticationCode *string) (resp string, err error) {
+	params := []interface{}{
+		unverifiedAuthenticationCode,
+	}
+	err = r.Session.DoRequest("SoftLayer_Account_Internal_Ibm", "getEmployeeAccessToken", params, &r.Options, &resp)
+	return
+}
+
+// After validating the requesting user through the access token, generates a container with the relevant request information and returns it.
+func (r Account_Internal_Ibm) GetManagerPreview(requestId *int, accessToken *string) (resp datatypes.Container_Account_Internal_Ibm_Request, err error) {
+	params := []interface{}{
+		requestId,
+		accessToken,
+	}
+	err = r.Session.DoRequest("SoftLayer_Account_Internal_Ibm", "getManagerPreview", params, &r.Options, &resp)
+	return
+}
+
+// Applies manager approval to a pending internal IBM account request. If cost recovery is already configured, this will create an account. If not, this will remind the internal team to configure cost recovery and create the account when possible.
+func (r Account_Internal_Ibm) ManagerApprove(requestId *int, accessToken *string) (err error) {
+	var resp datatypes.Void
+	params := []interface{}{
+		requestId,
+		accessToken,
+	}
+	err = r.Session.DoRequest("SoftLayer_Account_Internal_Ibm", "managerApprove", params, &r.Options, &resp)
+	return
+}
+
+// Denies a pending request and prevents additional requests from the same applicant for as long as the manager remains the same.
+func (r Account_Internal_Ibm) ManagerDeny(requestId *int, accessToken *string) (err error) {
+	var resp datatypes.Void
+	params := []interface{}{
+		requestId,
+		accessToken,
+	}
+	err = r.Session.DoRequest("SoftLayer_Account_Internal_Ibm", "managerDeny", params, &r.Options, &resp)
+	return
+}
+
+// Validates request and kicks off the approval process.
+func (r Account_Internal_Ibm) RequestAccount(requestContainer *datatypes.Container_Account_Internal_Ibm_Request) (err error) {
+	var resp datatypes.Void
+	params := []interface{}{
+		requestContainer,
+	}
+	err = r.Session.DoRequest("SoftLayer_Account_Internal_Ibm", "requestAccount", params, &r.Options, &resp)
+	return
+}
+
+// no documentation yet
 type Account_Link_Bluemix struct {
 	Session *session.Session
 	Options sl.Options
@@ -3582,6 +3719,58 @@ func (r Account_Note_Type) GetAllObjects() (resp []datatypes.Account_Note_Type, 
 // no documentation yet
 func (r Account_Note_Type) GetObject() (resp datatypes.Account_Note_Type, err error) {
 	err = r.Session.DoRequest("SoftLayer_Account_Note_Type", "getObject", nil, &r.Options, &resp)
+	return
+}
+
+// The SoftLayer_Account_Partner_Business data type contains specific information concerning an Account's relationship with Business Partner Data, in the form of the Account's Country Experience Identifier (CEID), Channel ID, and Segment ID.
+type Account_Partner_Business struct {
+	Session *session.Session
+	Options sl.Options
+}
+
+// GetAccountPartnerBusinessService returns an instance of the Account_Partner_Business SoftLayer service
+func GetAccountPartnerBusinessService(sess *session.Session) Account_Partner_Business {
+	return Account_Partner_Business{Session: sess}
+}
+
+func (r Account_Partner_Business) Id(id int) Account_Partner_Business {
+	r.Options.Id = &id
+	return r
+}
+
+func (r Account_Partner_Business) Mask(mask string) Account_Partner_Business {
+	if !strings.HasPrefix(mask, "mask[") && (strings.Contains(mask, "[") || strings.Contains(mask, ",")) {
+		mask = fmt.Sprintf("mask[%s]", mask)
+	}
+
+	r.Options.Mask = mask
+	return r
+}
+
+func (r Account_Partner_Business) Filter(filter string) Account_Partner_Business {
+	r.Options.Filter = filter
+	return r
+}
+
+func (r Account_Partner_Business) Limit(limit int) Account_Partner_Business {
+	r.Options.Limit = &limit
+	return r
+}
+
+func (r Account_Partner_Business) Offset(offset int) Account_Partner_Business {
+	r.Options.Offset = &offset
+	return r
+}
+
+// Retrieve The SoftLayer customer account associated with this business partner data.
+func (r Account_Partner_Business) GetAccount() (resp datatypes.Account, err error) {
+	err = r.Session.DoRequest("SoftLayer_Account_Partner_Business", "getAccount", nil, &r.Options, &resp)
+	return
+}
+
+// no documentation yet
+func (r Account_Partner_Business) GetObject() (resp datatypes.Account_Partner_Business, err error) {
+	err = r.Session.DoRequest("SoftLayer_Account_Partner_Business", "getObject", nil, &r.Options, &resp)
 	return
 }
 

--- a/vendor/github.com/softlayer/softlayer-go/services/billing.go
+++ b/vendor/github.com/softlayer/softlayer-go/services/billing.go
@@ -2583,6 +2583,12 @@ func (r Billing_Order_Item) GetParent() (resp datatypes.Billing_Order_Item, err 
 	return
 }
 
+// Retrieve The SoftLayer_Product_Package_Preset related to this order item.
+func (r Billing_Order_Item) GetPreset() (resp datatypes.Product_Package_Preset, err error) {
+	err = r.Session.DoRequest("SoftLayer_Billing_Order_Item", "getPreset", nil, &r.Options, &resp)
+	return
+}
+
 // Retrieve A count of power supplies contained within this SoftLayer_Billing_Order
 func (r Billing_Order_Item) GetRedundantPowerSupplyCount() (resp uint, err error) {
 	err = r.Session.DoRequest("SoftLayer_Billing_Order_Item", "getRedundantPowerSupplyCount", nil, &r.Options, &resp)

--- a/vendor/github.com/softlayer/softlayer-go/services/hardware.go
+++ b/vendor/github.com/softlayer/softlayer-go/services/hardware.go
@@ -676,6 +676,12 @@ func (r Hardware) GetDatacenterName() (resp string, err error) {
 	return
 }
 
+// Retrieve Number of day(s) a server have been in spare pool.
+func (r Hardware) GetDaysInSparePool() (resp int, err error) {
+	err = r.Session.DoRequest("SoftLayer_Hardware", "getDaysInSparePool", nil, &r.Options, &resp)
+	return
+}
+
 // Retrieve All hardware that has uplink network connections to a piece of hardware.
 func (r Hardware) GetDownlinkHardware() (resp []datatypes.Hardware, err error) {
 	err = r.Session.DoRequest("SoftLayer_Hardware", "getDownlinkHardware", nil, &r.Options, &resp)
@@ -1250,6 +1256,12 @@ func (r Hardware) GetRouters() (resp []datatypes.Hardware, err error) {
 	return
 }
 
+// Retrieve Determine if hardware object has Software Guard Extension (SGX) enabled.
+func (r Hardware) GetSGXEnabled() (resp bool, err error) {
+	err = r.Session.DoRequest("SoftLayer_Hardware", "getSGXEnabled", nil, &r.Options, &resp)
+	return
+}
+
 // Retrieve Collection of scale assets this hardware corresponds to.
 func (r Hardware) GetScaleAssets() (resp []datatypes.Scale_Asset, err error) {
 	err = r.Session.DoRequest("SoftLayer_Hardware", "getScaleAssets", nil, &r.Options, &resp)
@@ -1668,6 +1680,18 @@ func (r Hardware_Component_Model) GetCompatibleChildComponentModels() (resp []da
 // Retrieve All the component models that a hardware component model is compatible with.
 func (r Hardware_Component_Model) GetCompatibleParentComponentModels() (resp []datatypes.Hardware_Component_Model, err error) {
 	err = r.Session.DoRequest("SoftLayer_Hardware_Component_Model", "getCompatibleParentComponentModels", nil, &r.Options, &resp)
+	return
+}
+
+// Retrieve
+func (r Hardware_Component_Model) GetFirmwareQuantity() (resp uint, err error) {
+	err = r.Session.DoRequest("SoftLayer_Hardware_Component_Model", "getFirmwareQuantity", nil, &r.Options, &resp)
+	return
+}
+
+// Retrieve
+func (r Hardware_Component_Model) GetFirmwares() (resp []datatypes.Hardware_Component_Firmware, err error) {
+	err = r.Session.DoRequest("SoftLayer_Hardware_Component_Model", "getFirmwares", nil, &r.Options, &resp)
 	return
 }
 
@@ -2521,6 +2545,12 @@ func (r Hardware_Router) GetDatacenterName() (resp string, err error) {
 	return
 }
 
+// Retrieve Number of day(s) a server have been in spare pool.
+func (r Hardware_Router) GetDaysInSparePool() (resp int, err error) {
+	err = r.Session.DoRequest("SoftLayer_Hardware_Router", "getDaysInSparePool", nil, &r.Options, &resp)
+	return
+}
+
 // Retrieve All hardware that has uplink network connections to a piece of hardware.
 func (r Hardware_Router) GetDownlinkHardware() (resp []datatypes.Hardware, err error) {
 	err = r.Session.DoRequest("SoftLayer_Hardware_Router", "getDownlinkHardware", nil, &r.Options, &resp)
@@ -3098,6 +3128,12 @@ func (r Hardware_Router) GetResourceGroups() (resp []datatypes.Resource_Group, e
 // Retrieve A hardware's routers.
 func (r Hardware_Router) GetRouters() (resp []datatypes.Hardware, err error) {
 	err = r.Session.DoRequest("SoftLayer_Hardware_Router", "getRouters", nil, &r.Options, &resp)
+	return
+}
+
+// Retrieve Determine if hardware object has Software Guard Extension (SGX) enabled.
+func (r Hardware_Router) GetSGXEnabled() (resp bool, err error) {
+	err = r.Session.DoRequest("SoftLayer_Hardware_Router", "getSGXEnabled", nil, &r.Options, &resp)
 	return
 }
 
@@ -4251,6 +4287,12 @@ func (r Hardware_SecurityModule) GetDatacenterName() (resp string, err error) {
 	return
 }
 
+// Retrieve Number of day(s) a server have been in spare pool.
+func (r Hardware_SecurityModule) GetDaysInSparePool() (resp int, err error) {
+	err = r.Session.DoRequest("SoftLayer_Hardware_SecurityModule", "getDaysInSparePool", nil, &r.Options, &resp)
+	return
+}
+
 // Retrieve All hardware that has uplink network connections to a piece of hardware.
 func (r Hardware_SecurityModule) GetDownlinkHardware() (resp []datatypes.Hardware, err error) {
 	err = r.Session.DoRequest("SoftLayer_Hardware_SecurityModule", "getDownlinkHardware", nil, &r.Options, &resp)
@@ -5074,6 +5116,12 @@ func (r Hardware_SecurityModule) GetReverseDomainRecords() (resp []datatypes.Dns
 // Retrieve A hardware's routers.
 func (r Hardware_SecurityModule) GetRouters() (resp []datatypes.Hardware, err error) {
 	err = r.Session.DoRequest("SoftLayer_Hardware_SecurityModule", "getRouters", nil, &r.Options, &resp)
+	return
+}
+
+// Retrieve Determine if hardware object has Software Guard Extension (SGX) enabled.
+func (r Hardware_SecurityModule) GetSGXEnabled() (resp bool, err error) {
+	err = r.Session.DoRequest("SoftLayer_Hardware_SecurityModule", "getSGXEnabled", nil, &r.Options, &resp)
 	return
 }
 
@@ -6443,6 +6491,12 @@ func (r Hardware_Server) GetDatacenterName() (resp string, err error) {
 	return
 }
 
+// Retrieve Number of day(s) a server have been in spare pool.
+func (r Hardware_Server) GetDaysInSparePool() (resp int, err error) {
+	err = r.Session.DoRequest("SoftLayer_Hardware_Server", "getDaysInSparePool", nil, &r.Options, &resp)
+	return
+}
+
 // Retrieve All hardware that has uplink network connections to a piece of hardware.
 func (r Hardware_Server) GetDownlinkHardware() (resp []datatypes.Hardware, err error) {
 	err = r.Session.DoRequest("SoftLayer_Hardware_Server", "getDownlinkHardware", nil, &r.Options, &resp)
@@ -7266,6 +7320,12 @@ func (r Hardware_Server) GetReverseDomainRecords() (resp []datatypes.Dns_Domain,
 // Retrieve A hardware's routers.
 func (r Hardware_Server) GetRouters() (resp []datatypes.Hardware, err error) {
 	err = r.Session.DoRequest("SoftLayer_Hardware_Server", "getRouters", nil, &r.Options, &resp)
+	return
+}
+
+// Retrieve Determine if hardware object has Software Guard Extension (SGX) enabled.
+func (r Hardware_Server) GetSGXEnabled() (resp bool, err error) {
+	err = r.Session.DoRequest("SoftLayer_Hardware_Server", "getSGXEnabled", nil, &r.Options, &resp)
 	return
 }
 

--- a/vendor/github.com/softlayer/softlayer-go/services/locale.go
+++ b/vendor/github.com/softlayer/softlayer-go/services/locale.go
@@ -124,6 +124,12 @@ func (r Locale_Country) Offset(offset int) Locale_Country {
 	return r
 }
 
+// This method is to get the collection of VAT country codes and VAT ID Regexes.
+func (r Locale_Country) GetAllVatCountryCodesAndVatIdRegexes() (resp []datatypes.Container_Collection_Locale_VatCountryCodeAndFormat, err error) {
+	err = r.Session.DoRequest("SoftLayer_Locale_Country", "getAllVatCountryCodesAndVatIdRegexes", nil, &r.Options, &resp)
+	return
+}
+
 // Use this method to retrieve a list of countries and locale information available to the current user.
 func (r Locale_Country) GetAvailableCountries() (resp []datatypes.Locale_Country, err error) {
 	err = r.Session.DoRequest("SoftLayer_Locale_Country", "getAvailableCountries", nil, &r.Options, &resp)

--- a/vendor/github.com/softlayer/softlayer-go/services/network.go
+++ b/vendor/github.com/softlayer/softlayer-go/services/network.go
@@ -1930,6 +1930,18 @@ func (r Network_CdnMarketplace_Account) Offset(offset int) Network_CdnMarketplac
 	return r
 }
 
+// Retrieve SoftLayer account to which the CDN account belongs.
+func (r Network_CdnMarketplace_Account) GetAccount() (resp datatypes.Account, err error) {
+	err = r.Session.DoRequest("SoftLayer_Network_CdnMarketplace_Account", "getAccount", nil, &r.Options, &resp)
+	return
+}
+
+// Retrieve An associated parent billing item which is active.
+func (r Network_CdnMarketplace_Account) GetBillingItem() (resp datatypes.Billing_Item, err error) {
+	err = r.Session.DoRequest("SoftLayer_Network_CdnMarketplace_Account", "getBillingItem", nil, &r.Options, &resp)
+	return
+}
+
 // no documentation yet
 func (r Network_CdnMarketplace_Account) GetObject() (resp datatypes.Network_CdnMarketplace_Account, err error) {
 	err = r.Session.DoRequest("SoftLayer_Network_CdnMarketplace_Account", "getObject", nil, &r.Options, &resp)
@@ -2018,18 +2030,6 @@ func (r Network_CdnMarketplace_Configuration_Cache_Purge) GetPurgeStatus(uniqueI
 		path,
 	}
 	err = r.Session.DoRequest("SoftLayer_Network_CdnMarketplace_Configuration_Cache_Purge", "getPurgeStatus", params, &r.Options, &resp)
-	return
-}
-
-// no documentation yet
-func (r Network_CdnMarketplace_Configuration_Cache_Purge) GetPurgesPerMapping(transactionId *int, softLayerAccountId *int, uniqueId *string, saved *int) (resp []datatypes.Container_Network_CdnMarketplace_Configuration_Cache_Purge, err error) {
-	params := []interface{}{
-		transactionId,
-		softLayerAccountId,
-		uniqueId,
-		saved,
-	}
-	err = r.Session.DoRequest("SoftLayer_Network_CdnMarketplace_Configuration_Cache_Purge", "getPurgesPerMapping", params, &r.Options, &resp)
 	return
 }
 
@@ -2198,18 +2198,6 @@ func (r Network_CdnMarketplace_Configuration_Mapping) GetObject() (resp datatype
 }
 
 // no documentation yet
-func (r Network_CdnMarketplace_Configuration_Mapping) ListCustomerDomains(transactionId *int, softLayerAccountId *int, vendorName *string, status *int) (resp []datatypes.Container_Network_CdnMarketplace_Configuration_Mapping, err error) {
-	params := []interface{}{
-		transactionId,
-		softLayerAccountId,
-		vendorName,
-		status,
-	}
-	err = r.Session.DoRequest("SoftLayer_Network_CdnMarketplace_Configuration_Mapping", "listCustomerDomains", params, &r.Options, &resp)
-	return
-}
-
-// no documentation yet
 func (r Network_CdnMarketplace_Configuration_Mapping) ListDomainMappingByUniqueId(uniqueId *string) (resp []datatypes.Container_Network_CdnMarketplace_Configuration_Mapping, err error) {
 	params := []interface{}{
 		uniqueId,
@@ -2251,7 +2239,7 @@ func (r Network_CdnMarketplace_Configuration_Mapping) UpdateDomainMapping(input 
 	return
 }
 
-// Verifies the CNAME is Unique in the domain. The method will return true if CNAME is unique else false
+// Verifies the CNAME is Unique in the domain. The method will return true if CNAME is unique else returns false
 func (r Network_CdnMarketplace_Configuration_Mapping) VerifyCname(cname *string) (resp bool, err error) {
 	params := []interface{}{
 		cname,
@@ -3660,6 +3648,119 @@ func (r Network_Customer_Subnet) GetObject() (resp datatypes.Network_Customer_Su
 	return
 }
 
+// The SoftLayer_Network_DirectLink_CloudExchangeProvider presents a structure containing attributes of a Direct Link Cloud exchange provider.
+type Network_DirectLink_CloudExchangeProvider struct {
+	Session *session.Session
+	Options sl.Options
+}
+
+// GetNetworkDirectLinkCloudExchangeProviderService returns an instance of the Network_DirectLink_CloudExchangeProvider SoftLayer service
+func GetNetworkDirectLinkCloudExchangeProviderService(sess *session.Session) Network_DirectLink_CloudExchangeProvider {
+	return Network_DirectLink_CloudExchangeProvider{Session: sess}
+}
+
+func (r Network_DirectLink_CloudExchangeProvider) Id(id int) Network_DirectLink_CloudExchangeProvider {
+	r.Options.Id = &id
+	return r
+}
+
+func (r Network_DirectLink_CloudExchangeProvider) Mask(mask string) Network_DirectLink_CloudExchangeProvider {
+	if !strings.HasPrefix(mask, "mask[") && (strings.Contains(mask, "[") || strings.Contains(mask, ",")) {
+		mask = fmt.Sprintf("mask[%s]", mask)
+	}
+
+	r.Options.Mask = mask
+	return r
+}
+
+func (r Network_DirectLink_CloudExchangeProvider) Filter(filter string) Network_DirectLink_CloudExchangeProvider {
+	r.Options.Filter = filter
+	return r
+}
+
+func (r Network_DirectLink_CloudExchangeProvider) Limit(limit int) Network_DirectLink_CloudExchangeProvider {
+	r.Options.Limit = &limit
+	return r
+}
+
+func (r Network_DirectLink_CloudExchangeProvider) Offset(offset int) Network_DirectLink_CloudExchangeProvider {
+	r.Options.Offset = &offset
+	return r
+}
+
+// no documentation yet
+func (r Network_DirectLink_CloudExchangeProvider) GetObject() (resp datatypes.Network_DirectLink_CloudExchangeProvider, err error) {
+	err = r.Session.DoRequest("SoftLayer_Network_DirectLink_CloudExchangeProvider", "getObject", nil, &r.Options, &resp)
+	return
+}
+
+// The SoftLayer_Network_DirectLink_Location presents a structure containing attributes of a Direct Link location, and its related object SoftLayer location.
+type Network_DirectLink_Location struct {
+	Session *session.Session
+	Options sl.Options
+}
+
+// GetNetworkDirectLinkLocationService returns an instance of the Network_DirectLink_Location SoftLayer service
+func GetNetworkDirectLinkLocationService(sess *session.Session) Network_DirectLink_Location {
+	return Network_DirectLink_Location{Session: sess}
+}
+
+func (r Network_DirectLink_Location) Id(id int) Network_DirectLink_Location {
+	r.Options.Id = &id
+	return r
+}
+
+func (r Network_DirectLink_Location) Mask(mask string) Network_DirectLink_Location {
+	if !strings.HasPrefix(mask, "mask[") && (strings.Contains(mask, "[") || strings.Contains(mask, ",")) {
+		mask = fmt.Sprintf("mask[%s]", mask)
+	}
+
+	r.Options.Mask = mask
+	return r
+}
+
+func (r Network_DirectLink_Location) Filter(filter string) Network_DirectLink_Location {
+	r.Options.Filter = filter
+	return r
+}
+
+func (r Network_DirectLink_Location) Limit(limit int) Network_DirectLink_Location {
+	r.Options.Limit = &limit
+	return r
+}
+
+func (r Network_DirectLink_Location) Offset(offset int) Network_DirectLink_Location {
+	r.Options.Offset = &offset
+	return r
+}
+
+// Retrieve The Id of Direct Link cloud exchange provider.
+func (r Network_DirectLink_Location) GetCloudExchangeProvider() (resp datatypes.Network_DirectLink_CloudExchangeProvider, err error) {
+	err = r.Session.DoRequest("SoftLayer_Network_DirectLink_Location", "getCloudExchangeProvider", nil, &r.Options, &resp)
+	return
+}
+
+// Retrieve all locations for a Cloud Exchange Provider. IBM SoftLayer's datacenters exist in various cities and each contain one or more infrastructure.
+func (r Network_DirectLink_Location) GetCloudExchangeProviderLocations(provider *string) (resp []datatypes.Network_DirectLink_Location, err error) {
+	params := []interface{}{
+		provider,
+	}
+	err = r.Session.DoRequest("SoftLayer_Network_DirectLink_Location", "getCloudExchangeProviderLocations", params, &r.Options, &resp)
+	return
+}
+
+// Retrieve The location of Direct Link facility.
+func (r Network_DirectLink_Location) GetLocation() (resp datatypes.Location, err error) {
+	err = r.Session.DoRequest("SoftLayer_Network_DirectLink_Location", "getLocation", nil, &r.Options, &resp)
+	return
+}
+
+// no documentation yet
+func (r Network_DirectLink_Location) GetObject() (resp datatypes.Network_DirectLink_Location, err error) {
+	err = r.Session.DoRequest("SoftLayer_Network_DirectLink_Location", "getObject", nil, &r.Options, &resp)
+	return
+}
+
 // The SoftLayer_Network_Firewall_AccessControlList data type contains general information relating to a single SoftLayer firewall access to controll list. This is the object which ties the running rules to a specific context. Use the [[SoftLayer Network Firewall Template]] service to pull SoftLayer recommended rule set templates. Use the [[SoftLayer Network Firewall Update Request]] service to submit a firewall update request.
 type Network_Firewall_AccessControlList struct {
 	Session *session.Session
@@ -4185,6 +4286,12 @@ func (r Network_Gateway) GetNetworkFirewall() (resp datatypes.Network_Vlan_Firew
 	return
 }
 
+// Retrieve Whether or not there is a firewall associated with this gateway.
+func (r Network_Gateway) GetNetworkFirewallFlag() (resp bool, err error) {
+	err = r.Session.DoRequest("SoftLayer_Network_Gateway", "getNetworkFirewallFlag", nil, &r.Options, &resp)
+	return
+}
+
 // no documentation yet
 func (r Network_Gateway) GetObject() (resp datatypes.Network_Gateway, err error) {
 	err = r.Session.DoRequest("SoftLayer_Network_Gateway", "getObject", nil, &r.Options, &resp)
@@ -4478,6 +4585,103 @@ func (r Network_Gateway_Vlan) Unbypass() (err error) {
 	return
 }
 
+// no documentation yet
+type Network_Interconnect_Tenant struct {
+	Session *session.Session
+	Options sl.Options
+}
+
+// GetNetworkInterconnectTenantService returns an instance of the Network_Interconnect_Tenant SoftLayer service
+func GetNetworkInterconnectTenantService(sess *session.Session) Network_Interconnect_Tenant {
+	return Network_Interconnect_Tenant{Session: sess}
+}
+
+func (r Network_Interconnect_Tenant) Id(id int) Network_Interconnect_Tenant {
+	r.Options.Id = &id
+	return r
+}
+
+func (r Network_Interconnect_Tenant) Mask(mask string) Network_Interconnect_Tenant {
+	if !strings.HasPrefix(mask, "mask[") && (strings.Contains(mask, "[") || strings.Contains(mask, ",")) {
+		mask = fmt.Sprintf("mask[%s]", mask)
+	}
+
+	r.Options.Mask = mask
+	return r
+}
+
+func (r Network_Interconnect_Tenant) Filter(filter string) Network_Interconnect_Tenant {
+	r.Options.Filter = filter
+	return r
+}
+
+func (r Network_Interconnect_Tenant) Limit(limit int) Network_Interconnect_Tenant {
+	r.Options.Limit = &limit
+	return r
+}
+
+func (r Network_Interconnect_Tenant) Offset(offset int) Network_Interconnect_Tenant {
+	r.Options.Offset = &offset
+	return r
+}
+
+// no documentation yet
+func (r Network_Interconnect_Tenant) GetAllObjects() (resp []datatypes.Network_Interconnect_Tenant, err error) {
+	err = r.Session.DoRequest("SoftLayer_Network_Interconnect_Tenant", "getAllObjects", nil, &r.Options, &resp)
+	return
+}
+
+// Retrieve The billing item for a network interconnect.
+func (r Network_Interconnect_Tenant) GetBillingItem() (resp datatypes.Billing_Item_Network_Interconnect, err error) {
+	err = r.Session.DoRequest("SoftLayer_Network_Interconnect_Tenant", "getBillingItem", nil, &r.Options, &resp)
+	return
+}
+
+// Retrieve
+func (r Network_Interconnect_Tenant) GetDatacenterName() (resp string, err error) {
+	err = r.Session.DoRequest("SoftLayer_Network_Interconnect_Tenant", "getDatacenterName", nil, &r.Options, &resp)
+	return
+}
+
+// no documentation yet
+func (r Network_Interconnect_Tenant) GetDirectLinkSpeeds(offeringType *string) (resp string, err error) {
+	params := []interface{}{
+		offeringType,
+	}
+	err = r.Session.DoRequest("SoftLayer_Network_Interconnect_Tenant", "getDirectLinkSpeeds", params, &r.Options, &resp)
+	return
+}
+
+// no documentation yet
+func (r Network_Interconnect_Tenant) GetNetworkZones() (resp []string, err error) {
+	err = r.Session.DoRequest("SoftLayer_Network_Interconnect_Tenant", "getNetworkZones", nil, &r.Options, &resp)
+	return
+}
+
+// no documentation yet
+func (r Network_Interconnect_Tenant) GetObject() (resp datatypes.Network_Interconnect_Tenant, err error) {
+	err = r.Session.DoRequest("SoftLayer_Network_Interconnect_Tenant", "getObject", nil, &r.Options, &resp)
+	return
+}
+
+// Retrieve
+func (r Network_Interconnect_Tenant) GetVendorName() (resp string, err error) {
+	err = r.Session.DoRequest("SoftLayer_Network_Interconnect_Tenant", "getVendorName", nil, &r.Options, &resp)
+	return
+}
+
+// Retrieve
+func (r Network_Interconnect_Tenant) GetZoneName() (resp string, err error) {
+	err = r.Session.DoRequest("SoftLayer_Network_Interconnect_Tenant", "getZoneName", nil, &r.Options, &resp)
+	return
+}
+
+// no documentation yet
+func (r Network_Interconnect_Tenant) IsAdnAccount() (resp bool, err error) {
+	err = r.Session.DoRequest("SoftLayer_Network_Interconnect_Tenant", "isAdnAccount", nil, &r.Options, &resp)
+	return
+}
+
 // The SoftLayer_Network_LBaaS_HealthMonitor type presents a structure containing attributes of a health monitor object associated with load balancer instance. Note that the relationship between backend (pool) and health monitor is N-to-1, especially that the pools object associated with a health monitor must have the same pair of protocol and port. Example: frontend FA: http, 80   - backend BA: tcp, 3456 - healthmonitor HM_tcp3456 frontend FB: https, 443 - backend BB: tcp, 3456 - healthmonitor HM_tcp3456 In above example both backends BA and BB share the same healthmonitor HM_tcp3456
 type Network_LBaaS_HealthMonitor struct {
 	Session *session.Session
@@ -4670,12 +4874,6 @@ func (r Network_LBaaS_LoadBalancer) GetDatacenter() (resp datatypes.Location, er
 // Retrieve Health monitors for the backend members.
 func (r Network_LBaaS_LoadBalancer) GetHealthMonitors() (resp []datatypes.Network_LBaaS_HealthMonitor, err error) {
 	err = r.Session.DoRequest("SoftLayer_Network_LBaaS_LoadBalancer", "getHealthMonitors", nil, &r.Options, &resp)
-	return
-}
-
-// Retrieve
-func (r Network_LBaaS_LoadBalancer) GetIpAddress() (resp datatypes.Network_Subnet_IpAddress, err error) {
-	err = r.Session.DoRequest("SoftLayer_Network_LBaaS_LoadBalancer", "getIpAddress", nil, &r.Options, &resp)
 	return
 }
 
@@ -6258,8 +6456,6 @@ func (r Network_Pod) ListCapabilities() (resp []string, err error) {
 	return
 }
 
-// This is a Beta release of the Security Group feature. The use of this feature is restricted to select users. When the Beta period is over, security groups will be available for all users. Contact sgbeta@us.ibm.com using 'Security Groups' in the subject line with any questions.
-//
 // The SoftLayer_Network_SecurityGroup data type contains general information for a single security group. A security group contains a set of IP filter [[SoftLayer_Network_SecurityGroup_Rule (type)|rules]] that define how to handle incoming (ingress) and outgoing (egress) traffic to both the public and private interfaces of a virtual server instance and a set of [[SoftLayer_Virtual_Network_SecurityGroup_NetworkComponentBinding (type)|bindings]] to associate virtual guest network components with the security group.
 type Network_SecurityGroup struct {
 	Session *session.Session
@@ -6301,7 +6497,7 @@ func (r Network_SecurityGroup) Offset(offset int) Network_SecurityGroup {
 }
 
 // Add new rules to a security group by sending in an array of template [[SoftLayer_Network_SecurityGroup_Rule (type)]] objects to be created.
-func (r Network_SecurityGroup) AddRules(ruleTemplates []datatypes.Network_SecurityGroup_Rule) (resp bool, err error) {
+func (r Network_SecurityGroup) AddRules(ruleTemplates []datatypes.Network_SecurityGroup_Rule) (resp datatypes.Network_SecurityGroup_Request, err error) {
 	params := []interface{}{
 		ruleTemplates,
 	}
@@ -6310,11 +6506,20 @@ func (r Network_SecurityGroup) AddRules(ruleTemplates []datatypes.Network_Securi
 }
 
 // Attach virtual guest network components to a security group by creating [[SoftLayer_Virtual_Network_SecurityGroup_NetworkComponentBinding (type)]] objects.
-func (r Network_SecurityGroup) AttachNetworkComponents(networkComponentIds []int) (resp bool, err error) {
+func (r Network_SecurityGroup) AttachNetworkComponents(networkComponentIds []int) (resp datatypes.Network_SecurityGroup_Request, err error) {
 	params := []interface{}{
 		networkComponentIds,
 	}
 	err = r.Session.DoRequest("SoftLayer_Network_SecurityGroup", "attachNetworkComponents", params, &r.Options, &resp)
+	return
+}
+
+// Create a new security group.
+func (r Network_SecurityGroup) CreateObject(templateObject *datatypes.Network_SecurityGroup) (resp datatypes.Network_SecurityGroup, err error) {
+	params := []interface{}{
+		templateObject,
+	}
+	err = r.Session.DoRequest("SoftLayer_Network_SecurityGroup", "createObject", params, &r.Options, &resp)
 	return
 }
 
@@ -6324,6 +6529,12 @@ func (r Network_SecurityGroup) CreateObjects(templateObjects []datatypes.Network
 		templateObjects,
 	}
 	err = r.Session.DoRequest("SoftLayer_Network_SecurityGroup", "createObjects", params, &r.Options, &resp)
+	return
+}
+
+// Delete a security group for an account. A security group cannot be deleted if any network components are attached or if the security group is a remote security group for a [[SoftLayer_Network_SecurityGroup_Rule (type)|rule]].
+func (r Network_SecurityGroup) DeleteObject() (resp bool, err error) {
+	err = r.Session.DoRequest("SoftLayer_Network_SecurityGroup", "deleteObject", nil, &r.Options, &resp)
 	return
 }
 
@@ -6337,11 +6548,20 @@ func (r Network_SecurityGroup) DeleteObjects(templateObjects []datatypes.Network
 }
 
 // Detach virtual guest network components from a security group by deleting its [[SoftLayer_Virtual_Network_SecurityGroup_NetworkComponentBinding (type)]].
-func (r Network_SecurityGroup) DetachNetworkComponents(networkComponentIds []int) (resp bool, err error) {
+func (r Network_SecurityGroup) DetachNetworkComponents(networkComponentIds []int) (resp datatypes.Network_SecurityGroup_Request, err error) {
 	params := []interface{}{
 		networkComponentIds,
 	}
 	err = r.Session.DoRequest("SoftLayer_Network_SecurityGroup", "detachNetworkComponents", params, &r.Options, &resp)
+	return
+}
+
+// Edit a security group.
+func (r Network_SecurityGroup) EditObject(templateObject *datatypes.Network_SecurityGroup) (resp bool, err error) {
+	params := []interface{}{
+		templateObject,
+	}
+	err = r.Session.DoRequest("SoftLayer_Network_SecurityGroup", "editObject", params, &r.Options, &resp)
 	return
 }
 
@@ -6355,7 +6575,7 @@ func (r Network_SecurityGroup) EditObjects(templateObjects []datatypes.Network_S
 }
 
 // Edit rules that belong to the security group. An array of skeleton [[SoftLayer_Network_SecurityGroup_Rule]] objects must be sent in with only the properties defined that you want to change. To edit a property to null, send in -1 for integer properties and "" for string properties. Unchanged properties are left alone.
-func (r Network_SecurityGroup) EditRules(rules []datatypes.Network_SecurityGroup_Rule) (resp bool, err error) {
+func (r Network_SecurityGroup) EditRules(rules []datatypes.Network_SecurityGroup_Rule) (resp datatypes.Network_SecurityGroup_Request, err error) {
 	params := []interface{}{
 		rules,
 	}
@@ -6405,8 +6625,14 @@ func (r Network_SecurityGroup) GetRules() (resp []datatypes.Network_SecurityGrou
 	return
 }
 
+// List the data centers that currently support the use of security groups.
+func (r Network_SecurityGroup) GetSupportedDataCenters() (resp []datatypes.Location, err error) {
+	err = r.Session.DoRequest("SoftLayer_Network_SecurityGroup", "getSupportedDataCenters", nil, &r.Options, &resp)
+	return
+}
+
 // Remove rules from a security group.
-func (r Network_SecurityGroup) RemoveRules(ruleIds []int) (resp bool, err error) {
+func (r Network_SecurityGroup) RemoveRules(ruleIds []int) (resp datatypes.Network_SecurityGroup_Request, err error) {
 	params := []interface{}{
 		ruleIds,
 	}
@@ -6854,7 +7080,7 @@ func (r Network_Storage) CreateFolder(folder *string) (resp bool, err error) {
 	return
 }
 
-// The LUN ID only takes effect during the Host Authorization process. It is recommended (but not necessary) to de-authorize all hosts before using this method.
+// The LUN ID only takes effect during the Host Authorization process. It is required to de-authorize all hosts before using this method.
 func (r Network_Storage) CreateOrUpdateLunId(lunId *int) (resp datatypes.Network_Storage_Property, err error) {
 	params := []interface{}{
 		lunId,
@@ -7446,6 +7672,12 @@ func (r Network_Storage) GetRemainingAllowedHosts() (resp int, err error) {
 	return
 }
 
+// Retrieves the remaining number of allowed hosts for a volume's replicant.
+func (r Network_Storage) GetRemainingAllowedHostsForReplicant() (resp int, err error) {
+	err = r.Session.DoRequest("SoftLayer_Network_Storage", "getRemainingAllowedHostsForReplicant", nil, &r.Options, &resp)
+	return
+}
+
 // Retrieve The iSCSI LUN volumes being replicated by this network storage volume.
 func (r Network_Storage) GetReplicatingLuns() (resp []datatypes.Network_Storage, err error) {
 	err = r.Session.DoRequest("SoftLayer_Network_Storage", "getReplicatingLuns", nil, &r.Options, &resp)
@@ -7934,6 +8166,45 @@ func (r Network_Storage_Allowed_Host) Offset(offset int) Network_Storage_Allowed
 	return r
 }
 
+// This method is used to create a new SoftLayer_Network_Storage_Allowed_Host using an existing SoftLayer_Hardware object's id.
+func (r Network_Storage_Allowed_Host) CreateFromHardware(hardwareId *int, iqn *string) (resp datatypes.Network_Storage_Allowed_Host, err error) {
+	params := []interface{}{
+		hardwareId,
+		iqn,
+	}
+	err = r.Session.DoRequest("SoftLayer_Network_Storage_Allowed_Host", "createFromHardware", params, &r.Options, &resp)
+	return
+}
+
+// This method is used to create a new SoftLayer_Network_Storage_Allowed_Host using an existing SoftLayer_Network_Subnet_IpAddress object's id.
+func (r Network_Storage_Allowed_Host) CreateFromIpAddress(ipAddressId *int, iqn *string) (resp datatypes.Network_Storage_Allowed_Host, err error) {
+	params := []interface{}{
+		ipAddressId,
+		iqn,
+	}
+	err = r.Session.DoRequest("SoftLayer_Network_Storage_Allowed_Host", "createFromIpAddress", params, &r.Options, &resp)
+	return
+}
+
+// This method is used to create a new SoftLayer_Network_Storage_Allowed_Host using an existing SoftLayer_Network_Subnet object's id. Allowed_Host objects created for SoftLayer_Network_Subnet objects do not support IQNs.
+func (r Network_Storage_Allowed_Host) CreateFromSubnet(subnetId *int) (resp datatypes.Network_Storage_Allowed_Host, err error) {
+	params := []interface{}{
+		subnetId,
+	}
+	err = r.Session.DoRequest("SoftLayer_Network_Storage_Allowed_Host", "createFromSubnet", params, &r.Options, &resp)
+	return
+}
+
+// This method is used to create a new SoftLayer_Network_Storage_Allowed_Host using an existing SoftLayer_Virtual_Guest object's id.
+func (r Network_Storage_Allowed_Host) CreateFromVirtualGuest(virtualGuestId *int, iqn *string) (resp datatypes.Network_Storage_Allowed_Host, err error) {
+	params := []interface{}{
+		virtualGuestId,
+		iqn,
+	}
+	err = r.Session.DoRequest("SoftLayer_Network_Storage_Allowed_Host", "createFromVirtualGuest", params, &r.Options, &resp)
+	return
+}
+
 // no documentation yet
 func (r Network_Storage_Allowed_Host) CreateObject(templateObject *datatypes.Network_Storage_Allowed_Host) (resp bool, err error) {
 	params := []interface{}{
@@ -7988,6 +8259,12 @@ func (r Network_Storage_Allowed_Host) GetObject() (resp datatypes.Network_Storag
 	return
 }
 
+// Retrieve Connections to a target with a source IP in this subnet prefix are allowed.
+func (r Network_Storage_Allowed_Host) GetSourceSubnet() (resp string, err error) {
+	err = r.Session.DoRequest("SoftLayer_Network_Storage_Allowed_Host", "getSourceSubnet", nil, &r.Options, &resp)
+	return
+}
+
 // Use this method to modify the credential password for a SoftLayer_Network_Storage_Allowed_Host object.
 func (r Network_Storage_Allowed_Host) SetCredentialPassword(password *string) (resp bool, err error) {
 	params := []interface{}{
@@ -8037,6 +8314,45 @@ func (r Network_Storage_Allowed_Host_Hardware) Offset(offset int) Network_Storag
 	return r
 }
 
+// This method is used to create a new SoftLayer_Network_Storage_Allowed_Host using an existing SoftLayer_Hardware object's id.
+func (r Network_Storage_Allowed_Host_Hardware) CreateFromHardware(hardwareId *int, iqn *string) (resp datatypes.Network_Storage_Allowed_Host, err error) {
+	params := []interface{}{
+		hardwareId,
+		iqn,
+	}
+	err = r.Session.DoRequest("SoftLayer_Network_Storage_Allowed_Host_Hardware", "createFromHardware", params, &r.Options, &resp)
+	return
+}
+
+// This method is used to create a new SoftLayer_Network_Storage_Allowed_Host using an existing SoftLayer_Network_Subnet_IpAddress object's id.
+func (r Network_Storage_Allowed_Host_Hardware) CreateFromIpAddress(ipAddressId *int, iqn *string) (resp datatypes.Network_Storage_Allowed_Host, err error) {
+	params := []interface{}{
+		ipAddressId,
+		iqn,
+	}
+	err = r.Session.DoRequest("SoftLayer_Network_Storage_Allowed_Host_Hardware", "createFromIpAddress", params, &r.Options, &resp)
+	return
+}
+
+// This method is used to create a new SoftLayer_Network_Storage_Allowed_Host using an existing SoftLayer_Network_Subnet object's id. Allowed_Host objects created for SoftLayer_Network_Subnet objects do not support IQNs.
+func (r Network_Storage_Allowed_Host_Hardware) CreateFromSubnet(subnetId *int) (resp datatypes.Network_Storage_Allowed_Host, err error) {
+	params := []interface{}{
+		subnetId,
+	}
+	err = r.Session.DoRequest("SoftLayer_Network_Storage_Allowed_Host_Hardware", "createFromSubnet", params, &r.Options, &resp)
+	return
+}
+
+// This method is used to create a new SoftLayer_Network_Storage_Allowed_Host using an existing SoftLayer_Virtual_Guest object's id.
+func (r Network_Storage_Allowed_Host_Hardware) CreateFromVirtualGuest(virtualGuestId *int, iqn *string) (resp datatypes.Network_Storage_Allowed_Host, err error) {
+	params := []interface{}{
+		virtualGuestId,
+		iqn,
+	}
+	err = r.Session.DoRequest("SoftLayer_Network_Storage_Allowed_Host_Hardware", "createFromVirtualGuest", params, &r.Options, &resp)
+	return
+}
+
 // no documentation yet
 func (r Network_Storage_Allowed_Host_Hardware) CreateObject(templateObject *datatypes.Network_Storage_Allowed_Host) (resp bool, err error) {
 	params := []interface{}{
@@ -8058,6 +8374,12 @@ func (r Network_Storage_Allowed_Host_Hardware) EditObject(templateObject *dataty
 		templateObject,
 	}
 	err = r.Session.DoRequest("SoftLayer_Network_Storage_Allowed_Host_Hardware", "editObject", params, &r.Options, &resp)
+	return
+}
+
+// Retrieve The SoftLayer_Account object which this SoftLayer_Network_Storage_Allowed_Host belongs to.
+func (r Network_Storage_Allowed_Host_Hardware) GetAccount() (resp datatypes.Account, err error) {
+	err = r.Session.DoRequest("SoftLayer_Network_Storage_Allowed_Host_Hardware", "getAccount", nil, &r.Options, &resp)
 	return
 }
 
@@ -8094,6 +8416,12 @@ func (r Network_Storage_Allowed_Host_Hardware) GetObject() (resp datatypes.Netwo
 // Retrieve The SoftLayer_Hardware object which this SoftLayer_Network_Storage_Allowed_Host is referencing.
 func (r Network_Storage_Allowed_Host_Hardware) GetResource() (resp datatypes.Hardware, err error) {
 	err = r.Session.DoRequest("SoftLayer_Network_Storage_Allowed_Host_Hardware", "getResource", nil, &r.Options, &resp)
+	return
+}
+
+// Retrieve Connections to a target with a source IP in this subnet prefix are allowed.
+func (r Network_Storage_Allowed_Host_Hardware) GetSourceSubnet() (resp string, err error) {
+	err = r.Session.DoRequest("SoftLayer_Network_Storage_Allowed_Host_Hardware", "getSourceSubnet", nil, &r.Options, &resp)
 	return
 }
 
@@ -8146,6 +8474,45 @@ func (r Network_Storage_Allowed_Host_IpAddress) Offset(offset int) Network_Stora
 	return r
 }
 
+// This method is used to create a new SoftLayer_Network_Storage_Allowed_Host using an existing SoftLayer_Hardware object's id.
+func (r Network_Storage_Allowed_Host_IpAddress) CreateFromHardware(hardwareId *int, iqn *string) (resp datatypes.Network_Storage_Allowed_Host, err error) {
+	params := []interface{}{
+		hardwareId,
+		iqn,
+	}
+	err = r.Session.DoRequest("SoftLayer_Network_Storage_Allowed_Host_IpAddress", "createFromHardware", params, &r.Options, &resp)
+	return
+}
+
+// This method is used to create a new SoftLayer_Network_Storage_Allowed_Host using an existing SoftLayer_Network_Subnet_IpAddress object's id.
+func (r Network_Storage_Allowed_Host_IpAddress) CreateFromIpAddress(ipAddressId *int, iqn *string) (resp datatypes.Network_Storage_Allowed_Host, err error) {
+	params := []interface{}{
+		ipAddressId,
+		iqn,
+	}
+	err = r.Session.DoRequest("SoftLayer_Network_Storage_Allowed_Host_IpAddress", "createFromIpAddress", params, &r.Options, &resp)
+	return
+}
+
+// This method is used to create a new SoftLayer_Network_Storage_Allowed_Host using an existing SoftLayer_Network_Subnet object's id. Allowed_Host objects created for SoftLayer_Network_Subnet objects do not support IQNs.
+func (r Network_Storage_Allowed_Host_IpAddress) CreateFromSubnet(subnetId *int) (resp datatypes.Network_Storage_Allowed_Host, err error) {
+	params := []interface{}{
+		subnetId,
+	}
+	err = r.Session.DoRequest("SoftLayer_Network_Storage_Allowed_Host_IpAddress", "createFromSubnet", params, &r.Options, &resp)
+	return
+}
+
+// This method is used to create a new SoftLayer_Network_Storage_Allowed_Host using an existing SoftLayer_Virtual_Guest object's id.
+func (r Network_Storage_Allowed_Host_IpAddress) CreateFromVirtualGuest(virtualGuestId *int, iqn *string) (resp datatypes.Network_Storage_Allowed_Host, err error) {
+	params := []interface{}{
+		virtualGuestId,
+		iqn,
+	}
+	err = r.Session.DoRequest("SoftLayer_Network_Storage_Allowed_Host_IpAddress", "createFromVirtualGuest", params, &r.Options, &resp)
+	return
+}
+
 // no documentation yet
 func (r Network_Storage_Allowed_Host_IpAddress) CreateObject(templateObject *datatypes.Network_Storage_Allowed_Host) (resp bool, err error) {
 	params := []interface{}{
@@ -8167,6 +8534,12 @@ func (r Network_Storage_Allowed_Host_IpAddress) EditObject(templateObject *datat
 		templateObject,
 	}
 	err = r.Session.DoRequest("SoftLayer_Network_Storage_Allowed_Host_IpAddress", "editObject", params, &r.Options, &resp)
+	return
+}
+
+// Retrieve The SoftLayer_Account object which this SoftLayer_Network_Storage_Allowed_Host belongs to.
+func (r Network_Storage_Allowed_Host_IpAddress) GetAccount() (resp datatypes.Account, err error) {
+	err = r.Session.DoRequest("SoftLayer_Network_Storage_Allowed_Host_IpAddress", "getAccount", nil, &r.Options, &resp)
 	return
 }
 
@@ -8203,6 +8576,12 @@ func (r Network_Storage_Allowed_Host_IpAddress) GetObject() (resp datatypes.Netw
 // Retrieve The SoftLayer_Network_Subnet_IpAddress object which this SoftLayer_Network_Storage_Allowed_Host is referencing.
 func (r Network_Storage_Allowed_Host_IpAddress) GetResource() (resp datatypes.Network_Subnet_IpAddress, err error) {
 	err = r.Session.DoRequest("SoftLayer_Network_Storage_Allowed_Host_IpAddress", "getResource", nil, &r.Options, &resp)
+	return
+}
+
+// Retrieve Connections to a target with a source IP in this subnet prefix are allowed.
+func (r Network_Storage_Allowed_Host_IpAddress) GetSourceSubnet() (resp string, err error) {
+	err = r.Session.DoRequest("SoftLayer_Network_Storage_Allowed_Host_IpAddress", "getSourceSubnet", nil, &r.Options, &resp)
 	return
 }
 
@@ -8255,6 +8634,45 @@ func (r Network_Storage_Allowed_Host_Subnet) Offset(offset int) Network_Storage_
 	return r
 }
 
+// This method is used to create a new SoftLayer_Network_Storage_Allowed_Host using an existing SoftLayer_Hardware object's id.
+func (r Network_Storage_Allowed_Host_Subnet) CreateFromHardware(hardwareId *int, iqn *string) (resp datatypes.Network_Storage_Allowed_Host, err error) {
+	params := []interface{}{
+		hardwareId,
+		iqn,
+	}
+	err = r.Session.DoRequest("SoftLayer_Network_Storage_Allowed_Host_Subnet", "createFromHardware", params, &r.Options, &resp)
+	return
+}
+
+// This method is used to create a new SoftLayer_Network_Storage_Allowed_Host using an existing SoftLayer_Network_Subnet_IpAddress object's id.
+func (r Network_Storage_Allowed_Host_Subnet) CreateFromIpAddress(ipAddressId *int, iqn *string) (resp datatypes.Network_Storage_Allowed_Host, err error) {
+	params := []interface{}{
+		ipAddressId,
+		iqn,
+	}
+	err = r.Session.DoRequest("SoftLayer_Network_Storage_Allowed_Host_Subnet", "createFromIpAddress", params, &r.Options, &resp)
+	return
+}
+
+// This method is used to create a new SoftLayer_Network_Storage_Allowed_Host using an existing SoftLayer_Network_Subnet object's id. Allowed_Host objects created for SoftLayer_Network_Subnet objects do not support IQNs.
+func (r Network_Storage_Allowed_Host_Subnet) CreateFromSubnet(subnetId *int) (resp datatypes.Network_Storage_Allowed_Host, err error) {
+	params := []interface{}{
+		subnetId,
+	}
+	err = r.Session.DoRequest("SoftLayer_Network_Storage_Allowed_Host_Subnet", "createFromSubnet", params, &r.Options, &resp)
+	return
+}
+
+// This method is used to create a new SoftLayer_Network_Storage_Allowed_Host using an existing SoftLayer_Virtual_Guest object's id.
+func (r Network_Storage_Allowed_Host_Subnet) CreateFromVirtualGuest(virtualGuestId *int, iqn *string) (resp datatypes.Network_Storage_Allowed_Host, err error) {
+	params := []interface{}{
+		virtualGuestId,
+		iqn,
+	}
+	err = r.Session.DoRequest("SoftLayer_Network_Storage_Allowed_Host_Subnet", "createFromVirtualGuest", params, &r.Options, &resp)
+	return
+}
+
 // no documentation yet
 func (r Network_Storage_Allowed_Host_Subnet) CreateObject(templateObject *datatypes.Network_Storage_Allowed_Host) (resp bool, err error) {
 	params := []interface{}{
@@ -8276,6 +8694,12 @@ func (r Network_Storage_Allowed_Host_Subnet) EditObject(templateObject *datatype
 		templateObject,
 	}
 	err = r.Session.DoRequest("SoftLayer_Network_Storage_Allowed_Host_Subnet", "editObject", params, &r.Options, &resp)
+	return
+}
+
+// Retrieve The SoftLayer_Account object which this SoftLayer_Network_Storage_Allowed_Host belongs to.
+func (r Network_Storage_Allowed_Host_Subnet) GetAccount() (resp datatypes.Account, err error) {
+	err = r.Session.DoRequest("SoftLayer_Network_Storage_Allowed_Host_Subnet", "getAccount", nil, &r.Options, &resp)
 	return
 }
 
@@ -8312,6 +8736,12 @@ func (r Network_Storage_Allowed_Host_Subnet) GetObject() (resp datatypes.Network
 // Retrieve The SoftLayer_Network_Subnet object which this SoftLayer_Network_Storage_Allowed_Host is referencing.
 func (r Network_Storage_Allowed_Host_Subnet) GetResource() (resp datatypes.Network_Subnet, err error) {
 	err = r.Session.DoRequest("SoftLayer_Network_Storage_Allowed_Host_Subnet", "getResource", nil, &r.Options, &resp)
+	return
+}
+
+// Retrieve Connections to a target with a source IP in this subnet prefix are allowed.
+func (r Network_Storage_Allowed_Host_Subnet) GetSourceSubnet() (resp string, err error) {
+	err = r.Session.DoRequest("SoftLayer_Network_Storage_Allowed_Host_Subnet", "getSourceSubnet", nil, &r.Options, &resp)
 	return
 }
 
@@ -8364,6 +8794,45 @@ func (r Network_Storage_Allowed_Host_VirtualGuest) Offset(offset int) Network_St
 	return r
 }
 
+// This method is used to create a new SoftLayer_Network_Storage_Allowed_Host using an existing SoftLayer_Hardware object's id.
+func (r Network_Storage_Allowed_Host_VirtualGuest) CreateFromHardware(hardwareId *int, iqn *string) (resp datatypes.Network_Storage_Allowed_Host, err error) {
+	params := []interface{}{
+		hardwareId,
+		iqn,
+	}
+	err = r.Session.DoRequest("SoftLayer_Network_Storage_Allowed_Host_VirtualGuest", "createFromHardware", params, &r.Options, &resp)
+	return
+}
+
+// This method is used to create a new SoftLayer_Network_Storage_Allowed_Host using an existing SoftLayer_Network_Subnet_IpAddress object's id.
+func (r Network_Storage_Allowed_Host_VirtualGuest) CreateFromIpAddress(ipAddressId *int, iqn *string) (resp datatypes.Network_Storage_Allowed_Host, err error) {
+	params := []interface{}{
+		ipAddressId,
+		iqn,
+	}
+	err = r.Session.DoRequest("SoftLayer_Network_Storage_Allowed_Host_VirtualGuest", "createFromIpAddress", params, &r.Options, &resp)
+	return
+}
+
+// This method is used to create a new SoftLayer_Network_Storage_Allowed_Host using an existing SoftLayer_Network_Subnet object's id. Allowed_Host objects created for SoftLayer_Network_Subnet objects do not support IQNs.
+func (r Network_Storage_Allowed_Host_VirtualGuest) CreateFromSubnet(subnetId *int) (resp datatypes.Network_Storage_Allowed_Host, err error) {
+	params := []interface{}{
+		subnetId,
+	}
+	err = r.Session.DoRequest("SoftLayer_Network_Storage_Allowed_Host_VirtualGuest", "createFromSubnet", params, &r.Options, &resp)
+	return
+}
+
+// This method is used to create a new SoftLayer_Network_Storage_Allowed_Host using an existing SoftLayer_Virtual_Guest object's id.
+func (r Network_Storage_Allowed_Host_VirtualGuest) CreateFromVirtualGuest(virtualGuestId *int, iqn *string) (resp datatypes.Network_Storage_Allowed_Host, err error) {
+	params := []interface{}{
+		virtualGuestId,
+		iqn,
+	}
+	err = r.Session.DoRequest("SoftLayer_Network_Storage_Allowed_Host_VirtualGuest", "createFromVirtualGuest", params, &r.Options, &resp)
+	return
+}
+
 // no documentation yet
 func (r Network_Storage_Allowed_Host_VirtualGuest) CreateObject(templateObject *datatypes.Network_Storage_Allowed_Host) (resp bool, err error) {
 	params := []interface{}{
@@ -8385,6 +8854,12 @@ func (r Network_Storage_Allowed_Host_VirtualGuest) EditObject(templateObject *da
 		templateObject,
 	}
 	err = r.Session.DoRequest("SoftLayer_Network_Storage_Allowed_Host_VirtualGuest", "editObject", params, &r.Options, &resp)
+	return
+}
+
+// Retrieve The SoftLayer_Account object which this SoftLayer_Network_Storage_Allowed_Host belongs to.
+func (r Network_Storage_Allowed_Host_VirtualGuest) GetAccount() (resp datatypes.Account, err error) {
+	err = r.Session.DoRequest("SoftLayer_Network_Storage_Allowed_Host_VirtualGuest", "getAccount", nil, &r.Options, &resp)
 	return
 }
 
@@ -8421,6 +8896,12 @@ func (r Network_Storage_Allowed_Host_VirtualGuest) GetObject() (resp datatypes.N
 // Retrieve The SoftLayer_Virtual_Guest object which this SoftLayer_Network_Storage_Allowed_Host is referencing.
 func (r Network_Storage_Allowed_Host_VirtualGuest) GetResource() (resp datatypes.Virtual_Guest, err error) {
 	err = r.Session.DoRequest("SoftLayer_Network_Storage_Allowed_Host_VirtualGuest", "getResource", nil, &r.Options, &resp)
+	return
+}
+
+// Retrieve Connections to a target with a source IP in this subnet prefix are allowed.
+func (r Network_Storage_Allowed_Host_VirtualGuest) GetSourceSubnet() (resp string, err error) {
+	err = r.Session.DoRequest("SoftLayer_Network_Storage_Allowed_Host_VirtualGuest", "getSourceSubnet", nil, &r.Options, &resp)
 	return
 }
 
@@ -8695,7 +9176,7 @@ func (r Network_Storage_Backup_Evault) CreateFolder(folder *string) (resp bool, 
 	return
 }
 
-// The LUN ID only takes effect during the Host Authorization process. It is recommended (but not necessary) to de-authorize all hosts before using this method.
+// The LUN ID only takes effect during the Host Authorization process. It is required to de-authorize all hosts before using this method.
 func (r Network_Storage_Backup_Evault) CreateOrUpdateLunId(lunId *int) (resp datatypes.Network_Storage_Property, err error) {
 	params := []interface{}{
 		lunId,
@@ -9315,6 +9796,12 @@ func (r Network_Storage_Backup_Evault) GetRecycleBinFileByIdentifier(fileId *str
 // Retrieves the remaining number of allowed hosts per volume.
 func (r Network_Storage_Backup_Evault) GetRemainingAllowedHosts() (resp int, err error) {
 	err = r.Session.DoRequest("SoftLayer_Network_Storage_Backup_Evault", "getRemainingAllowedHosts", nil, &r.Options, &resp)
+	return
+}
+
+// Retrieves the remaining number of allowed hosts for a volume's replicant.
+func (r Network_Storage_Backup_Evault) GetRemainingAllowedHostsForReplicant() (resp int, err error) {
+	err = r.Session.DoRequest("SoftLayer_Network_Storage_Backup_Evault", "getRemainingAllowedHostsForReplicant", nil, &r.Options, &resp)
 	return
 }
 
@@ -10762,7 +11249,7 @@ func (r Network_Storage_Iscsi) CreateFolder(folder *string) (resp bool, err erro
 	return
 }
 
-// The LUN ID only takes effect during the Host Authorization process. It is recommended (but not necessary) to de-authorize all hosts before using this method.
+// The LUN ID only takes effect during the Host Authorization process. It is required to de-authorize all hosts before using this method.
 func (r Network_Storage_Iscsi) CreateOrUpdateLunId(lunId *int) (resp datatypes.Network_Storage_Property, err error) {
 	params := []interface{}{
 		lunId,
@@ -11352,6 +11839,12 @@ func (r Network_Storage_Iscsi) GetRemainingAllowedHosts() (resp int, err error) 
 	return
 }
 
+// Retrieves the remaining number of allowed hosts for a volume's replicant.
+func (r Network_Storage_Iscsi) GetRemainingAllowedHostsForReplicant() (resp int, err error) {
+	err = r.Session.DoRequest("SoftLayer_Network_Storage_Iscsi", "getRemainingAllowedHostsForReplicant", nil, &r.Options, &resp)
+	return
+}
+
 // Retrieve The iSCSI LUN volumes being replicated by this network storage volume.
 func (r Network_Storage_Iscsi) GetReplicatingLuns() (resp []datatypes.Network_Storage, err error) {
 	err = r.Session.DoRequest("SoftLayer_Network_Storage_Iscsi", "getReplicatingLuns", nil, &r.Options, &resp)
@@ -11852,6 +12345,325 @@ func (r Network_Storage_Iscsi_OS_Type) GetObject() (resp datatypes.Network_Stora
 	return
 }
 
+// no documentation yet
+type Network_Storage_MassDataMigration_CrossRegion_Country_Xref struct {
+	Session *session.Session
+	Options sl.Options
+}
+
+// GetNetworkStorageMassDataMigrationCrossRegionCountryXrefService returns an instance of the Network_Storage_MassDataMigration_CrossRegion_Country_Xref SoftLayer service
+func GetNetworkStorageMassDataMigrationCrossRegionCountryXrefService(sess *session.Session) Network_Storage_MassDataMigration_CrossRegion_Country_Xref {
+	return Network_Storage_MassDataMigration_CrossRegion_Country_Xref{Session: sess}
+}
+
+func (r Network_Storage_MassDataMigration_CrossRegion_Country_Xref) Id(id int) Network_Storage_MassDataMigration_CrossRegion_Country_Xref {
+	r.Options.Id = &id
+	return r
+}
+
+func (r Network_Storage_MassDataMigration_CrossRegion_Country_Xref) Mask(mask string) Network_Storage_MassDataMigration_CrossRegion_Country_Xref {
+	if !strings.HasPrefix(mask, "mask[") && (strings.Contains(mask, "[") || strings.Contains(mask, ",")) {
+		mask = fmt.Sprintf("mask[%s]", mask)
+	}
+
+	r.Options.Mask = mask
+	return r
+}
+
+func (r Network_Storage_MassDataMigration_CrossRegion_Country_Xref) Filter(filter string) Network_Storage_MassDataMigration_CrossRegion_Country_Xref {
+	r.Options.Filter = filter
+	return r
+}
+
+func (r Network_Storage_MassDataMigration_CrossRegion_Country_Xref) Limit(limit int) Network_Storage_MassDataMigration_CrossRegion_Country_Xref {
+	r.Options.Limit = &limit
+	return r
+}
+
+func (r Network_Storage_MassDataMigration_CrossRegion_Country_Xref) Offset(offset int) Network_Storage_MassDataMigration_CrossRegion_Country_Xref {
+	r.Options.Offset = &offset
+	return r
+}
+
+// no documentation yet
+func (r Network_Storage_MassDataMigration_CrossRegion_Country_Xref) GetAllObjects() (resp []datatypes.Network_Storage_MassDataMigration_CrossRegion_Country_Xref, err error) {
+	err = r.Session.DoRequest("SoftLayer_Network_Storage_MassDataMigration_CrossRegion_Country_Xref", "getAllObjects", nil, &r.Options, &resp)
+	return
+}
+
+// Retrieve SoftLayer_Locale_Country Id.
+func (r Network_Storage_MassDataMigration_CrossRegion_Country_Xref) GetCountry() (resp datatypes.Locale_Country, err error) {
+	err = r.Session.DoRequest("SoftLayer_Network_Storage_MassDataMigration_CrossRegion_Country_Xref", "getCountry", nil, &r.Options, &resp)
+	return
+}
+
+// Retrieve Location Group ID of CleverSafe cross region.
+func (r Network_Storage_MassDataMigration_CrossRegion_Country_Xref) GetLocationGroup() (resp datatypes.Location_Group, err error) {
+	err = r.Session.DoRequest("SoftLayer_Network_Storage_MassDataMigration_CrossRegion_Country_Xref", "getLocationGroup", nil, &r.Options, &resp)
+	return
+}
+
+// no documentation yet
+func (r Network_Storage_MassDataMigration_CrossRegion_Country_Xref) GetObject() (resp datatypes.Network_Storage_MassDataMigration_CrossRegion_Country_Xref, err error) {
+	err = r.Session.DoRequest("SoftLayer_Network_Storage_MassDataMigration_CrossRegion_Country_Xref", "getObject", nil, &r.Options, &resp)
+	return
+}
+
+// The SoftLayer_Network_Storage_MassDataMigration_Request data type contains information on a single Mass Data Migration request. Creation of these requests is limited to SoftLayer customers through the SoftLayer Customer Portal.
+type Network_Storage_MassDataMigration_Request struct {
+	Session *session.Session
+	Options sl.Options
+}
+
+// GetNetworkStorageMassDataMigrationRequestService returns an instance of the Network_Storage_MassDataMigration_Request SoftLayer service
+func GetNetworkStorageMassDataMigrationRequestService(sess *session.Session) Network_Storage_MassDataMigration_Request {
+	return Network_Storage_MassDataMigration_Request{Session: sess}
+}
+
+func (r Network_Storage_MassDataMigration_Request) Id(id int) Network_Storage_MassDataMigration_Request {
+	r.Options.Id = &id
+	return r
+}
+
+func (r Network_Storage_MassDataMigration_Request) Mask(mask string) Network_Storage_MassDataMigration_Request {
+	if !strings.HasPrefix(mask, "mask[") && (strings.Contains(mask, "[") || strings.Contains(mask, ",")) {
+		mask = fmt.Sprintf("mask[%s]", mask)
+	}
+
+	r.Options.Mask = mask
+	return r
+}
+
+func (r Network_Storage_MassDataMigration_Request) Filter(filter string) Network_Storage_MassDataMigration_Request {
+	r.Options.Filter = filter
+	return r
+}
+
+func (r Network_Storage_MassDataMigration_Request) Limit(limit int) Network_Storage_MassDataMigration_Request {
+	r.Options.Limit = &limit
+	return r
+}
+
+func (r Network_Storage_MassDataMigration_Request) Offset(offset int) Network_Storage_MassDataMigration_Request {
+	r.Options.Offset = &offset
+	return r
+}
+
+// Edit the properties of a Mass Data Migration request record by passing in a modified instance of a SoftLayer_Network_Storage_MassDataMigration_Request object.
+func (r Network_Storage_MassDataMigration_Request) EditObject(templateObject *datatypes.Network_Storage_MassDataMigration_Request) (resp bool, err error) {
+	params := []interface{}{
+		templateObject,
+	}
+	err = r.Session.DoRequest("SoftLayer_Network_Storage_MassDataMigration_Request", "editObject", params, &r.Options, &resp)
+	return
+}
+
+// Retrieve The account to which the request belongs.
+func (r Network_Storage_MassDataMigration_Request) GetAccount() (resp datatypes.Account, err error) {
+	err = r.Session.DoRequest("SoftLayer_Network_Storage_MassDataMigration_Request", "getAccount", nil, &r.Options, &resp)
+	return
+}
+
+// Retrieve The active tickets that are attached to the MDMS request.
+func (r Network_Storage_MassDataMigration_Request) GetActiveTickets() (resp []datatypes.Ticket, err error) {
+	err = r.Session.DoRequest("SoftLayer_Network_Storage_MassDataMigration_Request", "getActiveTickets", nil, &r.Options, &resp)
+	return
+}
+
+// Retrieve The customer address where the device is shipped to.
+func (r Network_Storage_MassDataMigration_Request) GetAddress() (resp datatypes.Account_Address, err error) {
+	err = r.Session.DoRequest("SoftLayer_Network_Storage_MassDataMigration_Request", "getAddress", nil, &r.Options, &resp)
+	return
+}
+
+// no documentation yet
+func (r Network_Storage_MassDataMigration_Request) GetAllObjects() (resp []datatypes.Network_Storage_MassDataMigration_Request, err error) {
+	err = r.Session.DoRequest("SoftLayer_Network_Storage_MassDataMigration_Request", "getAllObjects", nil, &r.Options, &resp)
+	return
+}
+
+// Retrieves a list of all the possible statuses to which a request may be set.
+func (r Network_Storage_MassDataMigration_Request) GetAllRequestStatuses() (resp []datatypes.Network_Storage_MassDataMigration_Request_Status, err error) {
+	err = r.Session.DoRequest("SoftLayer_Network_Storage_MassDataMigration_Request", "getAllRequestStatuses", nil, &r.Options, &resp)
+	return
+}
+
+// Retrieve An associated parent billing item which is active. Includes billing items which are scheduled to be cancelled in the future.
+func (r Network_Storage_MassDataMigration_Request) GetBillingItem() (resp datatypes.Billing_Item, err error) {
+	err = r.Session.DoRequest("SoftLayer_Network_Storage_MassDataMigration_Request", "getBillingItem", nil, &r.Options, &resp)
+	return
+}
+
+// Retrieve The employee user who created the request.
+func (r Network_Storage_MassDataMigration_Request) GetCreateEmployee() (resp datatypes.User_Employee, err error) {
+	err = r.Session.DoRequest("SoftLayer_Network_Storage_MassDataMigration_Request", "getCreateEmployee", nil, &r.Options, &resp)
+	return
+}
+
+// Retrieve The customer user who created the request.
+func (r Network_Storage_MassDataMigration_Request) GetCreateUser() (resp datatypes.User_Customer, err error) {
+	err = r.Session.DoRequest("SoftLayer_Network_Storage_MassDataMigration_Request", "getCreateUser", nil, &r.Options, &resp)
+	return
+}
+
+// Retrieve The device configurations.
+func (r Network_Storage_MassDataMigration_Request) GetDeviceConfiguration() (resp datatypes.Network_Storage_MassDataMigration_Request_DeviceConfiguration, err error) {
+	err = r.Session.DoRequest("SoftLayer_Network_Storage_MassDataMigration_Request", "getDeviceConfiguration", nil, &r.Options, &resp)
+	return
+}
+
+// Retrieve The key contacts for this requests.
+func (r Network_Storage_MassDataMigration_Request) GetKeyContacts() (resp []datatypes.Network_Storage_MassDataMigration_Request_KeyContact, err error) {
+	err = r.Session.DoRequest("SoftLayer_Network_Storage_MassDataMigration_Request", "getKeyContacts", nil, &r.Options, &resp)
+	return
+}
+
+// Retrieve The employee who last modified the request.
+func (r Network_Storage_MassDataMigration_Request) GetModifyEmployee() (resp datatypes.User_Employee, err error) {
+	err = r.Session.DoRequest("SoftLayer_Network_Storage_MassDataMigration_Request", "getModifyEmployee", nil, &r.Options, &resp)
+	return
+}
+
+// Retrieve The customer user who last modified the request.
+func (r Network_Storage_MassDataMigration_Request) GetModifyUser() (resp datatypes.User_Customer, err error) {
+	err = r.Session.DoRequest("SoftLayer_Network_Storage_MassDataMigration_Request", "getModifyUser", nil, &r.Options, &resp)
+	return
+}
+
+// no documentation yet
+func (r Network_Storage_MassDataMigration_Request) GetObject() (resp datatypes.Network_Storage_MassDataMigration_Request, err error) {
+	err = r.Session.DoRequest("SoftLayer_Network_Storage_MassDataMigration_Request", "getObject", nil, &r.Options, &resp)
+	return
+}
+
+// Returns placeholder MDMS requests for any MDMS order pending approval.
+func (r Network_Storage_MassDataMigration_Request) GetPendingRequests() (resp []datatypes.Network_Storage_MassDataMigration_Request, err error) {
+	err = r.Session.DoRequest("SoftLayer_Network_Storage_MassDataMigration_Request", "getPendingRequests", nil, &r.Options, &resp)
+	return
+}
+
+// Retrieve The shipments of the request.
+func (r Network_Storage_MassDataMigration_Request) GetShipments() (resp []datatypes.Account_Shipment, err error) {
+	err = r.Session.DoRequest("SoftLayer_Network_Storage_MassDataMigration_Request", "getShipments", nil, &r.Options, &resp)
+	return
+}
+
+// Retrieve The status of the request.
+func (r Network_Storage_MassDataMigration_Request) GetStatus() (resp datatypes.Network_Storage_MassDataMigration_Request_Status, err error) {
+	err = r.Session.DoRequest("SoftLayer_Network_Storage_MassDataMigration_Request", "getStatus", nil, &r.Options, &resp)
+	return
+}
+
+// Retrieve All tickets that are attached to the mass data migration request.
+func (r Network_Storage_MassDataMigration_Request) GetTickets() (resp []datatypes.Ticket, err error) {
+	err = r.Session.DoRequest("SoftLayer_Network_Storage_MassDataMigration_Request", "getTickets", nil, &r.Options, &resp)
+	return
+}
+
+// The SoftLayer_Network_Storage_MassDataMigration_Request_KeyContact data type contains name, email, and phone for key contact at customer location who will handle Mass Data Migration.
+type Network_Storage_MassDataMigration_Request_KeyContact struct {
+	Session *session.Session
+	Options sl.Options
+}
+
+// GetNetworkStorageMassDataMigrationRequestKeyContactService returns an instance of the Network_Storage_MassDataMigration_Request_KeyContact SoftLayer service
+func GetNetworkStorageMassDataMigrationRequestKeyContactService(sess *session.Session) Network_Storage_MassDataMigration_Request_KeyContact {
+	return Network_Storage_MassDataMigration_Request_KeyContact{Session: sess}
+}
+
+func (r Network_Storage_MassDataMigration_Request_KeyContact) Id(id int) Network_Storage_MassDataMigration_Request_KeyContact {
+	r.Options.Id = &id
+	return r
+}
+
+func (r Network_Storage_MassDataMigration_Request_KeyContact) Mask(mask string) Network_Storage_MassDataMigration_Request_KeyContact {
+	if !strings.HasPrefix(mask, "mask[") && (strings.Contains(mask, "[") || strings.Contains(mask, ",")) {
+		mask = fmt.Sprintf("mask[%s]", mask)
+	}
+
+	r.Options.Mask = mask
+	return r
+}
+
+func (r Network_Storage_MassDataMigration_Request_KeyContact) Filter(filter string) Network_Storage_MassDataMigration_Request_KeyContact {
+	r.Options.Filter = filter
+	return r
+}
+
+func (r Network_Storage_MassDataMigration_Request_KeyContact) Limit(limit int) Network_Storage_MassDataMigration_Request_KeyContact {
+	r.Options.Limit = &limit
+	return r
+}
+
+func (r Network_Storage_MassDataMigration_Request_KeyContact) Offset(offset int) Network_Storage_MassDataMigration_Request_KeyContact {
+	r.Options.Offset = &offset
+	return r
+}
+
+// Retrieve The request this key contact belongs to.
+func (r Network_Storage_MassDataMigration_Request_KeyContact) GetAccount() (resp datatypes.Account, err error) {
+	err = r.Session.DoRequest("SoftLayer_Network_Storage_MassDataMigration_Request_KeyContact", "getAccount", nil, &r.Options, &resp)
+	return
+}
+
+// no documentation yet
+func (r Network_Storage_MassDataMigration_Request_KeyContact) GetObject() (resp datatypes.Network_Storage_MassDataMigration_Request_KeyContact, err error) {
+	err = r.Session.DoRequest("SoftLayer_Network_Storage_MassDataMigration_Request_KeyContact", "getObject", nil, &r.Options, &resp)
+	return
+}
+
+// Retrieve The request this key contact belongs to.
+func (r Network_Storage_MassDataMigration_Request_KeyContact) GetRequest() (resp datatypes.Network_Storage_MassDataMigration_Request, err error) {
+	err = r.Session.DoRequest("SoftLayer_Network_Storage_MassDataMigration_Request_KeyContact", "getRequest", nil, &r.Options, &resp)
+	return
+}
+
+// The SoftLayer_Network_Storage_MassDataMigration_Request_Status data type contains general information relating to the statuses to which a Mass Data Migration Request may be set.
+type Network_Storage_MassDataMigration_Request_Status struct {
+	Session *session.Session
+	Options sl.Options
+}
+
+// GetNetworkStorageMassDataMigrationRequestStatusService returns an instance of the Network_Storage_MassDataMigration_Request_Status SoftLayer service
+func GetNetworkStorageMassDataMigrationRequestStatusService(sess *session.Session) Network_Storage_MassDataMigration_Request_Status {
+	return Network_Storage_MassDataMigration_Request_Status{Session: sess}
+}
+
+func (r Network_Storage_MassDataMigration_Request_Status) Id(id int) Network_Storage_MassDataMigration_Request_Status {
+	r.Options.Id = &id
+	return r
+}
+
+func (r Network_Storage_MassDataMigration_Request_Status) Mask(mask string) Network_Storage_MassDataMigration_Request_Status {
+	if !strings.HasPrefix(mask, "mask[") && (strings.Contains(mask, "[") || strings.Contains(mask, ",")) {
+		mask = fmt.Sprintf("mask[%s]", mask)
+	}
+
+	r.Options.Mask = mask
+	return r
+}
+
+func (r Network_Storage_MassDataMigration_Request_Status) Filter(filter string) Network_Storage_MassDataMigration_Request_Status {
+	r.Options.Filter = filter
+	return r
+}
+
+func (r Network_Storage_MassDataMigration_Request_Status) Limit(limit int) Network_Storage_MassDataMigration_Request_Status {
+	r.Options.Limit = &limit
+	return r
+}
+
+func (r Network_Storage_MassDataMigration_Request_Status) Offset(offset int) Network_Storage_MassDataMigration_Request_Status {
+	r.Options.Offset = &offset
+	return r
+}
+
+// no documentation yet
+func (r Network_Storage_MassDataMigration_Request_Status) GetObject() (resp datatypes.Network_Storage_MassDataMigration_Request_Status, err error) {
+	err = r.Session.DoRequest("SoftLayer_Network_Storage_MassDataMigration_Request_Status", "getObject", nil, &r.Options, &resp)
+	return
+}
+
 // Schedules can be created for select Storage services, such as iscsi. These schedules are used to perform various tasks such as scheduling snapshots or synchronizing replicants.
 type Network_Storage_Schedule struct {
 	Session *session.Session
@@ -12285,12 +13097,6 @@ func (r Network_Subnet) GetHardware() (resp []datatypes.Hardware, err error) {
 // Retrieve All the ip addresses associated with a subnet.
 func (r Network_Subnet) GetIpAddresses() (resp []datatypes.Network_Subnet_IpAddress, err error) {
 	err = r.Session.DoRequest("SoftLayer_Network_Subnet", "getIpAddresses", nil, &r.Options, &resp)
-	return
-}
-
-// Retrieve A subnet's associated network component.
-func (r Network_Subnet) GetNetworkComponent() (resp datatypes.Network_Component, err error) {
-	err = r.Session.DoRequest("SoftLayer_Network_Subnet", "getNetworkComponent", nil, &r.Options, &resp)
 	return
 }
 
@@ -14165,6 +14971,36 @@ func (r Network_Vlan_Firewall) ApproveBypassRequest() (err error) {
 	return
 }
 
+// Retrieve
+func (r Network_Vlan_Firewall) GetAccountId() (resp int, err error) {
+	err = r.Session.DoRequest("SoftLayer_Network_Vlan_Firewall", "getAccountId", nil, &r.Options, &resp)
+	return
+}
+
+// Retrieve A firewall's allotted bandwidth (measured in GB).
+func (r Network_Vlan_Firewall) GetBandwidthAllocation() (resp datatypes.Float64, err error) {
+	err = r.Session.DoRequest("SoftLayer_Network_Vlan_Firewall", "getBandwidthAllocation", nil, &r.Options, &resp)
+	return
+}
+
+// Retrieve The raw bandwidth usage data for the current billing cycle. One object will be returned for each network this firewall is attached to.
+func (r Network_Vlan_Firewall) GetBillingCycleBandwidthUsage() (resp []datatypes.Network_Bandwidth_Usage, err error) {
+	err = r.Session.DoRequest("SoftLayer_Network_Vlan_Firewall", "getBillingCycleBandwidthUsage", nil, &r.Options, &resp)
+	return
+}
+
+// Retrieve The raw private bandwidth usage data for the current billing cycle.
+func (r Network_Vlan_Firewall) GetBillingCyclePrivateBandwidthUsage() (resp datatypes.Network_Bandwidth_Usage, err error) {
+	err = r.Session.DoRequest("SoftLayer_Network_Vlan_Firewall", "getBillingCyclePrivateBandwidthUsage", nil, &r.Options, &resp)
+	return
+}
+
+// Retrieve The raw public bandwidth usage data for the current billing cycle.
+func (r Network_Vlan_Firewall) GetBillingCyclePublicBandwidthUsage() (resp datatypes.Network_Bandwidth_Usage, err error) {
+	err = r.Session.DoRequest("SoftLayer_Network_Vlan_Firewall", "getBillingCyclePublicBandwidthUsage", nil, &r.Options, &resp)
+	return
+}
+
 // Retrieve The billing item for a Hardware Firewall (Dedicated).
 func (r Network_Vlan_Firewall) GetBillingItem() (resp datatypes.Billing_Item, err error) {
 	err = r.Session.DoRequest("SoftLayer_Network_Vlan_Firewall", "getBillingItem", nil, &r.Options, &resp)
@@ -14174,6 +15010,12 @@ func (r Network_Vlan_Firewall) GetBillingItem() (resp datatypes.Billing_Item, er
 // Retrieve Administrative bypass request status.
 func (r Network_Vlan_Firewall) GetBypassRequestStatus() (resp string, err error) {
 	err = r.Session.DoRequest("SoftLayer_Network_Vlan_Firewall", "getBypassRequestStatus", nil, &r.Options, &resp)
+	return
+}
+
+// Retrieve An object that provides commonly used bandwidth summary components for the current billing cycle.
+func (r Network_Vlan_Firewall) GetCurrentBandwidthSummary() (resp datatypes.Metric_Tracking_Object_Bandwidth_Summary, err error) {
+	err = r.Session.DoRequest("SoftLayer_Network_Vlan_Firewall", "getCurrentBandwidthSummary", nil, &r.Options, &resp)
 	return
 }
 
@@ -14198,6 +15040,18 @@ func (r Network_Vlan_Firewall) GetFullyQualifiedDomainName() (resp string, err e
 // Retrieve The credentials to log in to a firewall device. This is only present for dedicated appliances.
 func (r Network_Vlan_Firewall) GetManagementCredentials() (resp datatypes.Software_Component_Password, err error) {
 	err = r.Session.DoRequest("SoftLayer_Network_Vlan_Firewall", "getManagementCredentials", nil, &r.Options, &resp)
+	return
+}
+
+// Retrieve A firewall's metric tracking object.
+func (r Network_Vlan_Firewall) GetMetricTrackingObject() (resp datatypes.Metric_Tracking_Object, err error) {
+	err = r.Session.DoRequest("SoftLayer_Network_Vlan_Firewall", "getMetricTrackingObject", nil, &r.Options, &resp)
+	return
+}
+
+// Retrieve The metric tracking object ID for this firewall.
+func (r Network_Vlan_Firewall) GetMetricTrackingObjectId() (resp int, err error) {
+	err = r.Session.DoRequest("SoftLayer_Network_Vlan_Firewall", "getMetricTrackingObjectId", nil, &r.Options, &resp)
 	return
 }
 
@@ -14231,6 +15085,24 @@ func (r Network_Vlan_Firewall) GetObject() (resp datatypes.Network_Vlan_Firewall
 	return
 }
 
+// Retrieve Whether the bandwidth usage for this firewall for the current billing cycle exceeds the allocation.
+func (r Network_Vlan_Firewall) GetOverBandwidthAllocationFlag() (resp int, err error) {
+	err = r.Session.DoRequest("SoftLayer_Network_Vlan_Firewall", "getOverBandwidthAllocationFlag", nil, &r.Options, &resp)
+	return
+}
+
+// Retrieve Whether the bandwidth usage for this firewall for the current billing cycle is projected to exceed the allocation.
+func (r Network_Vlan_Firewall) GetProjectedOverBandwidthAllocationFlag() (resp int, err error) {
+	err = r.Session.DoRequest("SoftLayer_Network_Vlan_Firewall", "getProjectedOverBandwidthAllocationFlag", nil, &r.Options, &resp)
+	return
+}
+
+// Retrieve The projected public outbound bandwidth for this firewall for the current billing cycle.
+func (r Network_Vlan_Firewall) GetProjectedPublicBandwidthUsage() (resp datatypes.Float64, err error) {
+	err = r.Session.DoRequest("SoftLayer_Network_Vlan_Firewall", "getProjectedPublicBandwidthUsage", nil, &r.Options, &resp)
+	return
+}
+
 // Retrieve The currently running rule set of this network component firewall.
 func (r Network_Vlan_Firewall) GetRules() (resp []datatypes.Network_Vlan_Firewall_Rule, err error) {
 	err = r.Session.DoRequest("SoftLayer_Network_Vlan_Firewall", "getRules", nil, &r.Options, &resp)
@@ -14240,6 +15112,18 @@ func (r Network_Vlan_Firewall) GetRules() (resp []datatypes.Network_Vlan_Firewal
 // Retrieve
 func (r Network_Vlan_Firewall) GetTagReferences() (resp []datatypes.Tag_Reference, err error) {
 	err = r.Session.DoRequest("SoftLayer_Network_Vlan_Firewall", "getTagReferences", nil, &r.Options, &resp)
+	return
+}
+
+// Retrieve A firewall's associated upgrade request object, if any.
+func (r Network_Vlan_Firewall) GetUpgradeRequest() (resp datatypes.Product_Upgrade_Request, err error) {
+	err = r.Session.DoRequest("SoftLayer_Network_Vlan_Firewall", "getUpgradeRequest", nil, &r.Options, &resp)
+	return
+}
+
+// Whether this firewall qualifies for High Availability upgrade.
+func (r Network_Vlan_Firewall) IsHighAvailabilityUpgradeAvailable() (resp bool, err error) {
+	err = r.Session.DoRequest("SoftLayer_Network_Vlan_Firewall", "isHighAvailabilityUpgradeAvailable", nil, &r.Options, &resp)
 	return
 }
 

--- a/vendor/github.com/softlayer/softlayer-go/services/product.go
+++ b/vendor/github.com/softlayer/softlayer-go/services/product.go
@@ -402,6 +402,12 @@ func (r Product_Item_Price) GetCategories() (resp []datatypes.Product_Item_Categ
 	return
 }
 
+// Retrieve Signifies pricing that is only available on a dedicated host virtual server order.
+func (r Product_Item_Price) GetDedicatedHostInstanceFlag() (resp bool, err error) {
+	err = r.Session.DoRequest("SoftLayer_Product_Item_Price", "getDedicatedHostInstanceFlag", nil, &r.Options, &resp)
+	return
+}
+
 // Retrieve Whether this price defines a software license for its product item.
 func (r Product_Item_Price) GetDefinedSoftwareLicenseFlag() (resp bool, err error) {
 	err = r.Session.DoRequest("SoftLayer_Product_Item_Price", "getDefinedSoftwareLicenseFlag", nil, &r.Options, &resp)
@@ -447,6 +453,12 @@ func (r Product_Item_Price) GetPackages() (resp []datatypes.Product_Package, err
 // Retrieve A list of preset configurations this price is used in.'
 func (r Product_Item_Price) GetPresetConfigurations() (resp []datatypes.Product_Package_Preset_Configuration, err error) {
 	err = r.Session.DoRequest("SoftLayer_Product_Item_Price", "getPresetConfigurations", nil, &r.Options, &resp)
+	return
+}
+
+// Retrieve The type keyname of this price which can be STANDARD or TIERED.
+func (r Product_Item_Price) GetPriceType() (resp string, err error) {
+	err = r.Session.DoRequest("SoftLayer_Product_Item_Price", "getPriceType", nil, &r.Options, &resp)
 	return
 }
 
@@ -1187,6 +1199,12 @@ func (r Product_Package) Limit(limit int) Product_Package {
 func (r Product_Package) Offset(offset int) Product_Package {
 	r.Options.Offset = &offset
 	return r
+}
+
+// Retrieve The preset configurations available only for the authenticated account and this package.
+func (r Product_Package) GetAccountRestrictedActivePresets() (resp []datatypes.Product_Package_Preset, err error) {
+	err = r.Session.DoRequest("SoftLayer_Product_Package", "getAccountRestrictedActivePresets", nil, &r.Options, &resp)
+	return
 }
 
 // Retrieve The results from this call are similar to [[SoftLayer_Product_Package/getCategories|getCategories]], but these ONLY include account-restricted prices. Not all accounts have restricted pricing.

--- a/vendor/github.com/softlayer/softlayer-go/services/user.go
+++ b/vendor/github.com/softlayer/softlayer-go/services/user.go
@@ -253,7 +253,7 @@ func (r User_Customer) CreateNotificationSubscriber(keyName *string, resourceTab
 	return
 }
 
-// Create a new user in the SoftLayer customer portal. createObject() creates a user's portal record and adds them into the SoftLayer community forums. It is no longer possible to set up the SSL or PPTP enable flag in this call since the manage permissions have not yet been set.  You will need to make a subsequent call to edit object in order to enable VPN access. An account's master user and sub-users who have the User Manage permission can add new users. createObject() creates users with a default permission set. After adding a user it may be helpful to set their permissions and hardware access.
+// Create a new user in the SoftLayer customer portal. createObject() creates a user's portal record and adds them into the SoftLayer community forums. It is not possible to set up SLL or PPTP enable flags during object creation. These flags are ignored during object creation. You will need to make a subsequent call to edit object in order to enable VPN access. An account's master user and sub-users who have the User Manage permission can add new users. createObject() creates users with a default permission set. After adding a user it may be helpful to set their permissions and hardware access.
 //
 // Note, neither password nor vpnPassword parameters are required.
 //
@@ -2725,7 +2725,7 @@ func (r User_Customer_OpenIdConnect) CreateNotificationSubscriber(keyName *strin
 	return
 }
 
-// Create a new user in the SoftLayer customer portal. createObject() creates a user's portal record and adds them into the SoftLayer community forums. It is no longer possible to set up the SSL or PPTP enable flag in this call since the manage permissions have not yet been set.  You will need to make a subsequent call to edit object in order to enable VPN access. An account's master user and sub-users who have the User Manage permission can add new users. createObject() creates users with a default permission set. After adding a user it may be helpful to set their permissions and hardware access.
+// Create a new user in the SoftLayer customer portal. createObject() creates a user's portal record and adds them into the SoftLayer community forums. It is not possible to set up SLL or PPTP enable flags during object creation. These flags are ignored during object creation. You will need to make a subsequent call to edit object in order to enable VPN access. An account's master user and sub-users who have the User Manage permission can add new users. createObject() creates users with a default permission set. After adding a user it may be helpful to set their permissions and hardware access.
 //
 // Note, neither password nor vpnPassword parameters are required.
 //
@@ -2740,7 +2740,7 @@ func (r User_Customer_OpenIdConnect) CreateNotificationSubscriber(keyName *strin
 // vpnPassword If the vpnPassword is provided, then the user's vpnPassword will be set to the provided password.  When creating a vpn only user, the vpnPassword MUST be supplied.  If the vpnPassword is not provided, then the user will need to use the portal to edit their profile and set the vpnPassword.
 //
 //
-func (r User_Customer_OpenIdConnect) CreateObject(templateObject *datatypes.User_Customer, password *string, vpnPassword *string) (resp datatypes.User_Customer, err error) {
+func (r User_Customer_OpenIdConnect) CreateObject(templateObject *datatypes.User_Customer_OpenIdConnect, password *string, vpnPassword *string) (resp datatypes.User_Customer_OpenIdConnect, err error) {
 	params := []interface{}{
 		templateObject,
 		password,

--- a/vendor/github.com/softlayer/softlayer-go/services/virtual.go
+++ b/vendor/github.com/softlayer/softlayer-go/services/virtual.go
@@ -2097,6 +2097,12 @@ func (r Virtual_Guest_Block_Device_Template_Group) Offset(offset int) Virtual_Gu
 	return r
 }
 
+// This method allows you to mark this image template as customer managed software license (BYOL)
+func (r Virtual_Guest_Block_Device_Template_Group) AddByolAttribute() (resp bool, err error) {
+	err = r.Session.DoRequest("SoftLayer_Virtual_Guest_Block_Device_Template_Group", "addByolAttribute", nil, &r.Options, &resp)
+	return
+}
+
 // This method allows you to mark this image template as cloud init
 func (r Virtual_Guest_Block_Device_Template_Group) AddCloudInitAttribute() (resp bool, err error) {
 	err = r.Session.DoRequest("SoftLayer_Virtual_Guest_Block_Device_Template_Group", "addCloudInitAttribute", nil, &r.Options, &resp)
@@ -2139,6 +2145,12 @@ func (r Virtual_Guest_Block_Device_Template_Group) CreatePublicArchiveTransactio
 		locations,
 	}
 	err = r.Session.DoRequest("SoftLayer_Virtual_Guest_Block_Device_Template_Group", "createPublicArchiveTransaction", params, &r.Options, &resp)
+	return
+}
+
+// This method allows you to remove BYOL attribute for a given image template.
+func (r Virtual_Guest_Block_Device_Template_Group) DeleteByolAttribute() (resp bool, err error) {
+	err = r.Session.DoRequest("SoftLayer_Virtual_Guest_Block_Device_Template_Group", "deleteByolAttribute", nil, &r.Options, &resp)
 	return
 }
 
@@ -2205,6 +2217,12 @@ func (r Virtual_Guest_Block_Device_Template_Group) GetBlockDevicesDiskSpaceTotal
 // This method returns the boot mode, if any, set on a given image template.
 func (r Virtual_Guest_Block_Device_Template_Group) GetBootMode() (resp string, err error) {
 	err = r.Session.DoRequest("SoftLayer_Virtual_Guest_Block_Device_Template_Group", "getBootMode", nil, &r.Options, &resp)
+	return
+}
+
+// Retrieve A flag indicating that customer is providing the software licenses.
+func (r Virtual_Guest_Block_Device_Template_Group) GetByolFlag() (resp bool, err error) {
+	err = r.Session.DoRequest("SoftLayer_Virtual_Guest_Block_Device_Template_Group", "getByolFlag", nil, &r.Options, &resp)
 	return
 }
 
@@ -2313,6 +2331,12 @@ func (r Virtual_Guest_Block_Device_Template_Group) GetTransaction() (resp dataty
 // Returns an array of SoftLayer_Software_Description that are supported for VHD imports.
 func (r Virtual_Guest_Block_Device_Template_Group) GetVhdImportSoftwareDescriptions() (resp []datatypes.Software_Description, err error) {
 	err = r.Session.DoRequest("SoftLayer_Virtual_Guest_Block_Device_Template_Group", "getVhdImportSoftwareDescriptions", nil, &r.Options, &resp)
+	return
+}
+
+// This method indicates whether or not this image is a customer supplied license image.
+func (r Virtual_Guest_Block_Device_Template_Group) IsByol() (resp bool, err error) {
+	err = r.Session.DoRequest("SoftLayer_Virtual_Guest_Block_Device_Template_Group", "isByol", nil, &r.Options, &resp)
 	return
 }
 

--- a/vendor/github.com/softlayer/softlayer-go/session/rest.go
+++ b/vendor/github.com/softlayer/softlayer-go/session/rest.go
@@ -21,11 +21,13 @@ import (
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
+	"math/rand"
 	"net/http"
 	"net/url"
 	"reflect"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/softlayer/softlayer-go/datatypes"
 	"github.com/softlayer/softlayer-go/sl"
@@ -50,7 +52,7 @@ func (r *RestTransport) DoRequest(sess *Session, service string, method string, 
 
 	path := buildPath(service, method, options)
 
-	resp, code, err := makeHTTPRequest(
+	resp, code, err := sendHTTPRequest(
 		sess,
 		path,
 		restMethod,
@@ -58,21 +60,12 @@ func (r *RestTransport) DoRequest(sess *Session, service string, method string, 
 		options)
 
 	if err != nil {
-		return sl.Error{Wrapped: err}
+		return sl.Error{Wrapped: err, StatusCode: code}
 	}
 
-	if code < 200 || code > 299 {
-		e := sl.Error{StatusCode: code}
-
-		err = json.Unmarshal(resp, &e)
-
-		// If unparseable, wrap the json error
-		if err != nil {
-			e.Wrapped = err
-			e.Message = err.Error()
-		}
-
-		return e
+	err = findResponseError(code, resp)
+	if err != nil {
+		return err
 	}
 
 	// Some APIs that normally return a collection, omit the []'s when the API returns a single value
@@ -136,7 +129,7 @@ func buildPath(service string, method string, options *sl.Options) string {
 
 	// omit the API method name if the method represents one of the basic REST methods
 	if method != "getObject" && method != "deleteObject" && method != "createObject" &&
-		method != "createObjects" && method != "editObject" && method != "editObjects" {
+		method != "editObject" && method != "editObjects" {
 		path = path + "/" + method
 	}
 
@@ -168,7 +161,49 @@ func encodeQuery(opts *sl.Options) string {
 	return query.Encode()
 }
 
-func makeHTTPRequest(session *Session, path string, requestType string, requestBody *bytes.Buffer, options *sl.Options) ([]byte, int, error) {
+func sendHTTPRequest(
+	sess *Session, path string, requestType string,
+	requestBody *bytes.Buffer, options *sl.Options) ([]byte, int, error) {
+
+	retries := sess.Retries
+	if retries < 2 {
+		return makeHTTPRequest(sess, path, requestType, requestBody, options)
+	}
+
+	wait := sess.RetryWait
+	if wait == 0 {
+		wait = DefaultRetryWait
+	}
+
+	return tryHTTPRequest(retries, wait, sess, path, requestType, requestBody, options)
+}
+
+func tryHTTPRequest(
+	retries int, wait time.Duration, sess *Session,
+	path string, requestType string, requestBody *bytes.Buffer,
+	options *sl.Options) ([]byte, int, error) {
+
+	resp, code, err := makeHTTPRequest(sess, path, requestType, requestBody, options)
+	if err != nil {
+		if !isRetryable(err) {
+			return resp, code, err
+		}
+
+		if retries--; retries > 0 {
+			jitter := time.Duration(rand.Int63n(int64(wait)))
+			wait = wait + jitter/2
+			time.Sleep(wait)
+			return tryHTTPRequest(
+				retries, wait, sess, path, requestType, requestBody, options)
+		}
+	}
+
+	return resp, code, err
+}
+
+func makeHTTPRequest(
+	session *Session, path string, requestType string,
+	requestBody *bytes.Buffer, options *sl.Options) ([]byte, int, error) {
 	log := Logger
 	client := http.DefaultClient
 	client.Timeout = DefaultTimeout
@@ -194,6 +229,13 @@ func makeHTTPRequest(session *Session, path string, requestType string, requestB
 		req.SetBasicAuth(fmt.Sprintf("%d", session.UserId), session.AuthToken)
 	}
 
+	// For cases where session is built from the raw structure and not using New() , the UserAgent would be empty
+	if session.userAgent == "" {
+		session.userAgent = getDefaultUserAgent()
+	}
+
+	req.Header.Set("User-Agent", session.userAgent)
+
 	req.URL.RawQuery = encodeQuery(options)
 
 	if session.Debug {
@@ -203,7 +245,16 @@ func makeHTTPRequest(session *Session, path string, requestType string, requestB
 
 	resp, err := client.Do(req)
 	if err != nil {
-		return nil, 520, err
+		statusCode := 520
+		if resp != nil && resp.StatusCode != 0 {
+			statusCode = resp.StatusCode
+		}
+
+		if isTimeout(err) {
+			statusCode = 599
+		}
+
+		return nil, statusCode, err
 	}
 
 	defer resp.Body.Close()
@@ -216,7 +267,8 @@ func makeHTTPRequest(session *Session, path string, requestType string, requestB
 	if session.Debug {
 		log.Println("[DEBUG] Response: ", string(responseBody))
 	}
-	return responseBody, resp.StatusCode, nil
+	err = findResponseError(resp.StatusCode, responseBody)
+	return responseBody, resp.StatusCode, err
 }
 
 func httpMethod(name string, args []interface{}) string {
@@ -229,4 +281,18 @@ func httpMethod(name string, args []interface{}) string {
 	}
 
 	return "GET"
+}
+
+func findResponseError(code int, resp []byte) error {
+	if code < 200 || code > 299 {
+		e := sl.Error{StatusCode: code}
+		err := json.Unmarshal(resp, &e)
+		// If unparseable, wrap the json error
+		if err != nil {
+			e.Wrapped = err
+			e.Message = err.Error()
+		}
+		return e
+	}
+	return nil
 }

--- a/vendor/github.com/softlayer/softlayer-go/session/session.go
+++ b/vendor/github.com/softlayer/softlayer-go/session/session.go
@@ -19,8 +19,11 @@ package session
 import (
 	"fmt"
 	"log"
+	"math/rand"
+	"net"
 	"os"
 	"os/user"
+	"runtime"
 	"strings"
 	"time"
 
@@ -40,7 +43,9 @@ func init() {
 // is provided.
 const DefaultEndpoint = "https://api.softlayer.com/rest/v3"
 
-// TransportHandler
+var retryableErrorCodes = []string{"SoftLayer_Exception_WebService_RateLimitExceeded"}
+
+// TransportHandler interface for the protocol-specific handling of API requests.
 type TransportHandler interface {
 	// DoRequest is the protocol-specific handler for making API requests.
 	//
@@ -74,7 +79,10 @@ type TransportHandler interface {
 		pResult interface{}) error
 }
 
-const DefaultTimeout = time.Second * 120
+const (
+	DefaultTimeout   = time.Second * 120
+	DefaultRetryWait = time.Second * 3
+)
 
 // Session stores the information required for communication with the SoftLayer
 // API
@@ -107,10 +115,24 @@ type Session struct {
 	// session. Requests that take longer that the specified timeout
 	// will result in an error.
 	Timeout time.Duration
+
+	// Retries is the number of times to retry a connection that failed due to a timeout.
+	Retries int
+
+	// RetryWait minimum wait time to retry a request
+	RetryWait time.Duration
+
+	// userAgent is the user agent to send with each API request
+	// User shouldn't be able to change or set the base user agent
+	userAgent string
+}
+
+func init() {
+	rand.Seed(time.Now().UnixNano())
 }
 
 // New creates and returns a pointer to a new session object.  It takes up to
-// three parameters, all of which are optional.  If specified, they will be
+// four parameters, all of which are optional.  If specified, they will be
 // interpreted in the following sequence:
 //
 // 1. UserName
@@ -185,9 +207,10 @@ func New(args ...interface{}) *Session {
 	}
 
 	sess := &Session{
-		UserName: values[keys["username"]],
-		APIKey:   values[keys["api_key"]],
-		Endpoint: endpointURL,
+		UserName:  values[keys["username"]],
+		APIKey:    values[keys["api_key"]],
+		Endpoint:  endpointURL,
+		userAgent: getDefaultUserAgent(),
 	}
 
 	timeout := values[keys["timeout"]]
@@ -197,6 +220,8 @@ func New(args ...interface{}) *Session {
 			sess.Timeout = timeoutDuration
 		}
 	}
+
+	sess.RetryWait = DefaultRetryWait
 
 	return sess
 }
@@ -215,6 +240,53 @@ func (r *Session) DoRequest(service string, method string, args []interface{}, o
 	return r.TransportHandler.DoRequest(r, service, method, args, options, pResult)
 }
 
+// SetTimeout creates a copy of the session and sets the passed timeout into it
+// before returning it.
+func (r *Session) SetTimeout(timeout time.Duration) *Session {
+	var s Session
+	s = *r
+	s.Timeout = timeout
+
+	return &s
+}
+
+// SetRetries creates a copy of the session and sets the passed retries into it
+// before returning it.
+func (r *Session) SetRetries(retries int) *Session {
+	var s Session
+	s = *r
+	s.Retries = retries
+
+	return &s
+}
+
+// SetRetryWait creates a copy of the session and sets the passed retryWait into it
+// before returning it.
+func (r *Session) SetRetryWait(retryWait time.Duration) *Session {
+	var s Session
+	s = *r
+	s.RetryWait = retryWait
+
+	return &s
+}
+
+// AppendUserAgent allows higher level application to identify themselves by
+// appending to the useragent string
+func (r *Session) AppendUserAgent(agent string) {
+	if r.userAgent == "" {
+		r.userAgent = getDefaultUserAgent()
+	}
+
+	if agent != "" {
+		r.userAgent += " " + agent
+	}
+}
+
+// ResetUserAgent resets the current user agent to the default value
+func (r *Session) ResetUserAgent() {
+	r.userAgent = getDefaultUserAgent()
+}
+
 func envFallback(keyName string, value *string) {
 	if *value == "" {
 		*value = os.Getenv(keyName)
@@ -231,4 +303,50 @@ func getDefaultTransport(endpointURL string) TransportHandler {
 	}
 
 	return transportHandler
+}
+
+func isTimeout(err error) bool {
+	if slErr, ok := err.(sl.Error); ok {
+		switch slErr.StatusCode {
+		case 408, 504, 599:
+			return true
+		}
+	}
+
+	if netErr, ok := err.(net.Error); ok && netErr.Timeout() {
+		return true
+	}
+
+	if netErr, ok := err.(*net.OpError); ok && netErr.Timeout() {
+		return true
+	}
+
+	if netErr, ok := err.(net.UnknownNetworkError); ok && netErr.Timeout() {
+		return true
+	}
+
+	return false
+}
+
+func hasRetryableCode(err error) bool {
+	for _, code := range retryableErrorCodes {
+		if slErr, ok := err.(sl.Error); ok {
+			if slErr.Exception == code {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func isRetryable(err error) bool {
+	return isTimeout(err) || hasRetryableCode(err)
+}
+
+func getDefaultUserAgent() string {
+	return fmt.Sprintf("softlayer-go/%s (%s;%s;%s)", sl.Version.String(),
+		runtime.Version(),
+		runtime.GOARCH,
+		runtime.GOOS,
+	)
 }

--- a/vendor/github.com/softlayer/softlayer-go/session/xmlrpc.go
+++ b/vendor/github.com/softlayer/softlayer-go/session/xmlrpc.go
@@ -19,9 +19,11 @@ package session
 import (
 	"encoding/json"
 	"fmt"
+	"math/rand"
 	"net/http"
 	"net/http/httputil"
 	"strings"
+	"time"
 
 	"github.com/renier/xmlrpc"
 	"github.com/softlayer/softlayer-go/sl"
@@ -97,7 +99,14 @@ func (x *XmlRpcTransport) DoRequest(
 		authenticate["complexType"] = "PortalLoginToken"
 	}
 
+	// For cases where session is built from the raw structure and not using New() , the UserAgent would be empty
+	if sess.userAgent == "" {
+		sess.userAgent = getDefaultUserAgent()
+	}
+
 	headers := map[string]interface{}{}
+	headers["User-Agent"] = sess.userAgent
+
 	if len(authenticate) > 0 {
 		headers["authenticate"] = authenticate
 	}
@@ -157,12 +166,53 @@ func (x *XmlRpcTransport) DoRequest(
 		params = append(params, arg)
 	}
 
-	err = client.Call(method, params, pResult)
+	retries := sess.Retries
+	if retries < 2 {
+		err = client.Call(method, params, pResult)
+	} else {
+		wait := sess.RetryWait
+		if wait == 0 {
+			wait = DefaultRetryWait
+		}
+
+		err = makeXmlRequest(retries, wait, client, method, params, pResult)
+	}
+
 	if xmlRpcError, ok := err.(*xmlrpc.XmlRpcError); ok {
-		return sl.Error{
+		err = sl.Error{
 			StatusCode: xmlRpcError.HttpStatusCode,
 			Exception:  xmlRpcError.Code.(string),
 			Message:    xmlRpcError.Err,
+		}
+	}
+	return err
+}
+
+func makeXmlRequest(
+	retries int, wait time.Duration, client *xmlrpc.Client,
+	method string, params []interface{}, pResult interface{}) error {
+
+	err := client.Call(method, params, pResult)
+
+	if xmlRpcError, ok := err.(*xmlrpc.XmlRpcError); ok {
+		err = sl.Error{
+			StatusCode: xmlRpcError.HttpStatusCode,
+			Exception:  xmlRpcError.Code.(string),
+			Message:    xmlRpcError.Err,
+		}
+	}
+
+	if err != nil {
+		if !isRetryable(err) {
+			return err
+		}
+
+		if retries--; retries > 0 {
+			jitter := time.Duration(rand.Int63n(int64(wait)))
+			wait = wait + jitter/2
+			time.Sleep(wait)
+			return makeXmlRequest(
+				retries, wait, client, method, params, pResult)
 		}
 	}
 


### PR DESCRIPTION
The softlayer-go version needs to be updated to the latest to pull in support for retries on rate limit exceeded errors.  Also need to enable the retry support on the softlayer-go sessions.