### PR TITLE
CLI returns non-zero error code to shell if the plugin name does not exist

### DIFF
--- a/cmd/infrakit/main.go
+++ b/cmd/infrakit/main.go
@@ -367,7 +367,8 @@ func stackCommand(scope scope.Scope, stackCommandName string) *cobra.Command {
 				}
 
 				if !foundObject {
-					os.Exit(1)
+					// http://tldp.org/LDP/abs/html/exitcodes.html
+					os.Exit(127)
 				}
 			}
 			return err

--- a/pkg/run/manager/manager.go
+++ b/pkg/run/manager/manager.go
@@ -270,7 +270,7 @@ func countMatches(list []string, found map[string]*plugin.Endpoint) int {
 			}
 			objects, err := hs.Hello()
 			if err != nil {
-				log.Error("Bad handshake. Is this plugin running?", "lookup", l, "endpoint", ep)
+				log.Error("Bad handshake. Is this plugin running?", "lookup", l, "endpoint", ep, "err", err)
 				continue
 			}
 			log.Debug("Scan found", "lookup", l, "endpoint", ep, "V", debugLoopV, "implements", objects)

--- a/scripts/e2e-test-1.sh
+++ b/scripts/e2e-test-1.sh
@@ -19,7 +19,7 @@ note "Plugin start pid=$starterpid"
 
 sleep 5
 
-found=$(infrakit local -h | grep 'testlogs')
+found=$(infrakit plugin ls | grep 'testlogs')
 if [ "$found" = "" ]; then
     echo "tailer not started"
     exit 1
@@ -77,9 +77,9 @@ infrakit local mystack/groups commit-group scripts/cattle.json
 
 sleep 10
 
-if [[ $(infrakit local -h | grep mystack/cattle) == "" ]]; then
+if [[ $(infrakit local | grep mystack/cattle) == "" ]]; then
     echo "checking the CLI"
-    infrakit local -h
+    infrakit local
 fi
 expect_output_lines "Should be watching one group" "infrakit local mystack/cattle ls -q" "5"
 


### PR DESCRIPTION
Closes #802 

This PR catches the case when a help text is shown in the dynamic CLI commands.  When a help text is displayed, it's possible that a user entered subcommand, which corresponds to a plugin name, points to a non-existent plugin.  So the main checks for that case and returns a 127 ([ref](http://tldp.org/LDP/abs/html/exitcodes.html)) in that case.

Signed-off-by: David Chung <david.chung@docker.com>