### PR TITLE
Constants for Infrakit instance tags

### DIFF
--- a/pkg/plugin/group/group.go
+++ b/pkg/plugin/group/group.go
@@ -17,7 +17,6 @@ import (
 )
 
 const (
-	groupTag     = "infrakit.group"
 	configTag    = "infrakit.config_sha"
 	logicalIDTag = "infrakit.logical_id"
 
@@ -111,7 +110,7 @@ func (p *plugin) CommitGroup(config group.Spec, pretend bool) (string, error) {
 
 	scaled := &scaledGroup{
 		settings:   settings,
-		memberTags: map[string]string{groupTag: string(config.ID)},
+		memberTags: map[string]string{group.GroupTag: string(config.ID)},
 	}
 
 	var supervisor Supervisor

--- a/pkg/plugin/group/group.go
+++ b/pkg/plugin/group/group.go
@@ -17,8 +17,6 @@ import (
 )
 
 const (
-	logicalIDTag = "infrakit.logical_id"
-
 	debugV = logutil.V(300)
 )
 

--- a/pkg/plugin/group/group.go
+++ b/pkg/plugin/group/group.go
@@ -17,7 +17,6 @@ import (
 )
 
 const (
-	configTag    = "infrakit.config_sha"
 	logicalIDTag = "infrakit.logical_id"
 
 	debugV = logutil.V(300)

--- a/pkg/plugin/group/integration_test.go
+++ b/pkg/plugin/group/integration_test.go
@@ -114,7 +114,7 @@ func memberTags(id group.ID) map[string]string {
 
 func provisionTags(config group.Spec, logicalID *instance.LogicalID) map[string]string {
 	tags := memberTags(config.ID)
-	tags[configTag] = group_types.MustParse(group_types.ParseProperties(config)).InstanceHash()
+	tags[group.ConfigSHATag] = group_types.MustParse(group_types.ParseProperties(config)).InstanceHash()
 
 	if logicalID != nil {
 		tags[logicalIDTag] = string(*logicalID)

--- a/pkg/plugin/group/integration_test.go
+++ b/pkg/plugin/group/integration_test.go
@@ -117,7 +117,7 @@ func provisionTags(config group.Spec, logicalID *instance.LogicalID) map[string]
 	tags[group.ConfigSHATag] = group_types.MustParse(group_types.ParseProperties(config)).InstanceHash()
 
 	if logicalID != nil {
-		tags[logicalIDTag] = string(*logicalID)
+		tags[instance.LogicalIDTag] = string(*logicalID)
 	}
 	return tags
 }
@@ -540,7 +540,7 @@ func TestSuperviseQuorum(t *testing.T) {
 		expectTags := provisionTags(updated, i.LogicalID)
 		if i.LogicalID != nil {
 			// expect to also have a label with logical ID
-			expectTags[logicalIDTag] = string(*i.LogicalID)
+			expectTags[instance.LogicalIDTag] = string(*i.LogicalID)
 		}
 		require.Equal(t, expectTags, i.Tags)
 	}

--- a/pkg/plugin/group/integration_test.go
+++ b/pkg/plugin/group/integration_test.go
@@ -109,7 +109,7 @@ func TestInvalidGroupCalls(t *testing.T) {
 }
 
 func memberTags(id group.ID) map[string]string {
-	return map[string]string{groupTag: string(id)}
+	return map[string]string{group.GroupTag: string(id)}
 }
 
 func provisionTags(config group.Spec, logicalID *instance.LogicalID) map[string]string {

--- a/pkg/plugin/group/rollingupdate.go
+++ b/pkg/plugin/group/rollingupdate.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/docker/infrakit/pkg/spi/flavor"
+	"github.com/docker/infrakit/pkg/spi/group"
 	"github.com/docker/infrakit/pkg/spi/instance"
 )
 
@@ -48,7 +49,7 @@ func desiredAndUndesiredInstances(
 		// where the new leader will see that there's a discrepancy and update *this* node.
 		self = isSelf(inst, settings)
 
-		actualConfig, specified := inst.Tags[configTag]
+		actualConfig, specified := inst.Tags[group.ConfigSHATag]
 		if specified && actualConfig == desiredHash || self {
 			desired = append(desired, inst)
 		} else {

--- a/pkg/plugin/group/rollingupdate.go
+++ b/pkg/plugin/group/rollingupdate.go
@@ -23,7 +23,7 @@ func isSelf(inst instance.Description, settings groupSettings) bool {
 		if inst.LogicalID != nil && *inst.LogicalID == *settings.self {
 			return true
 		}
-		if v, has := inst.Tags[logicalIDTag]; has {
+		if v, has := inst.Tags[instance.LogicalIDTag]; has {
 			return string(*settings.self) == v
 		}
 	}

--- a/pkg/plugin/group/scaled.go
+++ b/pkg/plugin/group/scaled.go
@@ -66,7 +66,7 @@ func (s *scaledGroup) CreateOne(logicalID *instance.LogicalID) {
 	}
 
 	if logicalID != nil {
-		tags[logicalIDTag] = string(*logicalID)
+		tags[instance.LogicalIDTag] = string(*logicalID)
 	}
 
 	// Instances are tagged with a SHA of the entire instance configuration to support change detection.
@@ -149,7 +149,7 @@ func (s *scaledGroup) List() ([]instance.Description, error) {
 	for _, d := range found {
 
 		// Is there a tag for the logical ID and the logicalID field is not set?
-		if logicalIDString, has := d.Tags[logicalIDTag]; has && d.LogicalID == nil {
+		if logicalIDString, has := d.Tags[instance.LogicalIDTag]; has && d.LogicalID == nil {
 			logicalID := instance.LogicalID(logicalIDString)
 			d.LogicalID = &logicalID
 		}

--- a/pkg/plugin/group/scaled.go
+++ b/pkg/plugin/group/scaled.go
@@ -70,7 +70,7 @@ func (s *scaledGroup) CreateOne(logicalID *instance.LogicalID) {
 	}
 
 	// Instances are tagged with a SHA of the entire instance configuration to support change detection.
-	tags[configTag] = settings.config.InstanceHash()
+	tags[group.ConfigSHATag] = settings.config.InstanceHash()
 
 	spec := instance.Spec{
 		Tags:       tags,
@@ -171,7 +171,7 @@ func (s *scaledGroup) Label() error {
 	for k, v := range s.memberTags {
 		tagsWithConfigSha[k] = v
 	}
-	tagsWithConfigSha[configTag] = settings.config.InstanceHash()
+	tagsWithConfigSha[group.ConfigSHATag] = settings.config.InstanceHash()
 
 	for _, inst := range instances {
 		if instanceNeedsLabel(inst) {
@@ -214,5 +214,5 @@ func needsLabel(instances []instance.Description) bool {
 }
 
 func instanceNeedsLabel(instance instance.Description) bool {
-	return instance.Tags[configTag] == bootstrapConfigTag
+	return instance.Tags[group.ConfigSHATag] == bootstrapConfigTag
 }

--- a/pkg/plugin/group/scaled_test.go
+++ b/pkg/plugin/group/scaled_test.go
@@ -5,6 +5,7 @@ import (
 
 	mock_instance "github.com/docker/infrakit/pkg/mock/spi/instance"
 	"github.com/docker/infrakit/pkg/plugin/group/types"
+	"github.com/docker/infrakit/pkg/spi/group"
 	"github.com/docker/infrakit/pkg/spi/instance"
 	"github.com/golang/mock/gomock"
 	"github.com/pkg/errors"
@@ -82,15 +83,15 @@ func TestLabelAllLabelled(t *testing.T) {
 			{
 				ID: instance.ID("labbeled1"),
 				Tags: map[string]string{
-					"key":     "value",
-					configTag: "SHA",
+					"key":              "value",
+					group.ConfigSHATag: "SHA",
 				},
 			},
 			{
 				ID: instance.ID("labbeled2"),
 				Tags: map[string]string{
-					"key":     "value",
-					configTag: "SHA",
+					"key":              "value",
+					group.ConfigSHATag: "SHA",
 				},
 			},
 		}, nil),
@@ -124,21 +125,21 @@ func TestLabelOneUnlabelled(t *testing.T) {
 			{
 				ID: instance.ID("labbeled"),
 				Tags: map[string]string{
-					"key":     "value",
-					configTag: config.InstanceHash(),
+					"key":              "value",
+					group.ConfigSHATag: config.InstanceHash(),
 				},
 			},
 			{
 				ID: instance.ID("unlabelled"),
 				Tags: map[string]string{
-					"key":     "value",
-					configTag: bootstrapConfigTag,
+					"key":              "value",
+					group.ConfigSHATag: bootstrapConfigTag,
 				},
 			},
 		}, nil),
 		instancePlugin.EXPECT().Label(instance.ID("unlabelled"), map[string]string{
-			"key":     "value",
-			configTag: config.InstanceHash(),
+			"key":              "value",
+			group.ConfigSHATag: config.InstanceHash(),
 		}).Return(nil),
 	)
 
@@ -170,21 +171,21 @@ func TestUnableToLabel(t *testing.T) {
 			{
 				ID: instance.ID("labbeled"),
 				Tags: map[string]string{
-					"key":     "value",
-					configTag: config.InstanceHash(),
+					"key":              "value",
+					group.ConfigSHATag: config.InstanceHash(),
 				},
 			},
 			{
 				ID: instance.ID("unlabelled"),
 				Tags: map[string]string{
-					"key":     "value",
-					configTag: bootstrapConfigTag,
+					"key":              "value",
+					group.ConfigSHATag: bootstrapConfigTag,
 				},
 			},
 		}, nil),
 		instancePlugin.EXPECT().Label(instance.ID("unlabelled"), map[string]string{
-			"key":     "value",
-			configTag: config.InstanceHash(),
+			"key":              "value",
+			group.ConfigSHATag: config.InstanceHash(),
 		}).Return(errors.New("BUG")),
 	)
 

--- a/pkg/plugin/group/scaler_test.go
+++ b/pkg/plugin/group/scaler_test.go
@@ -23,7 +23,7 @@ var (
 	withoutLabel = instance.Description{
 		ID: instance.ID("withoutLabel"),
 		Tags: map[string]string{
-			"infrakit.config_sha": "bootstrap",
+			group.ConfigSHATag: "bootstrap",
 		},
 	}
 )
@@ -218,7 +218,7 @@ func TestScalerPlanUpdateNoChanges(t *testing.T) {
 	existingInst := instance.Description{
 		ID: instance.ID("id1"),
 		Tags: map[string]string{
-			"infrakit.config_sha": settings.config.InstanceHash(),
+			group.ConfigSHATag: settings.config.InstanceHash(),
 		},
 	}
 	gomock.InOrder(
@@ -248,7 +248,7 @@ func TestScalerPlanUpdateRollingUpdate(t *testing.T) {
 	existingInst := instance.Description{
 		ID: instance.ID("id1"),
 		Tags: map[string]string{
-			"infrakit.config_sha": "different-hash",
+			group.ConfigSHATag: "different-hash",
 		},
 	}
 	gomock.InOrder(
@@ -290,7 +290,7 @@ func TestScalerPlanUpdateScaleDown(t *testing.T) {
 	existingInst := instance.Description{
 		ID: instance.ID("id1"),
 		Tags: map[string]string{
-			"infrakit.config_sha": settingsOld.config.InstanceHash(),
+			group.ConfigSHATag: settingsOld.config.InstanceHash(),
 		},
 	}
 	gomock.InOrder(
@@ -332,7 +332,7 @@ func TestScalerPlanUpdateScaleDownRollingUpdate(t *testing.T) {
 	existingInst := instance.Description{
 		ID: instance.ID("id1"),
 		Tags: map[string]string{
-			"infrakit.config_sha": "different-hash",
+			group.ConfigSHATag: "different-hash",
 		},
 	}
 	gomock.InOrder(
@@ -374,7 +374,7 @@ func TestScalerPlanUpdateScaleUp(t *testing.T) {
 	existingInst := instance.Description{
 		ID: instance.ID("id1"),
 		Tags: map[string]string{
-			"infrakit.config_sha": settingsOld.config.InstanceHash(),
+			group.ConfigSHATag: settingsOld.config.InstanceHash(),
 		},
 	}
 	gomock.InOrder(
@@ -416,7 +416,7 @@ func TestScalerPlanUpdateScaleUpRollingUpdate(t *testing.T) {
 	existingInst := instance.Description{
 		ID: instance.ID("id1"),
 		Tags: map[string]string{
-			"infrakit.config_sha": "different-hash",
+			group.ConfigSHATag: "different-hash",
 		},
 	}
 	gomock.InOrder(

--- a/pkg/provider/aws/experimental/bootstrap/create.go
+++ b/pkg/provider/aws/experimental/bootstrap/create.go
@@ -4,6 +4,10 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
+	"strings"
+	"text/template"
+	"time"
+
 	log "github.com/Sirupsen/logrus"
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/client"
@@ -14,9 +18,6 @@ import (
 	"github.com/docker/infrakit/pkg/spi/group"
 	"github.com/docker/infrakit/pkg/spi/instance"
 	"github.com/docker/infrakit/pkg/types"
-	"strings"
-	"text/template"
-	"time"
 )
 
 func createEBSVolumes(config client.ConfigProvider, spec clusterSpec) error {
@@ -514,7 +515,7 @@ func startInitialManager(config client.ConfigProvider, spec clusterSpec) error {
 
 	return ProvisionManager(
 		provisioner,
-		map[string]string{"infrakit.group": string(managerGroup.Name)},
+		map[string]string{group.GroupTag: string(managerGroup.Name)},
 		rawConfig,
 		spec.ManagerIPs[0])
 }

--- a/pkg/provider/digitalocean/plugin/instance/plugin_test.go
+++ b/pkg/provider/digitalocean/plugin/instance/plugin_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/digitalocean/godo"
 	itypes "github.com/docker/infrakit/pkg/provider/digitalocean/plugin/instance/types"
+	"github.com/docker/infrakit/pkg/spi/group"
 	"github.com/docker/infrakit/pkg/spi/instance"
 	"github.com/docker/infrakit/pkg/types"
 	"github.com/stretchr/testify/assert"
@@ -299,7 +300,7 @@ func TestDescribeInstancesNone(t *testing.T) {
 			},
 		},
 	}
-	descriptions, err := plugin.DescribeInstances(map[string]string{"infrakit.group": "foo"}, false)
+	descriptions, err := plugin.DescribeInstances(map[string]string{group.GroupTag: "foo"}, false)
 
 	require.NoError(t, err)
 	assert.Len(t, descriptions, 0)
@@ -310,14 +311,14 @@ func TestDescribeInstances(t *testing.T) {
 		droplets: &fakeDropletsServices{
 			listfunc: func(context.Context, *godo.ListOptions) ([]godo.Droplet, *godo.Response, error) {
 				return []godo.Droplet{
-					godoDroplet(tags("infrakit.group:foo")),
-					godoDroplet(tags("infrakit.group:bar")),
-					godoDroplet(tags("infrakit.group:foo")),
+					godoDroplet(tags(group.GroupTag + ":foo")),
+					godoDroplet(tags(group.GroupTag + ":bar")),
+					godoDroplet(tags(group.GroupTag + ":foo")),
 				}, godoResponse(), nil
 			},
 		},
 	}
-	descriptions, err := plugin.DescribeInstances(map[string]string{"infrakit.group": "foo"}, true)
+	descriptions, err := plugin.DescribeInstances(map[string]string{group.GroupTag: "foo"}, true)
 
 	require.NoError(t, err)
 	assert.Len(t, descriptions, 2)
@@ -332,14 +333,14 @@ func TestDescribeInstancesHandlesPages(t *testing.T) {
 					resp = godoResponse()
 				}
 				return []godo.Droplet{
-					godoDroplet(tags("infrakit.group:foo")),
-					godoDroplet(tags("infrakit.group:bar")),
-					godoDroplet(tags("infrakit.group:foo")),
+					godoDroplet(tags(group.GroupTag + ":foo")),
+					godoDroplet(tags(group.GroupTag + ":bar")),
+					godoDroplet(tags(group.GroupTag + ":foo")),
 				}, resp, nil
 			},
 		},
 	}
-	descriptions, err := plugin.DescribeInstances(map[string]string{"infrakit.group": "foo"}, true)
+	descriptions, err := plugin.DescribeInstances(map[string]string{group.GroupTag: "foo"}, true)
 
 	require.NoError(t, err)
 	assert.Len(t, descriptions, 4)

--- a/pkg/provider/oneview/plugin.go
+++ b/pkg/provider/oneview/plugin.go
@@ -10,6 +10,7 @@ import (
 
 	logutil "github.com/docker/infrakit/pkg/log"
 	"github.com/docker/infrakit/pkg/spi"
+	"github.com/docker/infrakit/pkg/spi/group"
 	"github.com/docker/infrakit/pkg/spi/instance"
 	"github.com/docker/infrakit/pkg/types"
 
@@ -146,7 +147,7 @@ func (p *plugin) Provision(spec instance.Spec) (*instance.ID, error) {
 	}
 
 	// Build a custom Description to allow InfraKit to identify new Instances
-	profileTemplate.Description = spec.Tags["infrakit.group"] + "|" + spec.Tags["infrakit.config_sha"]
+	profileTemplate.Description = spec.Tags[group.GroupTag] + "|" + spec.Tags["infrakit.config_sha"]
 
 	err = p.createProfileFromTemplate(string(instanceName), profileTemplate, availHW, spec)
 	if err != nil {
@@ -154,7 +155,7 @@ func (p *plugin) Provision(spec instance.Spec) (*instance.ID, error) {
 	}
 
 	if spec.Tags != nil {
-		log.Info("Adding %s to Group %v", string(instanceName), spec.Tags["infrakit.group"])
+		log.Info("Adding %s to Group %v", string(instanceName), spec.Tags[group.GroupTag])
 	}
 
 	var newInstance provisioningFSM
@@ -208,7 +209,7 @@ func (p *plugin) DescribeInstances(tags map[string]string, properties bool) ([]i
 		tagSlice := strings.Split(profile.Description, "|")
 		// If it exists, grab the group name
 		if len(tagSlice) > 0 {
-			instanceTags["infrakit.group"] = tagSlice[0]
+			instanceTags[group.GroupTag] = tagSlice[0]
 		}
 		// If it exists, grab the sha
 		if len(tagSlice) > 1 {
@@ -216,7 +217,7 @@ func (p *plugin) DescribeInstances(tags map[string]string, properties bool) ([]i
 		}
 
 		// We're only wanting to return instances from a specific group
-		if val, ok := tags["infrakit.group"]; ok {
+		if val, ok := tags[group.GroupTag]; ok {
 			// Check that we can get the group from the profile
 			if len(tagSlice) > 0 {
 				// Does this group match, if so add it to the results
@@ -255,7 +256,7 @@ func (p *plugin) DescribeInstances(tags map[string]string, properties bool) ([]i
 				provisioned = false
 			}
 		}
-		if provisioned == false && unprovisionedInstance.countdown != 0 && unprovisionedInstance.tags["infrakit.group"] == tags["infrakit.group"] {
+		if provisioned == false && unprovisionedInstance.countdown != 0 && unprovisionedInstance.tags[group.GroupTag] == tags[group.GroupTag] {
 			unprovisionedInstance.countdown--
 			updatedFSM = append(updatedFSM, unprovisionedInstance)
 		}
@@ -298,7 +299,7 @@ func (p *plugin) createProfileFromTemplate(name string, template ov.ServerProfil
 	}
 	newTemplate.ServerHardwareURI = blade.URI
 	// HPE OneView doesn't carry any concept of tags, we place all details needed in the Description field
-	newTemplate.Description = spec.Tags["infrakit.group"] + "|" + spec.Tags["infrakit.config_sha"]
+	newTemplate.Description = spec.Tags[group.GroupTag] + "|" + spec.Tags["infrakit.config_sha"]
 	newTemplate.Name = name
 
 	t, err := p.client.SubmitNewProfile(newTemplate)

--- a/pkg/provider/oneview/plugin.go
+++ b/pkg/provider/oneview/plugin.go
@@ -147,7 +147,7 @@ func (p *plugin) Provision(spec instance.Spec) (*instance.ID, error) {
 	}
 
 	// Build a custom Description to allow InfraKit to identify new Instances
-	profileTemplate.Description = spec.Tags[group.GroupTag] + "|" + spec.Tags["infrakit.config_sha"]
+	profileTemplate.Description = spec.Tags[group.GroupTag] + "|" + spec.Tags[group.ConfigSHATag]
 
 	err = p.createProfileFromTemplate(string(instanceName), profileTemplate, availHW, spec)
 	if err != nil {
@@ -213,7 +213,7 @@ func (p *plugin) DescribeInstances(tags map[string]string, properties bool) ([]i
 		}
 		// If it exists, grab the sha
 		if len(tagSlice) > 1 {
-			instanceTags["infrakit.config_sha"] = tagSlice[1]
+			instanceTags[group.ConfigSHATag] = tagSlice[1]
 		}
 
 		// We're only wanting to return instances from a specific group
@@ -299,7 +299,7 @@ func (p *plugin) createProfileFromTemplate(name string, template ov.ServerProfil
 	}
 	newTemplate.ServerHardwareURI = blade.URI
 	// HPE OneView doesn't carry any concept of tags, we place all details needed in the Description field
-	newTemplate.Description = spec.Tags[group.GroupTag] + "|" + spec.Tags["infrakit.config_sha"]
+	newTemplate.Description = spec.Tags[group.GroupTag] + "|" + spec.Tags[group.ConfigSHATag]
 	newTemplate.Name = name
 
 	t, err := p.client.SubmitNewProfile(newTemplate)

--- a/pkg/provider/rackhd/plugin/instance/instance_test.go
+++ b/pkg/provider/rackhd/plugin/instance/instance_test.go
@@ -3,6 +3,7 @@ package instance
 import (
 	"strings"
 
+	"github.com/docker/infrakit/pkg/spi/group"
 	"github.com/docker/infrakit/pkg/spi/instance"
 	"github.com/docker/infrakit/pkg/types"
 	"github.com/go-openapi/runtime"
@@ -109,7 +110,7 @@ var _ = Describe("Infrakit.Rackhd.Plugin.Instance", func() {
 					Expect(descriptions[0].ID).To(Equal(instanceID))
 					// Expect(descriptions[0].LogicalID).To(Exist())
 					Expect(descriptions[0].Tags["infrakit.config_sha"]).To(Equal("006438mMXW8gXeYtUxgf9Zbg94Y"))
-					Expect(descriptions[0].Tags["infrakit.group"]).To(Equal("cattle"))
+					Expect(descriptions[0].Tags[group.GroupTag]).To(Equal("cattle"))
 					Expect(descriptions[0].Tags["project"]).To(Equal("infrakit"))
 					Expect(descriptions[0].Tags["tier"]).To(Equal("web"))
 					Expect(err).To(BeNil())
@@ -148,7 +149,7 @@ var _ = Describe("Infrakit.Rackhd.Plugin.Instance", func() {
 			It("should tag a node during a label operation", func() {
 				labels := make(map[string]string)
 				labels["infrakit.config_sha"] = "006438mMXW8gXeYtUxgf9Zbg94Y"
-				labels["infrakit.group"] = "cattle"
+				labels[group.GroupTag] = "cattle"
 				labels["project"] = "infrakit"
 				labels["tier"] = "web"
 				err := pluginImpl.Label(instanceID, labels)
@@ -202,11 +203,11 @@ func _Nodes(provisioned bool) []*models.Node20Node {
 	var tags2 []string
 	if provisioned {
 		tags1 = append(tags1, "infrakit.config_sha=006438mMXW8gXeYtUxgf9Zbg94Y")
-		tags1 = append(tags1, "infrakit.group=cattle")
+		tags1 = append(tags1, group.GroupTag+"=cattle")
 		tags1 = append(tags1, "project=infrakit")
 		tags1 = append(tags1, "tier=web")
 		tags2 = append(tags1, "infrakit.config_sha=007429nMYW5gWExtUxfG8AcaF2Z")
-		tags2 = append(tags1, "infrakit.group=cattle")
+		tags2 = append(tags1, group.GroupTag+"=cattle")
 		tags2 = append(tags1, "project=infrakit")
 		tags2 = append(tags1, "tier=app")
 	}
@@ -245,11 +246,11 @@ func _SkuNodes(provisioned bool) []*models.Node20SkuNode {
 	var tags2 []string
 	if provisioned {
 		tags1 = append(tags1, "infrakit.config_sha=006438mMXW8gXeYtUxgf9Zbg94Y")
-		tags1 = append(tags1, "infrakit.group=cattle")
+		tags1 = append(tags1, group.GroupTag+"=cattle")
 		tags1 = append(tags1, "project=infrakit")
 		tags1 = append(tags1, "tier=web")
 		tags2 = append(tags1, "infrakit.config_sha=007429nMYW5gWExtUxfG8AcaF2Z")
-		tags2 = append(tags1, "infrakit.group=cattle")
+		tags2 = append(tags1, group.GroupTag+"=cattle")
 		tags2 = append(tags1, "project=infrakit")
 		tags2 = append(tags1, "tier=app")
 	}

--- a/pkg/provider/rackhd/plugin/instance/instance_test.go
+++ b/pkg/provider/rackhd/plugin/instance/instance_test.go
@@ -109,7 +109,7 @@ var _ = Describe("Infrakit.Rackhd.Plugin.Instance", func() {
 					Expect(len(descriptions)).To(Equal(1))
 					Expect(descriptions[0].ID).To(Equal(instanceID))
 					// Expect(descriptions[0].LogicalID).To(Exist())
-					Expect(descriptions[0].Tags["infrakit.config_sha"]).To(Equal("006438mMXW8gXeYtUxgf9Zbg94Y"))
+					Expect(descriptions[0].Tags[group.ConfigSHATag]).To(Equal("006438mMXW8gXeYtUxgf9Zbg94Y"))
 					Expect(descriptions[0].Tags[group.GroupTag]).To(Equal("cattle"))
 					Expect(descriptions[0].Tags["project"]).To(Equal("infrakit"))
 					Expect(descriptions[0].Tags["tier"]).To(Equal("web"))
@@ -148,7 +148,7 @@ var _ = Describe("Infrakit.Rackhd.Plugin.Instance", func() {
 
 			It("should tag a node during a label operation", func() {
 				labels := make(map[string]string)
-				labels["infrakit.config_sha"] = "006438mMXW8gXeYtUxgf9Zbg94Y"
+				labels[group.ConfigSHATag] = "006438mMXW8gXeYtUxgf9Zbg94Y"
 				labels[group.GroupTag] = "cattle"
 				labels["project"] = "infrakit"
 				labels["tier"] = "web"
@@ -202,11 +202,11 @@ func _Nodes(provisioned bool) []*models.Node20Node {
 	var tags1 []string
 	var tags2 []string
 	if provisioned {
-		tags1 = append(tags1, "infrakit.config_sha=006438mMXW8gXeYtUxgf9Zbg94Y")
+		tags1 = append(tags1, group.ConfigSHATag+"=006438mMXW8gXeYtUxgf9Zbg94Y")
 		tags1 = append(tags1, group.GroupTag+"=cattle")
 		tags1 = append(tags1, "project=infrakit")
 		tags1 = append(tags1, "tier=web")
-		tags2 = append(tags1, "infrakit.config_sha=007429nMYW5gWExtUxfG8AcaF2Z")
+		tags2 = append(tags1, group.ConfigSHATag+"=007429nMYW5gWExtUxfG8AcaF2Z")
 		tags2 = append(tags1, group.GroupTag+"=cattle")
 		tags2 = append(tags1, "project=infrakit")
 		tags2 = append(tags1, "tier=app")
@@ -245,11 +245,11 @@ func _SkuNodes(provisioned bool) []*models.Node20SkuNode {
 	var tags1 []string
 	var tags2 []string
 	if provisioned {
-		tags1 = append(tags1, "infrakit.config_sha=006438mMXW8gXeYtUxgf9Zbg94Y")
+		tags1 = append(tags1, group.ConfigSHATag+"=006438mMXW8gXeYtUxgf9Zbg94Y")
 		tags1 = append(tags1, group.GroupTag+"=cattle")
 		tags1 = append(tags1, "project=infrakit")
 		tags1 = append(tags1, "tier=web")
-		tags2 = append(tags1, "infrakit.config_sha=007429nMYW5gWExtUxfG8AcaF2Z")
+		tags2 = append(tags1, group.ConfigSHATag+"=007429nMYW5gWExtUxfG8AcaF2Z")
 		tags2 = append(tags1, group.GroupTag+"=cattle")
 		tags2 = append(tags1, "project=infrakit")
 		tags2 = append(tags1, "tier=app")

--- a/pkg/provider/terraform/instance/plugin_test.go
+++ b/pkg/provider/terraform/instance/plugin_test.go
@@ -4041,8 +4041,8 @@ func TestImportResourceTagMap(t *testing.T) {
 	}
 	spec := instance.Spec{
 		Tags: map[string]string{
-			group.GroupTag:        "managers",
-			"infrakit.config_sha": "bootstrap",
+			group.GroupTag:     "managers",
+			group.ConfigSHATag: "bootstrap",
 		},
 		Properties: types.AnyString(`
 {
@@ -4080,10 +4080,10 @@ func TestImportResourceTagMap(t *testing.T) {
 						"hostname": "actual-hostname",
 						"spec-key": "actual-val",
 						"tags": map[string]interface{}{
-							"imported-tag1":       "val1",
-							"t1":                  "v1",
-							group.GroupTag:        "managers",
-							"infrakit.config_sha": "bootstrap",
+							"imported-tag1":    "val1",
+							"t1":               "v1",
+							group.GroupTag:     "managers",
+							group.ConfigSHATag: "bootstrap",
 						},
 					},
 				},
@@ -4133,8 +4133,8 @@ func TestImportResourceTagSlice(t *testing.T) {
 	}
 	spec := instance.Spec{
 		Tags: map[string]string{
-			group.GroupTag:        "managers",
-			"infrakit.config_sha": "bootstrap",
+			group.GroupTag:     "managers",
+			group.ConfigSHATag: "bootstrap",
 		},
 		Properties: types.AnyString(`
 {
@@ -4174,7 +4174,7 @@ func TestImportResourceTagSlice(t *testing.T) {
 	require.Len(t, tags, 3)
 	require.Contains(t, tags, "t1:v1")
 	require.Contains(t, tags, group.GroupTag+":managers")
-	require.Contains(t, tags, "infrakit.config_sha:bootstrap")
+	require.Contains(t, tags, group.ConfigSHATag+":bootstrap")
 	// Compare everythine else
 	require.Equal(t,
 		TResourceProperties{
@@ -4364,9 +4364,9 @@ func internalTestImportResourceDedicatedGlobal(t *testing.T, options importOptio
 	}
 	spec := instance.Spec{
 		Tags: map[string]string{
-			group.GroupTag:        "managers",
-			"infrakit.config_sha": "bootstrap",
-			"LogicalID":           "mgr1",
+			group.GroupTag:     "managers",
+			group.ConfigSHATag: "bootstrap",
+			"LogicalID":        "mgr1",
 		},
 		Properties: types.AnyString(`
 {
@@ -4463,7 +4463,7 @@ func internalTestImportResourceDedicatedGlobal(t *testing.T, options importOptio
 		require.Len(t, tags, 4)
 		require.Contains(t, tags, "logicalid:mgr1")
 		require.Contains(t, tags, group.GroupTag+":managers")
-		require.Contains(t, tags, "infrakit.config_sha:bootstrap")
+		require.Contains(t, tags, group.ConfigSHATag+":bootstrap")
 		require.Contains(t, tags, "infrakit.attach:managers_dedicated_mgr1 managers_global")
 		// Compare everythine else
 		require.Equal(t,

--- a/pkg/provider/terraform/instance/plugin_test.go
+++ b/pkg/provider/terraform/instance/plugin_test.go
@@ -12,6 +12,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/docker/infrakit/pkg/spi/group"
 	"github.com/docker/infrakit/pkg/spi/instance"
 	"github.com/docker/infrakit/pkg/types"
 	"github.com/spf13/afero"
@@ -4040,7 +4041,7 @@ func TestImportResourceTagMap(t *testing.T) {
 	}
 	spec := instance.Spec{
 		Tags: map[string]string{
-			"infrakit.group":      "managers",
+			group.GroupTag:        "managers",
 			"infrakit.config_sha": "bootstrap",
 		},
 		Properties: types.AnyString(`
@@ -4081,7 +4082,7 @@ func TestImportResourceTagMap(t *testing.T) {
 						"tags": map[string]interface{}{
 							"imported-tag1":       "val1",
 							"t1":                  "v1",
-							"infrakit.group":      "managers",
+							group.GroupTag:        "managers",
 							"infrakit.config_sha": "bootstrap",
 						},
 					},
@@ -4132,7 +4133,7 @@ func TestImportResourceTagSlice(t *testing.T) {
 	}
 	spec := instance.Spec{
 		Tags: map[string]string{
-			"infrakit.group":      "managers",
+			group.GroupTag:        "managers",
 			"infrakit.config_sha": "bootstrap",
 		},
 		Properties: types.AnyString(`
@@ -4172,7 +4173,7 @@ func TestImportResourceTagSlice(t *testing.T) {
 	delete(props, "tags")
 	require.Len(t, tags, 3)
 	require.Contains(t, tags, "t1:v1")
-	require.Contains(t, tags, "infrakit.group:managers")
+	require.Contains(t, tags, group.GroupTag+":managers")
 	require.Contains(t, tags, "infrakit.config_sha:bootstrap")
 	// Compare everythine else
 	require.Equal(t,
@@ -4363,7 +4364,7 @@ func internalTestImportResourceDedicatedGlobal(t *testing.T, options importOptio
 	}
 	spec := instance.Spec{
 		Tags: map[string]string{
-			"infrakit.group":      "managers",
+			group.GroupTag:        "managers",
 			"infrakit.config_sha": "bootstrap",
 			"LogicalID":           "mgr1",
 		},
@@ -4461,7 +4462,7 @@ func internalTestImportResourceDedicatedGlobal(t *testing.T, options importOptio
 		delete(props, "tags")
 		require.Len(t, tags, 4)
 		require.Contains(t, tags, "logicalid:mgr1")
-		require.Contains(t, tags, "infrakit.group:managers")
+		require.Contains(t, tags, group.GroupTag+":managers")
 		require.Contains(t, tags, "infrakit.config_sha:bootstrap")
 		require.Contains(t, tags, "infrakit.attach:managers_dedicated_mgr1 managers_global")
 		// Compare everythine else

--- a/pkg/provider/terraform/instance/show_test.go
+++ b/pkg/provider/terraform/instance/show_test.go
@@ -518,7 +518,7 @@ func TestTerraformShowParseResultTagsList(t *testing.T) {
 		"ssh_key_ids":      []interface{}{123456},
 		"tags": []interface{}{
 			group.GroupTag + ":workers",
-			"infrakit.config_sha:tubmesopo6lrsfnl5otajlpvwd23v46j",
+			group.ConfigSHATag + ":tubmesopo6lrsfnl5otajlpvwd23v46j",
 			"name:instance-1499827079",
 			"infrakit-link-context:swarm::c80s4c4kq0kgjs64ojxzvsdjz::worker",
 			"swarm-id:c80s4c4kq0kgjs64ojxzvsdjz",
@@ -555,7 +555,7 @@ func TestTerraformShowParseResultTagsListWithFilters(t *testing.T) {
 		"cores": 1,
 		"tags": []interface{}{
 			group.GroupTag + ":workers",
-			"infrakit.config_sha:tubmesopo6lrsfnl5otajlpvwd23v46j",
+			group.ConfigSHATag + ":tubmesopo6lrsfnl5otajlpvwd23v46j",
 			"name:instance-1499827079",
 			"infrakit-link-context:swarm::c80s4c4kq0kgjs64ojxzvsdjz::worker",
 			"swarm-id:c80s4c4kq0kgjs64ojxzvsdjz",

--- a/pkg/provider/terraform/instance/show_test.go
+++ b/pkg/provider/terraform/instance/show_test.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/docker/infrakit/pkg/spi/group"
 	"github.com/stretchr/testify/require"
 
 	. "github.com/docker/infrakit/pkg/testing"
@@ -516,7 +517,7 @@ func TestTerraformShowParseResultTagsList(t *testing.T) {
 		"memory":           2048,
 		"ssh_key_ids":      []interface{}{123456},
 		"tags": []interface{}{
-			"infrakit.group:workers",
+			group.GroupTag + ":workers",
 			"infrakit.config_sha:tubmesopo6lrsfnl5otajlpvwd23v46j",
 			"name:instance-1499827079",
 			"infrakit-link-context:swarm::c80s4c4kq0kgjs64ojxzvsdjz::worker",
@@ -553,7 +554,7 @@ func TestTerraformShowParseResultTagsListWithFilters(t *testing.T) {
 		"id":    36147555,
 		"cores": 1,
 		"tags": []interface{}{
-			"infrakit.group:workers",
+			group.GroupTag + ":workers",
 			"infrakit.config_sha:tubmesopo6lrsfnl5otajlpvwd23v46j",
 			"name:instance-1499827079",
 			"infrakit-link-context:swarm::c80s4c4kq0kgjs64ojxzvsdjz::worker",

--- a/pkg/provider/vsphere/plugin.go
+++ b/pkg/provider/vsphere/plugin.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/docker/infrakit/pkg/spi"
+	"github.com/docker/infrakit/pkg/spi/group"
 	"github.com/docker/infrakit/pkg/spi/instance"
 	"github.com/docker/infrakit/pkg/types"
 
@@ -134,7 +135,7 @@ func (p *plugin) Provision(spec instance.Spec) (*instance.ID, error) {
 	// Use the VMware plugin data in order to provision a new VM server
 	vmName := instance.ID(fmt.Sprintf(newVM.vmPrefix+"-%d", rand.Int63()))
 	if spec.Tags != nil {
-		log.Info("Provisioning", "vm", string(vmName), "group", spec.Tags["infrakit.group"])
+		log.Info("Provisioning", "vm", string(vmName), "group", spec.Tags[group.GroupTag])
 	} else {
 		log.Info("Provisioning", "vm", string(vmName))
 	}
@@ -204,7 +205,7 @@ func (p *plugin) DescribeInstances(tags map[string]string, properties bool) ([]i
 	log.Debug(fmt.Sprintf("describe-instances: %v", tags))
 	results := []instance.Description{}
 
-	groupName := tags["infrakit.group"]
+	groupName := tags[group.GroupTag]
 
 	instances, err := findGroupInstances(p, groupName)
 	if err != nil {
@@ -250,7 +251,7 @@ func (p *plugin) DescribeInstances(tags map[string]string, properties bool) ([]i
 				provisioned = false
 			}
 		}
-		if provisioned == false && unprovisionedInstance.timer.After(time.Now()) && unprovisionedInstance.tags["infrakit.group"] == tags["infrakit.group"] {
+		if provisioned == false && unprovisionedInstance.timer.After(time.Now()) && unprovisionedInstance.tags[group.GroupTag] == tags[group.GroupTag] {
 			updatedFSM = append(updatedFSM, unprovisionedInstance)
 		}
 	}

--- a/pkg/provider/vsphere/plugin.go
+++ b/pkg/provider/vsphere/plugin.go
@@ -226,7 +226,7 @@ func (p *plugin) DescribeInstances(tags map[string]string, properties bool) ([]i
 			vmTags[k] = v
 		}
 
-		vmTags["infrakit.config_sha"] = configSHA
+		vmTags[group.ConfigSHATag] = configSHA
 		vmTags["guestIP"] = guestIP
 		results = append(results, instance.Description{
 			ID:        instance.ID(vmInstance.Name()),

--- a/pkg/provider/vsphere/vsphereTasks.go
+++ b/pkg/provider/vsphere/vsphereTasks.go
@@ -49,7 +49,7 @@ func cloneNewInstance(p *plugin, vm *vmInstance, vmSpec instance.Spec) error {
 
 	// The only change we make to the Template Spec, is the config sha and group name
 	spec := types.VirtualMachineConfigSpec{
-		Annotation: vmSpec.Tags[group.GroupTag] + "\n" + vmSpec.Tags["infrakit.config_sha"] + "\n" + vm.annotation,
+		Annotation: vmSpec.Tags[group.GroupTag] + "\n" + vmSpec.Tags[group.ConfigSHATag] + "\n" + vm.annotation,
 	}
 
 	// Changes can be to spec or relocateSpec
@@ -124,7 +124,7 @@ func createNewVMInstance(p *plugin, vm *vmInstance, vmSpec instance.Spec) error 
 		Files:      &types.VirtualMachineFileInfo{VmPathName: fmt.Sprintf("[%s]", p.vCenterInternals.datastore.Name())},
 		NumCPUs:    int32(vm.vCpus),
 		MemoryMB:   int64(vm.mem),
-		Annotation: vmSpec.Tags[group.GroupTag] + "\n" + vmSpec.Tags["infrakit.config_sha"] + "\n" + vm.annotation,
+		Annotation: vmSpec.Tags[group.GroupTag] + "\n" + vmSpec.Tags[group.ConfigSHATag] + "\n" + vm.annotation,
 	}
 
 	scsi, err := object.SCSIControllerTypes().CreateSCSIController("pvscsi")

--- a/pkg/run/v0/docker/docker.go
+++ b/pkg/run/v0/docker/docker.go
@@ -14,6 +14,7 @@ import (
 	"github.com/docker/infrakit/pkg/run"
 	"github.com/docker/infrakit/pkg/run/local"
 	"github.com/docker/infrakit/pkg/run/scope"
+	"github.com/docker/infrakit/pkg/spi/group"
 	"github.com/docker/infrakit/pkg/types"
 	"golang.org/x/net/context"
 )
@@ -89,7 +90,7 @@ func Run(scope scope.Scope, name plugin.Name,
 
 	// filter on containers managed by InfraKit
 	filter := filters.NewArgs()
-	filter.Add("label", "infrakit.group")
+	filter.Add("label", group.GroupTag)
 	listOptions := apitypes.ContainerListOptions{Filters: filter}
 	go func() {
 		tick := time.Tick(2 * time.Second)

--- a/pkg/run/v0/terraform/terraform.go
+++ b/pkg/run/v0/terraform/terraform.go
@@ -199,7 +199,7 @@ func parseInstanceSpecFromGroup(scope scope.Scope, groupSpecURL, groupID string)
 			return nil, fmt.Errorf("Given spec ID '%v' does not match given group ID '%v'",
 				string(groupSpec.ID), groupID)
 		}
-		tags["infrakit.group"] = groupID
+		tags[group.GroupTag] = groupID
 	}
 	// Use the first logical ID if set
 	if len(groupProps.Allocation.LogicalIDs) > 0 {

--- a/pkg/run/v0/terraform/terraform.go
+++ b/pkg/run/v0/terraform/terraform.go
@@ -191,7 +191,7 @@ func parseInstanceSpecFromGroup(scope scope.Scope, groupSpecURL, groupID string)
 
 	// Add in the bootstrap tag and (if set) the group ID
 	tags := map[string]string{
-		"infrakit.config_sha": "bootstrap",
+		group.ConfigSHATag: "bootstrap",
 	}
 	// The group ID should match the spec
 	if groupID != "" {

--- a/pkg/spi/group/spi.go
+++ b/pkg/spi/group/spi.go
@@ -6,6 +6,11 @@ import (
 	"github.com/docker/infrakit/pkg/types"
 )
 
+const (
+	// GroupTag is the name of the tag that contains the group name
+	GroupTag = "infrakit.group"
+)
+
 // InterfaceSpec is the current name and version of the Group API.
 var InterfaceSpec = spi.InterfaceSpec{
 	Name:    "Group",

--- a/pkg/spi/group/spi.go
+++ b/pkg/spi/group/spi.go
@@ -9,6 +9,8 @@ import (
 const (
 	// GroupTag is the name of the tag that contains the group name
 	GroupTag = "infrakit.group"
+	// ConfigSHATag is the name of the tag that contains the group SHA hash
+	ConfigSHATag = "infrakit.config_sha"
 )
 
 // InterfaceSpec is the current name and version of the Group API.

--- a/pkg/spi/instance/spi.go
+++ b/pkg/spi/instance/spi.go
@@ -5,6 +5,11 @@ import (
 	"github.com/docker/infrakit/pkg/types"
 )
 
+const (
+	// LogicalIDTag is the name of the tag that contains the logical ID of the instance
+	LogicalIDTag = "infrakit.logical_id"
+)
+
 // InterfaceSpec is the current name and version of the Instance API.
 var InterfaceSpec = spi.InterfaceSpec{
 	Name:    "Instance",


### PR DESCRIPTION
- Move `infrakit.group` tag to a constant in `spi/group/spi.go`
- Move `infrakit.config_sha` tag to a constant in `spi/group/spi.go`
- Move `infrakit.logical_id` tag to a constant in `spi/instance/spi.go`