### PR TITLE
IBM Cloud LB Publish() for Cert not found

### DIFF
--- a/pkg/provider/ibmcloud/plugin/loadbalancer/lb.go
+++ b/pkg/provider/ibmcloud/plugin/loadbalancer/lb.go
@@ -206,8 +206,10 @@ func (l *ibmcloudlb) Publish(route loadbalancer.Route) (loadbalancer.Result, err
 		}
 		if len(cert) == 1 {
 			certID = *cert[0].Id
+		} else if len(cert) == 0 {
+			return nil, fmt.Errorf("No certificate found with common name '%s'", *route.Certificate)
 		} else {
-			return nil, fmt.Errorf("Cannot identify an unique certificate with common name '%s'", *route.Certificate)
+			return nil, fmt.Errorf("Cannot identify an unique certificate with common name '%s' (%d certificates found)", *route.Certificate, len(cert))
 		}
 	}
 


### PR DESCRIPTION
The IBM Cloud Publish() error for invalid number (!= 1) of certs is updated so we can differentiate if there are 0 or >1.

Signed-off-by: Eric Van Norman <ericvn@us.ibm.com>