### PR TITLE
Update old terraform LogicalID tag refs

### DIFF
--- a/pkg/provider/terraform/instance/cmd/main.go
+++ b/pkg/provider/terraform/instance/cmd/main.go
@@ -141,7 +141,7 @@ func parseInstanceSpecFromGroup(groupSpecURL, groupID string) (*instance.Spec, e
 
 	// Add in the bootstrap tag and (if set) the group ID
 	tags := map[string]string{
-		"infrakit.config_sha": "bootstrap",
+		group.ConfigSHATag: "bootstrap",
 	}
 	// The group ID should match the spec
 	if groupID != "" {
@@ -149,11 +149,11 @@ func parseInstanceSpecFromGroup(groupSpecURL, groupID string) (*instance.Spec, e
 			return nil, fmt.Errorf("Given spec ID '%v' does not match given group ID '%v'",
 				string(groupSpec.ID), groupID)
 		}
-		tags["infrakit.group"] = groupID
+		tags[group.GroupTag] = groupID
 	}
 	// Use the first logical ID if set
 	if len(groupProps.Allocation.LogicalIDs) > 0 {
-		tags["LogicalID"] = string(groupProps.Allocation.LogicalIDs[0])
+		tags[instance.LogicalIDTag] = string(groupProps.Allocation.LogicalIDs[0])
 	}
 
 	spec := instance.Spec{

--- a/pkg/provider/terraform/instance/cmd/main_test.go
+++ b/pkg/provider/terraform/instance/cmd/main_test.go
@@ -3,6 +3,7 @@ package main
 import (
 	"testing"
 
+	"github.com/docker/infrakit/pkg/spi/group"
 	"github.com/docker/infrakit/pkg/spi/instance"
 	"github.com/docker/infrakit/pkg/types"
 	"github.com/stretchr/testify/require"
@@ -41,8 +42,8 @@ func TestParseInstanceSpecFromGroup(t *testing.T) {
 		instance.Spec{
 			Properties: types.AnyString(`{"resource": {"aws_instance": {}}}`),
 			Tags: map[string]string{
-				"infrakit.config_sha": "bootstrap",
-				"infrakit.group":      groupID,
+				group.ConfigSHATag: "bootstrap",
+				group.GroupTag:     groupID,
 			},
 		},
 		*instSpec)
@@ -68,9 +69,9 @@ func TestParseInstanceSpecFromGroupLogicalID(t *testing.T) {
 		instance.Spec{
 			Properties: types.AnyString(`{"resource": {"aws_instance": {}}}`),
 			Tags: map[string]string{
-				"infrakit.config_sha": "bootstrap",
-				"infrakit.group":      groupID,
-				"LogicalID":           "mgr1",
+				group.ConfigSHATag:    "bootstrap",
+				group.GroupTag:        groupID,
+				instance.LogicalIDTag: "mgr1",
 			},
 		},
 		*instSpec)
@@ -92,7 +93,7 @@ func TestParseInstanceSpecFromGroupNoGroupIDSpecified(t *testing.T) {
 		instance.Spec{
 			Properties: types.AnyString(`{"resource": {"aws_instance": {}}}`),
 			Tags: map[string]string{
-				"infrakit.config_sha": "bootstrap",
+				group.ConfigSHATag: "bootstrap",
 			},
 		},
 		*instSpec)

--- a/pkg/provider/terraform/instance/plugin.go
+++ b/pkg/provider/terraform/instance/plugin.go
@@ -1306,13 +1306,14 @@ func (p *plugin) importResources(fns importFns, resources []*ImportResource, spe
 	}
 
 	// Map resources to import with resources in the spec
-	var specLogicalID instance.LogicalID
+	var specLogicalID *instance.LogicalID
 	if spec.Tags != nil {
 		if logicalID, has := spec.Tags[instance.LogicalIDTag]; has {
-			specLogicalID = instance.LogicalID(logicalID)
+			logicalID := instance.LogicalID(logicalID)
+			specLogicalID = &logicalID
 		}
 	}
-	decomposedFiles, err := p.decompose(&specLogicalID, vmResName, &tf, specVMType, specVMProps)
+	decomposedFiles, err := p.decompose(specLogicalID, vmResName, &tf, specVMType, specVMProps)
 	if err != nil {
 		return err
 	}

--- a/pkg/run/v0/terraform/terraform.go
+++ b/pkg/run/v0/terraform/terraform.go
@@ -203,7 +203,7 @@ func parseInstanceSpecFromGroup(scope scope.Scope, groupSpecURL, groupID string)
 	}
 	// Use the first logical ID if set
 	if len(groupProps.Allocation.LogicalIDs) > 0 {
-		tags["LogicalID"] = string(groupProps.Allocation.LogicalIDs[0])
+		tags[instance.LogicalIDTag] = string(groupProps.Allocation.LogicalIDs[0])
 	}
 
 	spec := instance.Spec{


### PR DESCRIPTION
A few were missed when we did https://github.com/docker/infrakit/pull/811

Also updates the import logic to only specify the Logical ID if it is set in the tags; currently it is being passed as an empty string if the tag is not set.
