### PR TITLE
Return error when terraform show fails

### DIFF
--- a/pkg/provider/terraform/instance/plugin.go
+++ b/pkg/provider/terraform/instance/plugin.go
@@ -1158,8 +1158,8 @@ func (p *plugin) DescribeInstances(tags map[string]string, properties bool) ([]i
 			if result, err := p.doTerraformShow([]TResourceType{vmResourceType}, nil); err == nil {
 				terraformShowResult = result
 			} else {
-				// Don't blow up... just do best and show what we can find.
 				logger.Warn("DescribeInstances", "terraform show error", err)
+				return nil, err
 			}
 		}
 	}


### PR DESCRIPTION
If `terraform show` fails we need to return on error on the API, if not then consumers (like the enrollment and ingress controllers) have no idea the expected data was not returned. This is particularly problematic for the NFS enrollment controller, when the `id` property is not returned
then it assumes that all instances should be removed (which de-authorizes all managers from NFS).
