### PR TITLE
Support "MissingKey" template option

### DIFF
--- a/pkg/controller/enrollment/types/types.go
+++ b/pkg/controller/enrollment/types/types.go
@@ -123,8 +123,11 @@ type Options struct {
 	DestroyOnTerminate bool
 }
 
-// TemplateFrom returns a template after it has un-escapes any escape sequences
+// TemplateFrom returns a template after it has un-escaped any escape sequences
 func TemplateFrom(source []byte) (*template.Template, error) {
 	buff := template.Unescape(source)
-	return template.NewTemplate("str://"+string(buff), template.Options{MultiPass: false})
+	return template.NewTemplate(
+		"str://"+string(buff),
+		template.Options{MultiPass: false, MissingKey: template.MissingKeyError},
+	)
 }

--- a/pkg/controller/ingress/types/types.go
+++ b/pkg/controller/ingress/types/types.go
@@ -132,5 +132,8 @@ type Options struct {
 // TemplateFrom returns a template after it has un-escapes any escape sequences
 func TemplateFrom(source []byte) (*template.Template, error) {
 	buff := template.Unescape(source)
-	return template.NewTemplate("str://"+string(buff), template.Options{MultiPass: false})
+	return template.NewTemplate(
+		"str://"+string(buff),
+		template.Options{MultiPass: false, MissingKey: template.MissingKeyError},
+	)
 }

--- a/pkg/core/object.go
+++ b/pkg/core/object.go
@@ -137,7 +137,7 @@ func templateEngine(url string,
 					"and calls GET on the plugin with the path \"path/to/data\".",
 					"It's identical to the CLI command infrakit metadata cat ...",
 				},
-				Func: func(n string, optional ...interface{}) interface{} {
+				Func: func(n string, optional ...interface{}) (interface{}, error) {
 
 					// It's chained -- first we try to get value from the object itself
 					// then we try the default template var
@@ -145,7 +145,7 @@ func templateEngine(url string,
 
 					v := types.Get(p, objectView)
 					if v != nil {
-						return v
+						return v, nil
 					}
 					return t.Var(n, optional...)
 				},

--- a/pkg/run/scope/scope.go
+++ b/pkg/run/scope/scope.go
@@ -109,7 +109,7 @@ func (f fullScope) TemplateEngine(url string, opts template.Options) (*template.
 				Func: func(name string, optional ...interface{}) (interface{}, error) {
 
 					if len(optional) > 0 {
-						return engine.Var(name, optional...), nil
+						return engine.Var(name, optional...)
 					}
 
 					v := engine.Ref(name)

--- a/pkg/template/template.go
+++ b/pkg/template/template.go
@@ -275,17 +275,20 @@ func (t *Template) DeferVar(name string) string {
 // in multiple passes where some var cannot be resolved to values in the first pass.
 // In this case, if the MultiplePass flag is set, the var function will just echo back
 // the same template expression in case of no value.
-func (t *Template) Var(name string, optional ...interface{}) interface{} {
+func (t *Template) Var(name string, optional ...interface{}) (interface{}, error) {
 	base := t.doVar(name, optional...)
 
 	if !t.options.MultiPass {
-		return base
+		if base == nil && t.options.MissingKey == MissingKeyError {
+			return nil, fmt.Errorf("Missing variable %s", name)
+		}
+		return base, nil
 	}
 
 	if base != nil {
-		return base
+		return base, nil
 	}
-	return t.DeferVar(name)
+	return t.DeferVar(name), nil
 }
 
 // var implements the var function. It's a combination of global and ref

--- a/pkg/template/template.go
+++ b/pkg/template/template.go
@@ -17,6 +17,12 @@ import (
 
 var log = logutil.New("module", "core/template")
 
+const (
+	// MissingKeyError is the value for the MissingKey template option, an error
+	// is raised if a key does not exist
+	MissingKeyError = "error"
+)
+
 // Function contains the description of an exported template function
 type Function struct {
 
@@ -75,6 +81,11 @@ type Options struct {
 
 	// CacheDir is the location of the cache
 	CacheDir string
+
+	// MissingKey is used to handle when a key value not set; the default value
+	// of "default" yields a "<no value>" template output. Specifying "error" yields
+	// an error if the key value is not set.
+	MissingKey string
 }
 
 // Template is the templating engine
@@ -378,6 +389,9 @@ func (t *Template) build(context Context) error {
 	tt := template.New(t.url).Funcs(fm)
 	if t.options.DelimLeft != "" && t.options.DelimRight != "" {
 		tt.Delims(t.options.DelimLeft, t.options.DelimRight)
+	}
+	if t.options.MissingKey != "" {
+		tt.Option(fmt.Sprintf("missingkey=%s", t.options.MissingKey))
 	}
 
 	parsed, err := tt.Parse(string(t.body))

--- a/pkg/template/template_test.go
+++ b/pkg/template/template_test.go
@@ -156,6 +156,22 @@ func TestMissingKey(t *testing.T) {
 	require.Error(t, err)
 }
 
+func TestMissingKeyVar(t *testing.T) {
+	str := `{{ var "foo" }}`
+	// Default behavior
+	tpl, err := NewTemplate("str://"+str, Options{})
+	require.NoError(t, err)
+	view, err := tpl.Render("")
+	require.NoError(t, err)
+	expected := "<no value>"
+	require.Equal(t, expected, view)
+	// Raise an error
+	tpl, err = NewTemplate("str://"+str, Options{MissingKey: MissingKeyError})
+	require.NoError(t, err)
+	_, err = tpl.Render("")
+	require.Error(t, err)
+}
+
 type context struct {
 	Count  int
 	Bool   bool

--- a/pkg/template/template_test.go
+++ b/pkg/template/template_test.go
@@ -140,6 +140,22 @@ func TestVarAndGlobalMultiPass(t *testing.T) {
 
 }
 
+func TestMissingKey(t *testing.T) {
+	str := `{{ $x := "{}" | jsonDecode }}{{ $x.key }}`
+	// Default behavior
+	tpl, err := NewTemplate("str://"+str, Options{})
+	require.NoError(t, err)
+	view, err := tpl.Render("")
+	require.NoError(t, err)
+	expected := "<no value>"
+	require.Equal(t, expected, view)
+	// Raise an error
+	tpl, err = NewTemplate("str://"+str, Options{MissingKey: MissingKeyError})
+	require.NoError(t, err)
+	_, err = tpl.Render("")
+	require.Error(t, err)
+}
+
 type context struct {
 	Count  int
 	Bool   bool


### PR DESCRIPTION
By default, if a template map key is missing, the template rendering yields a String with `<no value>`. This commit adds support to pass the template `MissingKey` option, see:
https://golang.org/pkg/text/template/#Template.Option

Note that the default behavior will not change; this is opt-in.

This commit also updates the enrollment and ingress controllers to use this new Option so that an `error` is raised.

Lastly, the `var` function is also updated to conditionally raise an error if the variable does not exist (if if `MissingKey` option is set to `error)`.

Closes #821 
  