### PR TITLE
Fix broken build

### DIFF
--- a/scripts/e2e-test-1.sh
+++ b/scripts/e2e-test-1.sh
@@ -71,7 +71,7 @@ expect_exact_output "Scale to 5 instances" \
 sleep 10
 
 note "Freeing and re-committing cattle"
-infrakit local mystack/cattle free
+infrakit local mystack/cattle free-group
 sleep 5
 infrakit local mystack/groups commit-group scripts/cattle.json
 


### PR DESCRIPTION
This PR fixes broken e2e test by updating the `free` verb to `free-group` verb.

Signed-off-by: David Chung david.chung@docker.com