### PR TITLE
Check for changes to SSL cert and health monitor path.

### DIFF
--- a/pkg/controller/ingress/l4_test.go
+++ b/pkg/controller/ingress/l4_test.go
@@ -1,0 +1,228 @@
+package ingress
+
+import (
+	"testing"
+
+	"github.com/docker/infrakit/pkg/controller/ingress/types"
+	"github.com/docker/infrakit/pkg/spi/loadbalancer"
+	"github.com/stretchr/testify/require"
+)
+
+func TestPublishRoute(t *testing.T) {
+	// Prime the lb with nothing
+	lb := NewMockLBPlugin([]loadbalancer.Route{})
+
+	// Construct desired list
+	cert := "mycert"
+	hmPath := "/health"
+	desired := []loadbalancer.Route{{
+		Port:                 8080,
+		Protocol:             "HTTP",
+		LoadBalancerPort:     444,
+		LoadBalancerProtocol: "HTTPS",
+		Certificate:          &cert,
+		HealthMonitorPath:    &hmPath,
+	}}
+
+	var options types.Options
+	err := configureL4(lb, desired, options)
+	require.NoError(t, err)
+
+	routes, err := lb.Routes()
+	require.NoError(t, err)
+	require.Equal(t, len(desired), len(routes))
+	require.Equal(t, desired[0].Port, routes[0].Port)
+	require.Equal(t, desired[0].Protocol, routes[0].Protocol)
+	require.Equal(t, desired[0].LoadBalancerPort, routes[0].LoadBalancerPort)
+	require.Equal(t, desired[0].LoadBalancerProtocol, routes[0].LoadBalancerProtocol)
+	require.Equal(t, *desired[0].Certificate, *routes[0].Certificate)
+	require.Equal(t, *desired[0].HealthMonitorPath, *routes[0].HealthMonitorPath)
+}
+
+func TestUnpublishRoute(t *testing.T) {
+	// Prime the lb with a route
+	cert := "mycert"
+	hmPath := "/health"
+	lb := NewMockLBPlugin([]loadbalancer.Route{{
+		Port:                 8080,
+		Protocol:             "HTTP",
+		LoadBalancerPort:     444,
+		LoadBalancerProtocol: "HTTPS",
+		Certificate:          &cert,
+		HealthMonitorPath:    &hmPath,
+	}})
+
+	// Construct empty desired list
+	desired := []loadbalancer.Route{}
+
+	var options types.Options
+	err := configureL4(lb, desired, options)
+	require.NoError(t, err)
+
+	routes, err := lb.Routes()
+	require.NoError(t, err)
+	require.Equal(t, len(desired), len(routes))
+}
+
+func TestChangeCert(t *testing.T) {
+	// Prime the lb with a route
+	cert := "mycert"
+	hmPath := "/health"
+	lb := NewMockLBPlugin([]loadbalancer.Route{{
+		Port:                 8080,
+		Protocol:             "HTTP",
+		LoadBalancerPort:     444,
+		LoadBalancerProtocol: "HTTPS",
+		Certificate:          &cert,
+		HealthMonitorPath:    &hmPath,
+	}})
+
+	// Change the cert
+	newcert := "newcert"
+	desired := []loadbalancer.Route{{
+		Port:                 8080,
+		Protocol:             "HTTP",
+		LoadBalancerPort:     444,
+		LoadBalancerProtocol: "HTTPS",
+		Certificate:          &newcert,
+		HealthMonitorPath:    &hmPath,
+	}}
+
+	var options types.Options
+	err := configureL4(lb, desired, options)
+	require.NoError(t, err)
+
+	routes, err := lb.Routes()
+	require.NoError(t, err)
+	require.Equal(t, len(desired), len(routes))
+	require.Equal(t, desired[0].Port, routes[0].Port)
+	require.Equal(t, desired[0].Protocol, routes[0].Protocol)
+	require.Equal(t, desired[0].LoadBalancerPort, routes[0].LoadBalancerPort)
+	require.Equal(t, desired[0].LoadBalancerProtocol, routes[0].LoadBalancerProtocol)
+	require.Equal(t, *desired[0].Certificate, *routes[0].Certificate)
+	require.Equal(t, *desired[0].HealthMonitorPath, *routes[0].HealthMonitorPath)
+}
+
+func TestChangeHmPath(t *testing.T) {
+	// Prime the lb with a route
+	cert := "mycert"
+	hmPath := "/health"
+	lb := NewMockLBPlugin([]loadbalancer.Route{{
+		Port:                 8080,
+		Protocol:             "HTTP",
+		LoadBalancerPort:     444,
+		LoadBalancerProtocol: "HTTPS",
+		Certificate:          &cert,
+		HealthMonitorPath:    &hmPath,
+	}})
+
+	// Change the health monitor path
+	newHmPath := "/newpath"
+	desired := []loadbalancer.Route{{
+		Port:                 8080,
+		Protocol:             "HTTP",
+		LoadBalancerPort:     444,
+		LoadBalancerProtocol: "HTTPS",
+		Certificate:          &cert,
+		HealthMonitorPath:    &newHmPath,
+	}}
+
+	var options types.Options
+	err := configureL4(lb, desired, options)
+	require.NoError(t, err)
+
+	routes, err := lb.Routes()
+	require.NoError(t, err)
+	require.Equal(t, len(desired), len(routes))
+	require.Equal(t, desired[0].Port, routes[0].Port)
+	require.Equal(t, desired[0].Protocol, routes[0].Protocol)
+	require.Equal(t, desired[0].LoadBalancerPort, routes[0].LoadBalancerPort)
+	require.Equal(t, desired[0].LoadBalancerProtocol, routes[0].LoadBalancerProtocol)
+	require.Equal(t, *desired[0].Certificate, *routes[0].Certificate)
+	require.Equal(t, *desired[0].HealthMonitorPath, *routes[0].HealthMonitorPath)
+}
+
+func TestVarietyOperations(t *testing.T) {
+	// Have a changed route, an unchanged route, a new route and a route to be deleted
+	cert := "mycert"
+	hmPath := "/health"
+	lb := NewMockLBPlugin([]loadbalancer.Route{{
+		// This one will change
+		Port:                 8080,
+		Protocol:             "HTTP",
+		LoadBalancerPort:     444,
+		LoadBalancerProtocol: "HTTPS",
+		Certificate:          &cert,
+		HealthMonitorPath:    &hmPath,
+	}, {
+		// This one will match
+		Port:                 8081,
+		Protocol:             "HTTP",
+		LoadBalancerPort:     445,
+		LoadBalancerProtocol: "HTTPS",
+		Certificate:          &cert,
+		HealthMonitorPath:    &hmPath,
+	}, {
+		// This one is unmatched (should be removed)
+		Port:                 8081,
+		Protocol:             "HTTP",
+		LoadBalancerPort:     446,
+		LoadBalancerProtocol: "HTTPS",
+		Certificate:          &cert,
+		HealthMonitorPath:    &hmPath,
+	}})
+
+	// Change the cert
+	newcert := "newcert"
+	desired := []loadbalancer.Route{{
+		Port:                 8080,
+		Protocol:             "HTTP",
+		LoadBalancerPort:     444,
+		LoadBalancerProtocol: "HTTPS",
+		Certificate:          &newcert,
+		HealthMonitorPath:    &hmPath,
+	}, {
+		Port:                 8081,
+		Protocol:             "HTTP",
+		LoadBalancerPort:     445,
+		LoadBalancerProtocol: "HTTPS",
+		Certificate:          &cert,
+		HealthMonitorPath:    &hmPath,
+	}, {
+		// This one should be added
+		Port:                 8081,
+		Protocol:             "HTTP",
+		LoadBalancerPort:     447,
+		LoadBalancerProtocol: "HTTPS",
+		Certificate:          &cert,
+		HealthMonitorPath:    &hmPath,
+	}}
+
+	var options types.Options
+	err := configureL4(lb, desired, options)
+	require.NoError(t, err)
+
+	routes, err := lb.Routes()
+	require.NoError(t, err)
+	require.Equal(t, len(desired), len(routes))
+	for _, route := range routes {
+		found := false
+		for _, expected := range desired {
+			if expected.LoadBalancerPort == route.LoadBalancerPort {
+				require.Equal(t, expected.Port, route.Port)
+				require.Equal(t, expected.Protocol, route.Protocol)
+				require.Equal(t, expected.LoadBalancerPort, route.LoadBalancerPort)
+				require.Equal(t, expected.LoadBalancerProtocol, route.LoadBalancerProtocol)
+				require.Equal(t, *expected.Certificate, *route.Certificate)
+				require.Equal(t, *expected.HealthMonitorPath, *route.HealthMonitorPath)
+				found = true
+				break
+			} else {
+				continue
+			}
+		}
+		if !found {
+			require.Fail(t, "Match was not found")
+		}
+	}
+}

--- a/pkg/controller/ingress/mock_lb.go
+++ b/pkg/controller/ingress/mock_lb.go
@@ -1,0 +1,89 @@
+package ingress
+
+import (
+	"github.com/docker/infrakit/pkg/spi/instance"
+	"github.com/docker/infrakit/pkg/spi/loadbalancer"
+)
+
+// Result string
+type lbResult string
+
+func (r lbResult) String() string {
+	return string(r)
+}
+
+type mocklb struct {
+	name         string
+	routes       []loadbalancer.Route
+	publishErr   error
+	unpublishErr error
+}
+
+// NewMockLBPlugin returns a mock L4 loadbalancer
+func NewMockLBPlugin(mockRoutes []loadbalancer.Route) loadbalancer.L4 {
+	lb := &mocklb{
+		name:   "mocklb",
+		routes: mockRoutes,
+	}
+
+	return lb
+}
+
+// Name is the name of the load balancer
+func (l *mocklb) Name() string {
+	return l.name
+}
+
+// Routes lists all known routes.
+func (l *mocklb) Routes() ([]loadbalancer.Route, error) {
+	routes := make([]loadbalancer.Route, len(l.routes))
+	copy(routes, l.routes)
+	return routes, nil
+}
+
+// Publish publishes a route in the LB by adding a load balancing rule
+func (l *mocklb) Publish(route loadbalancer.Route) (loadbalancer.Result, error) {
+	if l.publishErr != nil {
+		return nil, l.publishErr
+	}
+
+	l.routes = append(l.routes, route)
+
+	return lbResult("publish"), nil
+}
+
+// Unpublish dissociates the load balancer from the backend service at the given port.
+func (l *mocklb) Unpublish(extPort int) (loadbalancer.Result, error) {
+	if l.unpublishErr != nil {
+		return nil, l.unpublishErr
+	}
+
+	for index, route := range l.routes {
+		if route.LoadBalancerPort == extPort {
+			// Remove the route
+			l.routes = append((l.routes)[:index], (l.routes)[index+1:]...)
+		}
+	}
+
+	return lbResult("unpublish"), nil
+}
+
+// ConfigureHealthCheck configures the health checks for instance removal and reconfiguration
+func (l *mocklb) ConfigureHealthCheck(hc loadbalancer.HealthCheck) (loadbalancer.Result, error) {
+	return lbResult("healthcheck"), nil
+}
+
+// RegisterBackend registers instances identified by the IDs to the LB's backend pool.
+func (l *mocklb) RegisterBackends(ids []instance.ID) (loadbalancer.Result, error) {
+	return lbResult("register"), nil
+}
+
+// DeregisterBackend removes the specified instances from the backend pool.
+func (l *mocklb) DeregisterBackends(ids []instance.ID) (loadbalancer.Result, error) {
+	return lbResult("deregister"), nil
+}
+
+// Backends returns a list of backends
+func (l *mocklb) Backends() ([]instance.ID, error) {
+	return []instance.ID{}, nil
+}


### PR DESCRIPTION
A docker service update (or a docker service rm followed by a docker service create) which changes the certificate or health check path values may result in the load balancer configuration for the service having the configuration of the older service.

The ingress controller does not check if the certificate or health check path has changed between the Service Load Balancer configuration and the Docker Swarm Listener configuration. This results in the old configuration not getting updated to the new values.