### PR TITLE
Avoid Deadlock on Failed Commands

### DIFF
--- a/pkg/util/exec/exec.go
+++ b/pkg/util/exec/exec.go
@@ -210,15 +210,14 @@ func (b *Builder) StartWithHandlers(stdinFunc func(io.Writer) error,
 		b.wg.Add(1)
 	}
 
-	if err := b.cmd.Start(); err != nil {
-		return err
-	}
+	err := b.cmd.Start()
 
+	// To avoid deadlock, run the I/O handlers even if the command fails to start.
 	go handleStdout()
 	go handleStderr()
 	go handleInput()
 
-	return nil
+	return err
 }
 
 // Start does a Cmd.Start on the command

--- a/pkg/util/exec/exec_test.go
+++ b/pkg/util/exec/exec_test.go
@@ -55,6 +55,28 @@ func TestBuilder(t *testing.T) {
 
 }
 
+func TestStartWithHandlersError(t *testing.T) {
+	// Testing command that fails to start, and makes sure Wait() doesn't deadlock
+	command := Command("pwd").InheritEnvs(true).
+		WithDir("/impossibledir*&$%#")
+	err := command.StartWithHandlers(
+		nil,
+		func(stdout io.Reader) error {
+			T(100).Info("reading from stdout")
+			return nil
+		},
+		func(stderr io.Reader) error {
+			T(100).Info("reading from stderr")
+			return nil
+		})
+	// Bad directory error
+	require.Error(t, err)
+
+	// Command not started error
+	err = command.Wait()
+	require.Error(t, err)
+}
+
 func TestRunDocker(t *testing.T) {
 
 	if SkipTests("docker") {


### PR DESCRIPTION
When StartWithHandlers() is called, the waitgroup gets incremented as
part of the setup for stdout/stderr handlers. If the command fails to
start, StartWithHandlers() returns prior to calling the handlers. This
leaves the waitgroup in a permanently incremented state. If wg.Wait() is
called, this will result in deadlock. To avoid this, we can call the
handlers prior to returning the error.

This issue surfaced in the terraform provider when we lost access to
NFS on manager nodes. The terraform commands that depended on that
directory failed to start, and the 'terraform apply' routine ended up
in deadlock. This prevented infrakit from recovering once NFS access had
been restored.

Signed-off-by: Dave Freitag <dcfreita@us.ibm.com>