### PR TITLE
Enrollment Options for parsing errors

### DIFF
--- a/pkg/controller/enrollment/controller.go
+++ b/pkg/controller/enrollment/controller.go
@@ -19,10 +19,10 @@ var (
 
 	// DefaultOptions return an Options with default values filled in.
 	DefaultOptions = enrollment.Options{
-		SyncInterval:         types.Duration(5 * time.Second),
-		DestroyOnTerminate:   false,
-		SourceParseErrOp:     enrollment.SourceParseErrorEnableDestroy,
-		EnrollmentParseErrOp: enrollment.EnrolledParseErrorEnableProvision,
+		SyncInterval:             types.Duration(5 * time.Second),
+		DestroyOnTerminate:       false,
+		SourceParseErrPolicy:     enrollment.SourceParseErrorEnableDestroy,
+		EnrollmentParseErrPolicy: enrollment.EnrolledParseErrorEnableProvision,
 	}
 )
 

--- a/pkg/controller/enrollment/controller.go
+++ b/pkg/controller/enrollment/controller.go
@@ -19,8 +19,10 @@ var (
 
 	// DefaultOptions return an Options with default values filled in.
 	DefaultOptions = enrollment.Options{
-		SyncInterval:       types.Duration(5 * time.Second),
-		DestroyOnTerminate: false,
+		SyncInterval:         types.Duration(5 * time.Second),
+		DestroyOnTerminate:   false,
+		SourceParseErrOp:     enrollment.SourceParseErrorEnableDestroy,
+		EnrollmentParseErrOp: enrollment.EnrolledParseErrorEnableProvision,
 	}
 )
 

--- a/pkg/controller/enrollment/enroller.go
+++ b/pkg/controller/enrollment/enroller.go
@@ -88,28 +88,28 @@ func newEnroller(scope scope.Scope, leader func() stack.Leadership, options enro
 // validateParseErrorOptions ensures that source and enrolled parse error
 // operation values are valid in the given options
 func validateParseErrorOptions(opts enrollment.Options) error {
-	srcParseErrorOp := opts.SourceParseErrOp
-	switch srcParseErrorOp {
+	srcParseErrorPolicy := opts.SourceParseErrPolicy
+	switch srcParseErrorPolicy {
 	case enrollment.SourceParseErrorEnableDestroy:
 		// Default value, Debug logging
-		log.Debug("validateParseErrorOptions", "SourceParseErrOp", srcParseErrorOp, "V", debugV)
+		log.Debug("validateParseErrorOptions", "SourceParseErrPolicy", srcParseErrorPolicy, "V", debugV)
 	case enrollment.SourceParseErrorDisableDestroy:
-		log.Info("validateParseErrorOptions", "SourceParseErrOp", srcParseErrorOp)
+		log.Info("validateParseErrorOptions", "SourceParseErrPolicy", srcParseErrorPolicy)
 	default:
-		return fmt.Errorf("SourceParseErrOp value '%s' is not supported, valid values: %v",
-			srcParseErrorOp,
+		return fmt.Errorf("SourceParseErrPolicy value '%s' is not supported, valid values: %v",
+			srcParseErrorPolicy,
 			[]string{enrollment.SourceParseErrorEnableDestroy, enrollment.SourceParseErrorDisableDestroy})
 	}
-	enrolledParseErrorOp := opts.EnrollmentParseErrOp
-	switch enrolledParseErrorOp {
+	enrolledParseErrorPolicy := opts.EnrollmentParseErrPolicy
+	switch enrolledParseErrorPolicy {
 	case enrollment.EnrolledParseErrorEnableProvision:
 		// Default value, Debug logging
-		log.Debug("validateParseErrorOptions", "EnrollmentParseErrOp", enrolledParseErrorOp, "V", debugV)
+		log.Debug("validateParseErrorOptions", "EnrollmentParseErrPolicy", enrolledParseErrorPolicy, "V", debugV)
 	case enrollment.EnrolledParseErrorDisableProvision:
-		log.Info("validateParseErrorOptions", "EnrollmentParseErrOp", enrolledParseErrorOp)
+		log.Info("validateParseErrorOptions", "EnrollmentParseErrPolicy", enrolledParseErrorPolicy)
 	default:
-		return fmt.Errorf("EnrollmentParseErrOp value '%s' is not supported, valid values: %v",
-			enrolledParseErrorOp,
+		return fmt.Errorf("EnrollmentParseErrPolicy value '%s' is not supported, valid values: %v",
+			enrolledParseErrorPolicy,
 			[]string{enrollment.EnrolledParseErrorEnableProvision, enrollment.EnrolledParseErrorDisableProvision})
 	}
 	return nil

--- a/pkg/controller/enrollment/enroller_test.go
+++ b/pkg/controller/enrollment/enroller_test.go
@@ -59,8 +59,8 @@ func TestEnrollerOptions(t *testing.T) {
 		DefaultOptions)
 	require.NoError(t, err)
 	require.Equal(t, types.FromDuration(time.Duration(5*time.Second)), e.options.SyncInterval)
-	require.Equal(t, enrollment.SourceParseErrorEnableDestroy, e.options.SourceParseErrOp)
-	require.Equal(t, enrollment.EnrolledParseErrorEnableProvision, e.options.EnrollmentParseErrOp)
+	require.Equal(t, enrollment.SourceParseErrorEnableDestroy, e.options.SourceParseErrPolicy)
+	require.Equal(t, enrollment.EnrolledParseErrorEnableProvision, e.options.EnrollmentParseErrPolicy)
 	// Override options, still valid
 	e, err = newEnroller(
 		scope.DefaultScope(func() discovery.Plugins {
@@ -70,14 +70,14 @@ func TestEnrollerOptions(t *testing.T) {
 		}),
 		fakeLeader(false),
 		enrollment.Options{
-			SyncInterval:         types.FromDuration(time.Duration(10 * time.Second)),
-			SourceParseErrOp:     enrollment.SourceParseErrorDisableDestroy,
-			EnrollmentParseErrOp: enrollment.EnrolledParseErrorDisableProvision,
+			SyncInterval:             types.FromDuration(time.Duration(10 * time.Second)),
+			SourceParseErrPolicy:     enrollment.SourceParseErrorDisableDestroy,
+			EnrollmentParseErrPolicy: enrollment.EnrolledParseErrorDisableProvision,
 		})
 	require.NoError(t, err)
 	require.Equal(t, types.FromDuration(time.Duration(10*time.Second)), e.options.SyncInterval)
-	require.Equal(t, enrollment.SourceParseErrorDisableDestroy, e.options.SourceParseErrOp)
-	require.Equal(t, enrollment.EnrolledParseErrorDisableProvision, e.options.EnrollmentParseErrOp)
+	require.Equal(t, enrollment.SourceParseErrorDisableDestroy, e.options.SourceParseErrPolicy)
+	require.Equal(t, enrollment.EnrolledParseErrorDisableProvision, e.options.EnrollmentParseErrPolicy)
 	// Invalid values, should error out
 	e, err = newEnroller(
 		scope.DefaultScope(func() discovery.Plugins {
@@ -87,9 +87,9 @@ func TestEnrollerOptions(t *testing.T) {
 		}),
 		fakeLeader(false),
 		enrollment.Options{
-			SyncInterval:         types.FromDuration(time.Duration(-1 * time.Second)),
-			SourceParseErrOp:     DefaultOptions.SourceParseErrOp,
-			EnrollmentParseErrOp: DefaultOptions.EnrollmentParseErrOp,
+			SyncInterval:             types.FromDuration(time.Duration(-1 * time.Second)),
+			SourceParseErrPolicy:     DefaultOptions.SourceParseErrPolicy,
+			EnrollmentParseErrPolicy: DefaultOptions.EnrollmentParseErrPolicy,
 		})
 	require.Error(t, err)
 	require.Equal(t, fmt.Errorf("SyncInterval must be greater than 0"), err)
@@ -101,13 +101,13 @@ func TestEnrollerOptions(t *testing.T) {
 		}),
 		fakeLeader(false),
 		enrollment.Options{
-			SyncInterval:         DefaultOptions.SyncInterval,
-			SourceParseErrOp:     "bogus-SourceParseErrOp",
-			EnrollmentParseErrOp: DefaultOptions.EnrollmentParseErrOp,
+			SyncInterval:             DefaultOptions.SyncInterval,
+			SourceParseErrPolicy:     "bogus-SourceParseErrPolicy",
+			EnrollmentParseErrPolicy: DefaultOptions.EnrollmentParseErrPolicy,
 		})
 	require.Error(t, err)
 	require.Equal(t,
-		fmt.Errorf("SourceParseErrOp value 'bogus-SourceParseErrOp' is not supported, valid values: %v",
+		fmt.Errorf("SourceParseErrPolicy value 'bogus-SourceParseErrPolicy' is not supported, valid values: %v",
 			[]string{enrollment.SourceParseErrorEnableDestroy, enrollment.SourceParseErrorDisableDestroy}),
 		err)
 	e, err = newEnroller(
@@ -118,13 +118,13 @@ func TestEnrollerOptions(t *testing.T) {
 		}),
 		fakeLeader(false),
 		enrollment.Options{
-			SyncInterval:         DefaultOptions.SyncInterval,
-			SourceParseErrOp:     DefaultOptions.SourceParseErrOp,
-			EnrollmentParseErrOp: "bogus-EnrollmentParseErrOp",
+			SyncInterval:             DefaultOptions.SyncInterval,
+			SourceParseErrPolicy:     DefaultOptions.SourceParseErrPolicy,
+			EnrollmentParseErrPolicy: "bogus-EnrollmentParseErrPolicy",
 		})
 	require.Error(t, err)
 	require.Equal(t,
-		fmt.Errorf("EnrollmentParseErrOp value 'bogus-EnrollmentParseErrOp' is not supported, valid values: %v",
+		fmt.Errorf("EnrollmentParseErrPolicy value 'bogus-EnrollmentParseErrPolicy' is not supported, valid values: %v",
 			[]string{enrollment.EnrolledParseErrorEnableProvision, enrollment.EnrolledParseErrorDisableProvision}),
 		err)
 }
@@ -206,8 +206,8 @@ options:
 	require.NotNil(t, et)
 
 	// Should use the defaults
-	require.Equal(t, enrollment.SourceParseErrorEnableDestroy, enroller.options.SourceParseErrOp)
-	require.Equal(t, enrollment.EnrolledParseErrorEnableProvision, enroller.options.EnrollmentParseErrOp)
+	require.Equal(t, enrollment.SourceParseErrorEnableDestroy, enroller.options.SourceParseErrPolicy)
+	require.Equal(t, enrollment.EnrolledParseErrorEnableProvision, enroller.options.EnrollmentParseErrPolicy)
 
 	require.NoError(t, err)
 
@@ -427,7 +427,7 @@ properties:
        backend_id: \{\{ $x := .Properties | jsonDecode \}\}\{\{ int $x.backend_id \}\}
 options:
   SourceKeySelector: \{\{ $x := .Properties | jsonDecode \}\}\{\{ int $x.backend_id \}\}
-  SourceParseErrOp: %s
+  SourceParseErrPolicy: %s
   EnrollmentKeySelector: \{\{.ID\}\}
 `, srcParseError))).Decode(&spec))
 
@@ -545,7 +545,7 @@ func TestEnrollerEnrolledParseError(t *testing.T) {
 
 	require.False(t, enroller.Running())
 
-	// Verify the various options for the EnrollmentParseErrOp
+	// Verify the various options for the EnrollmentParseErrPolicy
 	for _, enrolledParseError := range []string{enrollment.EnrolledParseErrorEnableProvision, enrollment.EnrolledParseErrorDisableProvision} {
 
 		// Build a spec that uses the "backend_id" as the key for the source and just
@@ -564,7 +564,7 @@ properties:
 options:
   SourceKeySelector: \{\{ $x := .Properties | jsonDecode \}\}\{\{ int $x.backend_id \}\}
   EnrollmentKeySelector: \{\{ $x := .Properties | jsonDecode \}\}\{\{ int $x.ID \}\}
-  EnrollmentParseErrOp: %s
+  EnrollmentParseErrPolicy: %s
 `, enrolledParseError))).Decode(&spec))
 
 		require.NoError(t, enroller.updateSpec(spec))
@@ -639,8 +639,8 @@ func TestEnrollerOptionParsing(t *testing.T) {
 		DefaultOptions)
 	require.NoError(t, err)
 	require.Equal(t, types.FromDuration(time.Duration(5*time.Second)), enroller.options.SyncInterval)
-	require.Equal(t, enrollment.SourceParseErrorEnableDestroy, enroller.options.SourceParseErrOp)
-	require.Equal(t, enrollment.EnrolledParseErrorEnableProvision, enroller.options.EnrollmentParseErrOp)
+	require.Equal(t, enrollment.SourceParseErrorEnableDestroy, enroller.options.SourceParseErrPolicy)
+	require.Equal(t, enrollment.EnrolledParseErrorEnableProvision, enroller.options.EnrollmentParseErrPolicy)
 
 	for _, srcParseErrorOp := range []string{enrollment.SourceParseErrorDisableDestroy, enrollment.SourceParseErrorDisableDestroy} {
 		for _, enrolledParseErrorOp := range []string{enrollment.EnrolledParseErrorDisableProvision, enrollment.EnrolledParseErrorEnableProvision} {
@@ -652,20 +652,20 @@ func TestEnrollerOptionParsing(t *testing.T) {
 				}),
 				fakeLeader(false),
 				enrollment.Options{
-					SyncInterval:         DefaultOptions.SyncInterval,
-					SourceParseErrOp:     srcParseErrorOp,
-					EnrollmentParseErrOp: enrolledParseErrorOp,
+					SyncInterval:             DefaultOptions.SyncInterval,
+					SourceParseErrPolicy:     srcParseErrorOp,
+					EnrollmentParseErrPolicy: enrolledParseErrorOp,
 				})
 			require.NoError(t, err)
 			if srcParseErrorOp == enrollment.SourceParseErrorDisableDestroy {
-				require.Equal(t, enrollment.SourceParseErrorDisableDestroy, enroller.options.SourceParseErrOp)
+				require.Equal(t, enrollment.SourceParseErrorDisableDestroy, enroller.options.SourceParseErrPolicy)
 			} else {
-				require.Equal(t, enrollment.SourceParseErrorEnableDestroy, enroller.options.SourceParseErrOp)
+				require.Equal(t, enrollment.SourceParseErrorEnableDestroy, enroller.options.SourceParseErrPolicy)
 			}
 			if enrolledParseErrorOp == enrollment.EnrolledParseErrorDisableProvision {
-				require.Equal(t, enrollment.EnrolledParseErrorDisableProvision, enroller.options.EnrollmentParseErrOp)
+				require.Equal(t, enrollment.EnrolledParseErrorDisableProvision, enroller.options.EnrollmentParseErrPolicy)
 			} else {
-				require.Equal(t, enrollment.EnrolledParseErrorEnableProvision, enroller.options.EnrollmentParseErrOp)
+				require.Equal(t, enrollment.EnrolledParseErrorEnableProvision, enroller.options.EnrollmentParseErrPolicy)
 			}
 		}
 	}
@@ -682,10 +682,10 @@ func TestEnrollerUpdateSpecOptionParsing(t *testing.T) {
 		fakeLeader(false),
 		DefaultOptions)
 	require.NoError(t, err)
-	require.Equal(t, enrollment.SourceParseErrorEnableDestroy, enroller.options.SourceParseErrOp)
-	require.Equal(t, enrollment.EnrolledParseErrorEnableProvision, enroller.options.EnrollmentParseErrOp)
+	require.Equal(t, enrollment.SourceParseErrorEnableDestroy, enroller.options.SourceParseErrPolicy)
+	require.Equal(t, enrollment.EnrolledParseErrorEnableProvision, enroller.options.EnrollmentParseErrPolicy)
 
-	// Should override with an updated spec, first try an invalid valid for SourceParseErrOp
+	// Should override with an updated spec, first try an invalid valid for SourceParseErrPolicy
 	spec := types.Spec{}
 	require.NoError(t, types.AnyYAMLMust([]byte(`
 kind: enrollment
@@ -699,20 +699,20 @@ properties:
        backend_id: \{\{ $x := .Properties | jsonDecode \}\}\{\{ int $x.backend_id \}\}
 options:
   SourceKeySelector: \{\{ $x := .Properties | jsonDecode \}\}\{\{ int $x.backend_id \}\}
-  SourceParseErrOp: foo
+  SourceParseErrPolicy: foo
   EnrollmentKeySelector: \{\{.ID\}\}
-  EnrollmentParseErrOp: DisableProvision
+  EnrollmentParseErrPolicy: DisableProvision
 `)).Decode(&spec))
 	err = enroller.updateSpec(spec)
 	require.Error(t, err)
 	require.Equal(t,
-		fmt.Errorf("SourceParseErrOp value 'foo' is not supported, valid values: %v",
+		fmt.Errorf("SourceParseErrPolicy value 'foo' is not supported, valid values: %v",
 			[]string{enrollment.SourceParseErrorEnableDestroy, enrollment.SourceParseErrorDisableDestroy}),
 		err)
-	require.Equal(t, enrollment.SourceParseErrorEnableDestroy, enroller.options.SourceParseErrOp)
-	require.Equal(t, enrollment.EnrolledParseErrorEnableProvision, enroller.options.EnrollmentParseErrOp)
+	require.Equal(t, enrollment.SourceParseErrorEnableDestroy, enroller.options.SourceParseErrPolicy)
+	require.Equal(t, enrollment.EnrolledParseErrorEnableProvision, enroller.options.EnrollmentParseErrPolicy)
 
-	// Should override with an updated spec, and an invalid valid for EnrollmentParseErrOp
+	// Should override with an updated spec, and an invalid valid for EnrollmentParseErrPolicy
 	spec = types.Spec{}
 	require.NoError(t, types.AnyYAMLMust([]byte(`
 kind: enrollment
@@ -726,18 +726,18 @@ properties:
        backend_id: \{\{ $x := .Properties | jsonDecode \}\}\{\{ int $x.backend_id \}\}
 options:
   SourceKeySelector: \{\{ $x := .Properties | jsonDecode \}\}\{\{ int $x.backend_id \}\}
-  SourceParseErrOp: DisableDestroy
+  SourceParseErrPolicy: DisableDestroy
   EnrollmentKeySelector: \{\{.ID\}\}
-  EnrollmentParseErrOp: foo
+  EnrollmentParseErrPolicy: foo
 `)).Decode(&spec))
 	err = enroller.updateSpec(spec)
 	require.Error(t, err)
 	require.Equal(t,
-		fmt.Errorf("EnrollmentParseErrOp value 'foo' is not supported, valid values: %v",
+		fmt.Errorf("EnrollmentParseErrPolicy value 'foo' is not supported, valid values: %v",
 			[]string{enrollment.EnrolledParseErrorEnableProvision, enrollment.EnrolledParseErrorDisableProvision}),
 		err)
-	require.Equal(t, enrollment.SourceParseErrorEnableDestroy, enroller.options.SourceParseErrOp)
-	require.Equal(t, enrollment.EnrolledParseErrorEnableProvision, enroller.options.EnrollmentParseErrOp)
+	require.Equal(t, enrollment.SourceParseErrorEnableDestroy, enroller.options.SourceParseErrPolicy)
+	require.Equal(t, enrollment.EnrolledParseErrorEnableProvision, enroller.options.EnrollmentParseErrPolicy)
 
 	// Then with a valid valid for both
 	spec = types.Spec{}
@@ -753,11 +753,11 @@ properties:
        backend_id: \{\{ $x := .Properties | jsonDecode \}\}\{\{ int $x.backend_id \}\}
 options:
   SourceKeySelector: \{\{ $x := .Properties | jsonDecode \}\}\{\{ int $x.backend_id \}\}
-  SourceParseErrOp: DisableDestroy
+  SourceParseErrPolicy: DisableDestroy
   EnrollmentKeySelector: \{\{.ID\}\}
-  EnrollmentParseErrOp: DisableProvision
+  EnrollmentParseErrPolicy: DisableProvision
 `)).Decode(&spec))
 	require.NoError(t, enroller.updateSpec(spec))
-	require.Equal(t, enrollment.SourceParseErrorDisableDestroy, enroller.options.SourceParseErrOp)
-	require.Equal(t, enrollment.EnrolledParseErrorDisableProvision, enroller.options.EnrollmentParseErrOp)
+	require.Equal(t, enrollment.SourceParseErrorDisableDestroy, enroller.options.SourceParseErrPolicy)
+	require.Equal(t, enrollment.EnrolledParseErrorDisableProvision, enroller.options.EnrollmentParseErrPolicy)
 }

--- a/pkg/controller/enrollment/enroller_test.go
+++ b/pkg/controller/enrollment/enroller_test.go
@@ -47,7 +47,7 @@ func (f fakePlugins) List() (map[string]*plugin.Endpoint, error) {
 	return (map[string]*plugin.Endpoint)(f), nil
 }
 
-func TestEnrollerOptions(t *testing.T) {
+func TestEnrollerInitOptions(t *testing.T) {
 	// Verify defaults
 	e, err := newEnroller(
 		scope.DefaultScope(func() discovery.Plugins {
@@ -78,7 +78,7 @@ func TestEnrollerOptions(t *testing.T) {
 	require.Equal(t, types.FromDuration(time.Duration(10*time.Second)), e.options.SyncInterval)
 	require.Equal(t, enrollment.SourceParseErrorDisableDestroy, e.options.SourceParseErrPolicy)
 	require.Equal(t, enrollment.EnrolledParseErrorDisableProvision, e.options.EnrollmentParseErrPolicy)
-	// Invalid values, should error out
+	// Invalid sync interval, should error out
 	e, err = newEnroller(
 		scope.DefaultScope(func() discovery.Plugins {
 			return fakePlugins{
@@ -93,6 +93,7 @@ func TestEnrollerOptions(t *testing.T) {
 		})
 	require.Error(t, err)
 	require.Equal(t, fmt.Errorf("SyncInterval must be greater than 0"), err)
+	// Another invalid option
 	e, err = newEnroller(
 		scope.DefaultScope(func() discovery.Plugins {
 			return fakePlugins{
@@ -109,23 +110,6 @@ func TestEnrollerOptions(t *testing.T) {
 	require.Equal(t,
 		fmt.Errorf("SourceParseErrPolicy value 'bogus-SourceParseErrPolicy' is not supported, valid values: %v",
 			[]string{enrollment.SourceParseErrorEnableDestroy, enrollment.SourceParseErrorDisableDestroy}),
-		err)
-	e, err = newEnroller(
-		scope.DefaultScope(func() discovery.Plugins {
-			return fakePlugins{
-				"test": &plugin.Endpoint{},
-			}
-		}),
-		fakeLeader(false),
-		enrollment.Options{
-			SyncInterval:             DefaultOptions.SyncInterval,
-			SourceParseErrPolicy:     DefaultOptions.SourceParseErrPolicy,
-			EnrollmentParseErrPolicy: "bogus-EnrollmentParseErrPolicy",
-		})
-	require.Error(t, err)
-	require.Equal(t,
-		fmt.Errorf("EnrollmentParseErrPolicy value 'bogus-EnrollmentParseErrPolicy' is not supported, valid values: %v",
-			[]string{enrollment.EnrolledParseErrorEnableProvision, enrollment.EnrolledParseErrorDisableProvision}),
 		err)
 }
 

--- a/pkg/controller/enrollment/set.go
+++ b/pkg/controller/enrollment/set.go
@@ -10,27 +10,37 @@ import (
 // keyFunc is a function that extracts the key from the description
 type keyFunc func(instance.Description) (string, error)
 
-func index(list instance.Descriptions, getKey keyFunc) (map[string]instance.Description, mapset.Set) {
+func index(list instance.Descriptions, getKey keyFunc) (map[string]instance.Description, mapset.Set, error) {
+	// Track errors and return what could be indexed
+	var e error
 	index := map[string]instance.Description{}
 	this := mapset.NewSet()
 	for _, n := range list {
 		key, err := getKey(n)
 		if err != nil {
 			log.Error("cannot index entry", "instance.Description", n, "err", err)
+			e = err
 			continue
 		}
 		this.Add(key)
 		index[key] = n
 	}
-	return index, this
+	return index, this, e
 }
 
 // Difference returns a list of specs that is not in the receiver.
 func Difference(list instance.Descriptions, listKeyFunc keyFunc,
-	other instance.Descriptions, otherKeyFunc keyFunc) instance.Descriptions {
-	this, thisSet := index(list, listKeyFunc)
-	_, thatSet := index(other, otherKeyFunc)
-	return toDescriptions(listKeyFunc, thisSet.Difference(thatSet), this)
+	other instance.Descriptions, otherKeyFunc keyFunc) (instance.Descriptions, error) {
+	this, thisSet, err1 := index(list, listKeyFunc)
+	_, thatSet, err2 := index(other, otherKeyFunc)
+	// Return an error if either failed to index
+	var e error
+	if err1 != nil {
+		e = err1
+	} else if err2 != nil {
+		e = err2
+	}
+	return toDescriptions(listKeyFunc, thisSet.Difference(thatSet), this), e
 }
 
 func toDescriptions(keyFunc keyFunc, set mapset.Set, index map[string]instance.Description) instance.Descriptions {
@@ -45,33 +55,30 @@ func toDescriptions(keyFunc keyFunc, set mapset.Set, index map[string]instance.D
 // Delta computes the changes necessary to make the list match other:
 // 1. the add Descriptions are entries to add to other
 // 2. the remove Descriptions are entries to remove from other
-// 3. changes are a slice of Descriptions where changes[x][0] is the original, and changes[x][1] is new
 func Delta(list instance.Descriptions, listKeyFunc keyFunc, other instance.Descriptions,
-	otherKeyFunc keyFunc) (add instance.Descriptions, remove instance.Descriptions, changes [][2]instance.Description) {
+	otherKeyFunc keyFunc) (add instance.Descriptions, remove instance.Descriptions) {
 
 	sort.Sort(instance.Descriptions(list))
 	sort.Sort(instance.Descriptions(other))
 
-	this, thisSet := index(list, listKeyFunc)
-	that, thatSet := index(other, otherKeyFunc)
+	this, thisSet, err1 := index(list, listKeyFunc)
+	that, thatSet, err2 := index(other, otherKeyFunc)
 
-	removeSet := thatSet.Difference(thisSet)
-	remove = toDescriptions(otherKeyFunc, removeSet, that)
+	// Never remove anything if there are errors since we do not know if the one
+	// of the current instances failed to parse
+	if err1 == nil && err2 == nil {
+		removeSet := thatSet.Difference(thisSet)
+		remove = toDescriptions(otherKeyFunc, removeSet, that)
+	} else {
+		remove = []instance.Description{}
+	}
 
+	// Always add what we could parse that is not in the set already
 	addSet := thisSet.Difference(thatSet)
 	add = toDescriptions(listKeyFunc, addSet, this)
-
-	changeSet := thatSet.Difference(removeSet)
 
 	sort.Sort(instance.Descriptions(add))
 	sort.Sort(instance.Descriptions(remove))
 
-	changes = [][2]instance.Description{}
-	for n := range changeSet.Iter() {
-		key := n.(string)
-		if this[key].Fingerprint() != that[key].Fingerprint() {
-			changes = append(changes, [2]instance.Description{this[key], that[key]})
-		}
-	}
 	return
 }

--- a/pkg/controller/enrollment/sync.go
+++ b/pkg/controller/enrollment/sync.go
@@ -159,8 +159,8 @@ func (l *enroller) sync() error {
 
 	// compute the delta required to make enrolled look like source
 	add, remove := Delta(
-		instance.Descriptions(source), sourceKeyFunc,
-		instance.Descriptions(enrolled), enrolledKeyFunc,
+		instance.Descriptions(source), sourceKeyFunc, l.options.SourceParseErrOp,
+		instance.Descriptions(enrolled), enrolledKeyFunc, l.options.EnrollmentParseErrOp,
 	)
 
 	// Use Info logging only when making deltas

--- a/pkg/controller/enrollment/sync.go
+++ b/pkg/controller/enrollment/sync.go
@@ -158,7 +158,7 @@ func (l *enroller) sync() error {
 	}
 
 	// compute the delta required to make enrolled look like source
-	add, remove, _ := Delta(
+	add, remove := Delta(
 		instance.Descriptions(source), sourceKeyFunc,
 		instance.Descriptions(enrolled), enrolledKeyFunc,
 	)

--- a/pkg/controller/enrollment/sync.go
+++ b/pkg/controller/enrollment/sync.go
@@ -159,8 +159,8 @@ func (l *enroller) sync() error {
 
 	// compute the delta required to make enrolled look like source
 	add, remove := Delta(
-		instance.Descriptions(source), sourceKeyFunc, l.options.SourceParseErrOp,
-		instance.Descriptions(enrolled), enrolledKeyFunc, l.options.EnrollmentParseErrOp,
+		instance.Descriptions(source), sourceKeyFunc, l.options.SourceParseErrPolicy,
+		instance.Descriptions(enrolled), enrolledKeyFunc, l.options.EnrollmentParseErrPolicy,
 	)
 
 	// Use Info logging only when making deltas

--- a/pkg/controller/enrollment/types/types.go
+++ b/pkg/controller/enrollment/types/types.go
@@ -1,13 +1,19 @@
 package types
 
 import (
+	"fmt"
+
 	"github.com/docker/infrakit/pkg/controller"
+	logutil "github.com/docker/infrakit/pkg/log"
 	"github.com/docker/infrakit/pkg/plugin"
 	"github.com/docker/infrakit/pkg/run/depends"
 	"github.com/docker/infrakit/pkg/spi/instance"
 	"github.com/docker/infrakit/pkg/template"
 	"github.com/docker/infrakit/pkg/types"
 )
+
+// PluginPhase defines the enroller lifecycle
+type PluginPhase int
 
 const (
 	// SourceParseErrorEnableDestroy means that the Destroy operation is enabled
@@ -31,6 +37,16 @@ const (
 	// whenever any enrolled instance fails to parse; therefore, no source instances will
 	// be added if any of the currently enrolled instances fails to parse.
 	EnrolledParseErrorDisableProvision = "DisableProvision"
+
+	// PluginInit is the phase when the enroller is created, used when validating options
+	PluginInit = iota
+	// PluginCommit is the phase when the spec is commited, used when validating options
+	PluginCommit
+)
+
+var (
+	log    = logutil.New("module", "controller/enrollment/types")
+	debugV = logutil.V(200)
 )
 
 func init() {
@@ -155,4 +171,40 @@ func TemplateFrom(source []byte) (*template.Template, error) {
 		"str://"+string(buff),
 		template.Options{MultiPass: false, MissingKey: template.MissingKeyError},
 	)
+}
+
+// Validate ensures that source and enrolled parse error
+// operation values are valid in the given options
+func (o Options) Validate(phase PluginPhase) error {
+	// SyncInterval is validated in the init phase only
+	if phase == PluginInit {
+		if o.SyncInterval.Duration() <= 0 {
+			return fmt.Errorf("SyncInterval must be greater than 0")
+		}
+	}
+	srcParseErrorPolicy := o.SourceParseErrPolicy
+	switch srcParseErrorPolicy {
+	case SourceParseErrorEnableDestroy:
+		// Default value, Debug logging
+		log.Debug("validateParseErrorOptions", "SourceParseErrPolicy", srcParseErrorPolicy, "V", debugV)
+	case SourceParseErrorDisableDestroy:
+		log.Info("validateParseErrorOptions", "SourceParseErrPolicy", srcParseErrorPolicy)
+	default:
+		return fmt.Errorf("SourceParseErrPolicy value '%s' is not supported, valid values: %v",
+			srcParseErrorPolicy,
+			[]string{SourceParseErrorEnableDestroy, SourceParseErrorDisableDestroy})
+	}
+	enrolledParseErrorPolicy := o.EnrollmentParseErrPolicy
+	switch enrolledParseErrorPolicy {
+	case EnrolledParseErrorEnableProvision:
+		// Default value, Debug logging
+		log.Debug("validateParseErrorOptions", "EnrollmentParseErrPolicy", enrolledParseErrorPolicy, "V", debugV)
+	case EnrolledParseErrorDisableProvision:
+		log.Info("validateParseErrorOptions", "EnrollmentParseErrPolicy", enrolledParseErrorPolicy)
+	default:
+		return fmt.Errorf("EnrollmentParseErrPolicy value '%s' is not supported, valid values: %v",
+			enrolledParseErrorPolicy,
+			[]string{EnrolledParseErrorEnableProvision, EnrolledParseErrorDisableProvision})
+	}
+	return nil
 }

--- a/pkg/controller/enrollment/types/types.go
+++ b/pkg/controller/enrollment/types/types.go
@@ -125,17 +125,17 @@ type Options struct {
 	// SourceKeySelector: \{\{ .ID \}\}  # selects the ID field.
 	SourceKeySelector string
 
-	// SourceParseErrOp defines the behavior when the source item cannot
+	// SourceParseErrPolicy defines the behavior when the source item cannot
 	// be indexed, value values are "EnableDestroy" and "DisableDestroy
-	SourceParseErrOp string
+	SourceParseErrPolicy string
 
 	// SourceKeySelector is a string template for selecting the join key from
 	// a enrollment plugin's instance.Description.
 	EnrollmentKeySelector string
 
-	// EnrollmentParseErrOp defines the behavior when the enrolled item cannot
+	// EnrollmentParseErrPolicy defines the behavior when the enrolled item cannot
 	// be indexed, value values are "EnableProvision" and "DisableProvision"
-	EnrollmentParseErrOp string
+	EnrollmentParseErrPolicy string
 
 	// SyncInterval is the time interval between reconciliation. Syntax
 	// is go's time.Duration string representation (e.g. 1m, 30s)

--- a/pkg/controller/enrollment/types/types.go
+++ b/pkg/controller/enrollment/types/types.go
@@ -9,6 +9,30 @@ import (
 	"github.com/docker/infrakit/pkg/types"
 )
 
+const (
+	// SourceParseErrorEnableDestroy means that the Destroy operation is enabled
+	// even if a source instance fails to parse; therefore, a currently enrolled
+	// instance will be removed if the associated source instance fails to parse.
+	// This is a the default operation on a source instance parse error.
+	SourceParseErrorEnableDestroy = "EnableDestroy"
+
+	// SourceParseErrorDisableDestroy means that the Destroy operation is disabled
+	// whenever any source instance fails to parse; therefore, no enrolled instances
+	// will be removed if any source instance fails to parse.
+	SourceParseErrorDisableDestroy = "DisableDestroy"
+
+	// EnrolledParseErrorEnableProvision means that the Provision operation is enabled
+	// even if an enrolled instance fails to parse; therefore, an instance may be enrolled
+	// multiple times.
+	// This is a the default operation on a enrolled instance parse error.
+	EnrolledParseErrorEnableProvision = "EnableProvision"
+
+	// EnrolledParseErrorDisableProvision means that the Provision operation is disabled
+	// whenever any enrolled instance fails to parse; therefore, no source instances will
+	// be added if any of the currently enrolled instances fails to parse.
+	EnrolledParseErrorDisableProvision = "DisableProvision"
+)
+
 func init() {
 	depends.Register("enroll", types.InterfaceSpec(controller.InterfaceSpec), ResolveDependencies)
 }
@@ -101,9 +125,17 @@ type Options struct {
 	// SourceKeySelector: \{\{ .ID \}\}  # selects the ID field.
 	SourceKeySelector string
 
+	// SourceParseErrOp defines the behavior when the source item cannot
+	// be indexed, value values are "EnableDestroy" and "DisableDestroy
+	SourceParseErrOp string
+
 	// SourceKeySelector is a string template for selecting the join key from
 	// a enrollment plugin's instance.Description.
 	EnrollmentKeySelector string
+
+	// EnrollmentParseErrOp defines the behavior when the enrolled item cannot
+	// be indexed, value values are "EnableProvision" and "DisableProvision"
+	EnrollmentParseErrOp string
 
 	// SyncInterval is the time interval between reconciliation. Syntax
 	// is go's time.Duration string representation (e.g. 1m, 30s)


### PR DESCRIPTION
The enrollment controller can encounter parsing errors in either the source instances or the enrolled instances.

A source instance failing to parse only affects the removal of currently enrolled instances (since we cannot determine the unique identifier of the source instance due to the parsing error and, hence, we cannot determine if the instance is currently enrolled). When a **source fails to parse** there are
two options:
- Enable the removal of one or more currently enrolled instances
- Disable the removal of any currently enrolled instances

**If removal is enabled**, then the source instance (that failed to parse) will be removed from the group (it is is currently enrolled).

When an **enrolled instance fails to parse**, this only affects the addition of source instances and there are two options:
- Enable the addition of one or more source instances
- Disable the addition of any source instances

**If addition is enabled**, the enrolled instance (that failed to parse) will be added again (if it is in the source instances).

This PR adds these `Options` to the enrollment controller configuration, the default is that removals and additions are **enabled** on parse errors.