### PR TITLE
Overriding enrollment options via environment variables and commit-time settings within the spec yml/json

### DIFF
--- a/pkg/controller/enrollment/controller.go
+++ b/pkg/controller/enrollment/controller.go
@@ -1,6 +1,8 @@
 package enrollment
 
 import (
+	"time"
+
 	"github.com/docker/infrakit/pkg/controller"
 	enrollment "github.com/docker/infrakit/pkg/controller/enrollment/types"
 	"github.com/docker/infrakit/pkg/controller/internal"
@@ -14,6 +16,12 @@ var (
 	log     = logutil.New("module", "controller/enrollment")
 	debugV  = logutil.V(200)
 	debugV2 = logutil.V(500)
+
+	// DefaultOptions return an Options with default values filled in.
+	DefaultOptions = enrollment.Options{
+		SyncInterval:       types.Duration(5 * time.Second),
+		DestroyOnTerminate: false,
+	}
 )
 
 // NewController returns a controller implementation
@@ -23,7 +31,7 @@ func NewController(scope scope.Scope, leader func() stack.Leadership,
 		leader,
 		// the constructor
 		func(spec types.Spec) (internal.Managed, error) {
-			return newEnroller(scope, leader, options), nil
+			return newEnroller(scope, leader, options)
 		},
 		// the key function
 		func(metadata types.Metadata) string {
@@ -41,7 +49,7 @@ func NewTypedControllers(scope scope.Scope, leader func() stack.Leadership,
 		// the constructor
 		func(spec types.Spec) (internal.Managed, error) {
 			log.Debug("Creating managed object", "spec", spec)
-			return newEnroller(scope, leader, options), nil
+			return newEnroller(scope, leader, options)
 		},
 		// the key function
 		func(metadata types.Metadata) string {

--- a/pkg/controller/enrollment/types/types.go
+++ b/pkg/controller/enrollment/types/types.go
@@ -1,19 +1,12 @@
 package types
 
 import (
-	"time"
-
 	"github.com/docker/infrakit/pkg/controller"
 	"github.com/docker/infrakit/pkg/plugin"
 	"github.com/docker/infrakit/pkg/run/depends"
 	"github.com/docker/infrakit/pkg/spi/instance"
 	"github.com/docker/infrakit/pkg/template"
 	"github.com/docker/infrakit/pkg/types"
-)
-
-const (
-	// DefaultSyncInterval is the default interval for syncing enrollments
-	DefaultSyncInterval = 5 * time.Second
 )
 
 func init() {

--- a/pkg/run/v0/enrollment/enrollment.go
+++ b/pkg/run/v0/enrollment/enrollment.go
@@ -31,6 +31,8 @@ var (
 	EnvDestroyOnTerminate = "INFRAKIT_ENROLLMENT_DESTROY_ON_TERMINATE"
 
 	log = logutil.New("module", "run/v0/enrollment")
+
+	defaultOptions = enrollment.DefaultOptions
 )
 
 func init() {
@@ -39,7 +41,6 @@ func init() {
 	// the default values.  These default options are then overridden
 	// after the plugin started if the user provides options in the spec
 	// to override them.
-	defaultOptions := enrollment.DefaultOptions
 	if d := types.MustParseDuration(local.Getenv(EnvSyncInterval, "0s")); d > 0 {
 		defaultOptions.SyncInterval = d
 	}
@@ -79,7 +80,7 @@ func leadership(plugins func() discovery.Plugins) stack.Leadership {
 func Run(scope scope.Scope, name plugin.Name,
 	config *types.Any) (transport plugin.Transport, impls map[run.PluginCode]interface{}, onStop func(), err error) {
 
-	options := enrollment.DefaultOptions
+	options := defaultOptions // decode into a copy of the updated defaults
 	err = config.Decode(&options)
 	if err != nil {
 		return


### PR DESCRIPTION
This PR tries to clear up some confusion raised in #826 and clean up the Options processing for the enrollment controller:
  + Enrollment controller can define some sane defaults within its package (`pkg/controller/enrollment.DefaultOptions`)
  + This `DefaultOptions` is referenced in `pkg/run/v0/enrollment/enrollment.go` as the base value for Options used to parse the plugins.json config.   If environment variables are set for the `infrakit plugin start` process, the values of the environment variables will override the default values set in code of the package.
  + This Options become the actual default value used to initialize the plugin.
  + At runtime, the user commits by providing a spec as input to `enrollment commit -y <yml>` CLI.  This spec can further container an `options` block.  The values here will *override* the default values.  There is a bug where the `updateSpecs` function did not honor the default by decoding the input options into an uninitialized `enrollment.Options{}`.  This is now fixed by decoding the yml input into a copy of the Options that the plugin initialized with.

Signed-off-by: David Chung <david.chung@docker.com>
  