### PR TITLE
Cache terrform instances

### DIFF
--- a/pkg/provider/terraform/instance/apply.go
+++ b/pkg/provider/terraform/instance/apply.go
@@ -328,7 +328,7 @@ func (p *plugin) handleFiles(fns tfFuncs) error {
 			// State files have instances of this type, check each resource name
 			for resName, propsFilename := range resNameFilenamePropsMap {
 				if _, has = tfStateResName[resName]; has {
-					logger.Info("handleFiles", "msg", fmt.Sprintf("Instance %v.%v exists in terraform state", resType, resName))
+					logger.Debug("handleFiles", "msg", fmt.Sprintf("Instance %v.%v exists in terraform state", resType, resName), "V", debugV1)
 				} else {
 					logger.Info("handleFiles", "msg", fmt.Sprintf("Detected candidate instance %v.%v to prune at file: %v", resType, resName, propsFilename.FileName))
 					addToResTypeNamePropsMap(prunes, resType, resName, propsFilename.FileName, propsFilename.FileProps)
@@ -444,13 +444,15 @@ func (p *plugin) handleFilePruning(
 			}
 		}
 	}
-	logger.Info("handleFilePruning", "msg", fmt.Sprintf("Pruning %v tf.json files", len(pruneFiles)))
-	for file := range pruneFiles {
-		path := filepath.Join(p.Dir, file)
-		logger.Info("handleFilePruning", "msg", fmt.Sprintf("Pruning file: %v", file))
-		err := p.fs.Remove(path)
-		if err != nil {
-			return err
+	if len(pruneFiles) > 0 {
+		logger.Info("handleFilePruning", "msg", fmt.Sprintf("Pruning %v tf.json files", len(pruneFiles)))
+		for file := range pruneFiles {
+			path := filepath.Join(p.Dir, file)
+			logger.Info("handleFilePruning", "msg", fmt.Sprintf("Pruning file: %v", file))
+			err := p.fs.Remove(path)
+			if err != nil {
+				return err
+			}
 		}
 	}
 	return nil

--- a/pkg/provider/terraform/instance/apply.go
+++ b/pkg/provider/terraform/instance/apply.go
@@ -274,8 +274,10 @@ func (p *plugin) handleFiles(fns tfFuncs) error {
 	// Once we have the update resources we need to lock out any new files (from Provision)
 	// and the listing of the files (from Describe) while we reconcile orphans and rename
 	p.fsLock.Lock()
-	defer p.fsLock.Unlock()
-	defer p.clearCachedInstances()
+	defer func() {
+		p.clearCachedInstances()
+		p.fsLock.Unlock()
+	}()
 
 	// Load all instance files and all new files from disk
 	tfInstFiles := map[TResourceType]map[TResourceName]TResourceFilenameProps{}

--- a/pkg/provider/terraform/instance/plugin.go
+++ b/pkg/provider/terraform/instance/plugin.go
@@ -926,8 +926,10 @@ func (p *plugin) Provision(spec instance.Spec) (*instance.ID, error) {
 
 	// Hold the fs lock for the duration since the file is written at the end
 	p.fsLock.Lock()
-	defer p.fsLock.Unlock()
-	defer p.clearCachedInstances()
+	defer func() {
+		p.clearCachedInstances()
+		p.fsLock.Unlock()
+	}()
 	name := ensureUniqueFile(p.Dir)
 	id := instance.ID(name)
 	logger.Info("Provision", "instance-id", name)
@@ -978,8 +980,10 @@ func (p *plugin) Provision(spec instance.Spec) (*instance.ID, error) {
 // Label labels the instance
 func (p *plugin) Label(instance instance.ID, labels map[string]string) error {
 	p.fsLock.Lock()
-	defer p.fsLock.Unlock()
-	defer p.clearCachedInstances()
+	defer func() {
+		p.clearCachedInstances()
+		p.fsLock.Unlock()
+	}()
 
 	tf, filename, err := p.parseFileForInstanceID(instance)
 	if err != nil {
@@ -1012,8 +1016,10 @@ func (p *plugin) Label(instance instance.ID, labels map[string]string) error {
 func (p *plugin) Destroy(instID instance.ID, context instance.Context) error {
 	// Acquire Lock outside of recursive doDestroy function
 	p.fsLock.Lock()
-	defer p.fsLock.Unlock()
-	defer p.clearCachedInstances()
+	defer func() {
+		p.clearCachedInstances()
+		p.fsLock.Unlock()
+	}()
 
 	processAttach := true
 	if context == instance.RollingUpdate {

--- a/pkg/provider/terraform/instance/plugin.go
+++ b/pkg/provider/terraform/instance/plugin.go
@@ -1191,13 +1191,21 @@ func (p *plugin) doDescribeInstances(fns describeFns, tags map[string]string, pr
 					LogicalID: terraformLogicalID(resProps),
 				}
 
+				// And the properties from either the tf show output or the file data
 				if properties {
+					instProps := resProps
 					if vms, has := terraformShowResult[resType]; has {
 						if details, has := vms[resName]; has {
-							if encoded, err := types.AnyValue(details); err == nil {
-								inst.Properties = encoded
-							}
+							instProps = details
 						}
+					}
+					if encoded, err := types.AnyValue(instProps); err != nil {
+						logger.Warn("doDescribeInstances",
+							"msg", "Failed to encode instance props",
+							"props", instProps,
+							"error", err)
+					} else {
+						inst.Properties = encoded
 					}
 				}
 


### PR DESCRIPTION
This commit caches the output for the `DescribeInstances` command. The cache needs to be invalidated whenever one of the following operations is done:
- Provision
- Label
- Destroy

Also, after `terraform refresh` is executed, then the properties may have changed OR one or more input `tf.json` files may have been pruned. Therefore, the cache also needs to be invalidated after each refresh.

This commit also updates the locking to use a read/write lock so that multiple describe operations can run in parallel.