### PR TITLE
Cleanup index error logging in ingress and enroller

### DIFF
--- a/pkg/controller/enrollment/set.go
+++ b/pkg/controller/enrollment/set.go
@@ -21,7 +21,7 @@ func index(list instance.Descriptions, getKey keyFunc) (map[string]instance.Desc
 	for _, n := range list {
 		key, err := getKey(n)
 		if err != nil {
-			log.Error("cannot index entry", "instance.Description", n, "err", err)
+			log.Error("cannot index entry", "instance.ID", n.ID, "instance.tags", n.Tags, "err", err)
 			e = err
 			continue
 		}

--- a/pkg/controller/ingress/sync.go
+++ b/pkg/controller/ingress/sync.go
@@ -134,7 +134,7 @@ func (c *managed) syncBackends() error {
 				} else {
 					view, err := t.Render(inst)
 					if err != nil {
-						log.Error("cannot index entry", "instance.Description", inst, "err", err, "meta", c.spec.Metadata)
+						log.Error("cannot index entry", "instance.ID", inst.ID, "instance.tags", inst.Tags, "err", err, "meta", c.spec.Metadata)
 						continue
 					}
 					nodes.Add(instance.ID(view))


### PR DESCRIPTION
Currently, the entire `instance.Description` object is logged, this includes all of the `instance.Properties` which is quite big (do to a long `userdata` boot script).

Instead of printing out the entire object, this commit updates the error message to print out the `instance.ID`, and the `instance.Tags` (which is enough to identity the instance).

The error messages pretty clearly show the reason for the parse error, there is no need to print out the entire `instance.Properties`. Some example errors are:
```
template: file://localhost/infrakit_files/:1:41: executing \"file://localhost/infrakit_files/\" at <$x.ipv4_address_priv...>: map has no entry for key \"ipv4_address_private\"
template: file://localhost/infrakit_files/:1:45: executing \"file://localhost/infrakit_files/\" at <$x.id>: map has no entry for key \"id\"
```