### PR TITLE
Policy for terminating leader node during rolling update

### DIFF
--- a/pkg/plugin/group/group.go
+++ b/pkg/plugin/group/group.go
@@ -69,6 +69,7 @@ func (p *plugin) CommitGroup(config group.Spec, pretend bool) (string, error) {
 	}
 
 	settings.self = p.self // need this logicalID of the running node to prevent destroying self.
+	settings.options = p.options
 
 	log.Info("Committing", "groupID", config.ID, "pretend", pretend)
 

--- a/pkg/plugin/group/quorum.go
+++ b/pkg/plugin/group/quorum.go
@@ -33,7 +33,6 @@ func NewQuorum(id group.ID, scaled Scaled, logicalIDs []instance.LogicalID, poll
 }
 
 func (q *quorum) PlanUpdate(scaled Scaled, settings groupSettings, newSettings groupSettings) (updatePlan, error) {
-
 	if !reflect.DeepEqual(settings.config.Allocation.LogicalIDs, newSettings.config.Allocation.LogicalIDs) {
 		return nil, errors.New("Logical ID changes to a quorum is not currently supported")
 	}
@@ -47,9 +46,10 @@ func (q *quorum) PlanUpdate(scaled Scaled, settings groupSettings, newSettings g
 		desc: fmt.Sprintf(
 			"Performing a rolling update on %d instances",
 			len(settings.config.Allocation.LogicalIDs)),
-		scaled:     scaled,
-		updatingTo: newSettings,
-		stop:       make(chan bool),
+		scaled:       scaled,
+		updatingFrom: settings,
+		updatingTo:   newSettings,
+		stop:         make(chan bool),
 	}, nil
 }
 

--- a/pkg/plugin/group/state_test.go
+++ b/pkg/plugin/group/state_test.go
@@ -1,0 +1,115 @@
+package group
+
+import (
+	"sort"
+	"testing"
+
+	group_types "github.com/docker/infrakit/pkg/plugin/group/types"
+	"github.com/docker/infrakit/pkg/spi/instance"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSortByID(t *testing.T) {
+
+	{
+		list := []instance.Description{
+			{ID: "d", LogicalID: logicalID("4")},
+			{ID: "c", LogicalID: logicalID("3")},
+			{ID: "b", LogicalID: logicalID("2")},
+			{ID: "a", LogicalID: logicalID("1")},
+		}
+
+		sort.Sort(sortByID{list: list})
+
+		require.Equal(t,
+			[]instance.Description{
+				{ID: "a", LogicalID: logicalID("1")},
+				{ID: "b", LogicalID: logicalID("2")},
+				{ID: "c", LogicalID: logicalID("3")},
+				{ID: "d", LogicalID: logicalID("4")},
+			},
+			list)
+
+	}
+	{
+		list := []instance.Description{
+			{ID: "d", LogicalID: logicalID("4")},
+			{ID: "c", LogicalID: logicalID("3")},
+			{ID: "b", LogicalID: logicalID("2")},
+			{ID: "a", LogicalID: logicalID("1")},
+		}
+
+		sort.Sort(sortByID{list: list,
+			settings: &groupSettings{
+				self: logicalID("1"),
+				options: group_types.Options{
+					PolicyLeaderSelfUpdate: &group_types.PolicyLeaderSelfUpdateLast,
+				}}})
+
+		require.Equal(t,
+			[]instance.Description{
+				{ID: "b", LogicalID: logicalID("2")},
+				{ID: "c", LogicalID: logicalID("3")},
+				{ID: "d", LogicalID: logicalID("4")},
+				{ID: "a", LogicalID: logicalID("1")},
+			},
+			list)
+
+	}
+	{
+		list := []instance.Description{
+			{ID: "d", LogicalID: logicalID("4")},
+			{ID: "c", LogicalID: logicalID("3")},
+			{ID: "b", LogicalID: logicalID("2")},
+			{ID: "a", LogicalID: logicalID("1")},
+		}
+
+		sort.Sort(sortByID{list: list,
+			settings: &groupSettings{
+				self: logicalID("3"),
+				options: group_types.Options{
+					PolicyLeaderSelfUpdate: &group_types.PolicyLeaderSelfUpdateLast,
+				}}})
+
+		require.Equal(t,
+			[]instance.Description{
+				{ID: "a", LogicalID: logicalID("1")},
+				{ID: "b", LogicalID: logicalID("2")},
+				{ID: "d", LogicalID: logicalID("4")},
+				{ID: "c", LogicalID: logicalID("3")},
+			},
+			list)
+
+	}
+
+	tagsWithLogicalID := func(v string) map[string]string {
+		return map[string]string{
+			instance.LogicalIDTag: v,
+		}
+	}
+	{
+		list := []instance.Description{
+			{ID: "d", Tags: tagsWithLogicalID("4")},
+			{ID: "c", Tags: tagsWithLogicalID("3")},
+			{ID: "b", Tags: tagsWithLogicalID("2")},
+			{ID: "a", Tags: tagsWithLogicalID("1")},
+		}
+
+		sort.Sort(sortByID{list: list,
+			settings: &groupSettings{
+				self: logicalID("1"),
+				options: group_types.Options{
+					PolicyLeaderSelfUpdate: &group_types.PolicyLeaderSelfUpdateLast,
+				}}})
+
+		require.Equal(t,
+			[]instance.Description{
+				{ID: "b", Tags: tagsWithLogicalID("2")},
+				{ID: "c", Tags: tagsWithLogicalID("3")},
+				{ID: "d", Tags: tagsWithLogicalID("4")},
+				{ID: "a", Tags: tagsWithLogicalID("1")},
+			},
+			list)
+
+	}
+}

--- a/pkg/plugin/group/testplugin.go
+++ b/pkg/plugin/group/testplugin.go
@@ -27,6 +27,8 @@ type testplugin struct {
 	idPrefix  string
 	nextID    int
 	instances map[instance.ID]instance.Spec
+
+	destroyed []instance.Spec
 }
 
 func (d *testplugin) instancesCopy() map[instance.ID]instance.Spec {
@@ -68,12 +70,14 @@ func (d *testplugin) Destroy(id instance.ID, ctx instance.Context) error {
 	d.lock.Lock()
 	defer d.lock.Unlock()
 
-	_, exists := d.instances[id]
+	spec, exists := d.instances[id]
 	if !exists {
 		return errors.New("Instance does not exist")
 	}
 
 	delete(d.instances, id)
+
+	d.destroyed = append(d.destroyed, spec)
 	return nil
 }
 

--- a/pkg/run/v0/group/group.go
+++ b/pkg/run/v0/group/group.go
@@ -33,6 +33,10 @@ const (
 	// EnvSelfLogicalID sets the self id of this controller. This will avoid
 	// the self node to be updated.
 	EnvSelfLogicalID = "INFRAKIT_GROUP_SELF_LOGICAL_ID"
+
+	// EnvPolicyLeaderSelfUpdate is either 'last' or 'never' which determines
+	// if the leader ever destroys itself, or lastly, in a rolling update.
+	EnvPolicyLeaderSelfUpdate = "INFRAKIT_GROUP_POLICY_LEADER_SELF_UPDATE"
 )
 
 var log = logutil.New("module", "run/group")
@@ -49,9 +53,21 @@ func nilLogicalIDIfEmptyString(s string) *instance.LogicalID {
 	return &id
 }
 
+func leaderSelfUpdatePolicy(v string) *group_types.PolicyLeaderSelfUpdate {
+	switch v {
+	case "never":
+		return &group_types.PolicyLeaderSelfUpdateNever
+	case "last":
+		return &group_types.PolicyLeaderSelfUpdateLast
+	default:
+		panic("invalid policy:" + v)
+	}
+}
+
 // DefaultOptions return an Options with default values filled in.
 var DefaultOptions = group_types.Options{
-	Self:                    nilLogicalIDIfEmptyString(local.Getenv(EnvSelfLogicalID, "")),
+	Self: nilLogicalIDIfEmptyString(local.Getenv(EnvSelfLogicalID, "")),
+	PolicyLeaderSelfUpdate:  leaderSelfUpdatePolicy(local.Getenv(EnvPolicyLeaderSelfUpdate, "last")),
 	PollInterval:            types.MustParseDuration(local.Getenv(EnvPollInterval, "10s")),
 	MaxParallelNum:          types.MustParseUint(local.Getenv(EnvMaxParallelNum, "0")),
 	PollIntervalGroupSpec:   types.MustParseDuration(local.Getenv(EnvPollInterval, "10s")),


### PR DESCRIPTION
This PR provides one implementation to address the leadership handover required by #838 

Since there isn't an explicit way to demote a leader in Swarm mode (even though it's possible to demote a manager to worker), this implementation tries to work around this limitation by making sure the leader node is either never destroyed or is the very last one.  In the latter case, the leadership will be transferred to another manager node that has been updated.  The cluster should then be able to complete the rolling update by provisioning the very last node, the previous leader.

This PR allows the user to specify an option
`INFRAKIT_GROUP_POLICY_LEADER_SELF_UPDATE` to be either `last` or `never`.  If the policy is set to be `last`, then the leader node (as determined by the node running the code and its own self LogicalID == the LogicalID of the instance) will always be the last node to be destroyed.  If the policy is set to be `never`, then the node is always considered 'desirable' and therefore left untouched during the rolling update process where 'undesirable' nodes are destroyed and re-provisioned.

Signed-off-by: David Chung <david.chung@docker.com>