### PR TITLE
swarm manager update: demote node then leave in flavor.Drain

### DIFF
--- a/pkg/plugin/flavor/swarm/manager.go
+++ b/pkg/plugin/flavor/swarm/manager.go
@@ -106,10 +106,11 @@ func (s *ManagerFlavor) Drain(flavorProperties *types.Any, inst instance.Descrip
 
 	switch {
 	case len(nodes) == 0:
-		log.Warn("Unable to drain - not found in swarm", "id", inst.ID)
-		return nil
+		return fmt.Errorf("not found %v", inst.ID)
 
 	case len(nodes) == 1:
+
+		// Do a swarm leave if and only if this is a manager
 
 		nodeID := nodes[0].ID
 
@@ -147,6 +148,7 @@ func (s *ManagerFlavor) Drain(flavorProperties *types.Any, inst instance.Descrip
 		// If running on the same node (self), then do docker swarm leave
 		// otherwise, remove the node
 		if s.isSelf(inst) {
+
 			log.Debug("Docker SwarmLeave", "id", nodeID)
 
 			err := dockerClient.SwarmLeave(ctx, true)

--- a/pkg/plugin/flavor/swarm/manager.go
+++ b/pkg/plugin/flavor/swarm/manager.go
@@ -2,7 +2,11 @@ package swarm
 
 import (
 	"errors"
+	"fmt"
 
+	docker_types "github.com/docker/docker/api/types"
+	"github.com/docker/docker/api/types/filters"
+	"github.com/docker/docker/api/types/swarm"
 	"github.com/docker/infrakit/pkg/plugin/metadata"
 	"github.com/docker/infrakit/pkg/run/scope"
 	"github.com/docker/infrakit/pkg/spi/group"
@@ -10,14 +14,15 @@ import (
 	"github.com/docker/infrakit/pkg/template"
 	"github.com/docker/infrakit/pkg/types"
 	"github.com/docker/infrakit/pkg/util/docker"
+	"golang.org/x/net/context"
 )
 
 // NewManagerFlavor creates a flavor.Plugin that creates manager and worker nodes connected in a swarm.
 func NewManagerFlavor(scope scope.Scope, connect func(Spec) (docker.APIClientCloser, error),
 	templ *template.Template,
-	stop <-chan struct{}) *ManagerFlavor {
+	stop <-chan struct{}, self *instance.LogicalID) *ManagerFlavor {
 
-	base := &baseFlavor{initScript: templ, getDockerClient: connect, scope: scope}
+	base := &baseFlavor{initScript: templ, getDockerClient: connect, scope: scope, self: self}
 	base.metadataPlugin = metadata.NewPluginFromChannel(base.runMetadataSnapshot(stop))
 	return &ManagerFlavor{baseFlavor: base}
 }
@@ -57,4 +62,113 @@ func (s *ManagerFlavor) Prepare(flavorProperties *types.Any,
 	instanceSpec instance.Spec, allocation group.AllocationMethod,
 	index group.Index) (instance.Spec, error) {
 	return s.baseFlavor.prepare("manager", flavorProperties, instanceSpec, allocation, index)
+}
+
+// Drain in the case of manager, first perform a swarm node demote to
+// downgrade the manager to a worker, then do a swarm leave.
+// Note that if the current node is the leader running this code, the demote
+// will turn the manager to a worker, and it's not possible to issue a
+// docker node rm anymore because this node is no longer a manager and only
+// manager nodes permit `docker node rm`.  So the node demote will be followed
+// by `docker swarm leave` of *this* node.  This in essence takes the current
+// leader node out of the swarm.
+func (s *ManagerFlavor) Drain(flavorProperties *types.Any, inst instance.Description) error {
+	if flavorProperties == nil {
+		return fmt.Errorf("missing config")
+	}
+
+	spec := Spec{}
+	err := flavorProperties.Decode(&spec)
+	if err != nil {
+		return err
+	}
+
+	link := types.NewLinkFromMap(inst.Tags)
+	if !link.Valid() {
+		return fmt.Errorf("Unable to drain %s without an association tag", inst.ID)
+	}
+
+	filter := filters.NewArgs()
+	filter.Add("label", fmt.Sprintf("%s=%s", link.Label(), link.Value()))
+
+	dockerClient, err := s.getDockerClient(spec)
+	if err != nil {
+		return err
+	}
+	defer dockerClient.Close()
+
+	ctx := context.Background()
+
+	nodes, err := dockerClient.NodeList(ctx, docker_types.NodeListOptions{Filters: filter})
+	if err != nil {
+		return err
+	}
+
+	switch {
+	case len(nodes) == 0:
+		log.Warn("Unable to drain - not found in swarm", "id", inst.ID)
+		return nil
+
+	case len(nodes) == 1:
+
+		nodeID := nodes[0].ID
+
+		// first read the swarm version which is needed to update node
+		sw, err := dockerClient.SwarmInspect(ctx)
+		if err != nil {
+			return err
+		}
+
+		version := sw.ClusterInfo.Meta.Version
+
+		// then read the state of the node
+		nodeInfo, _, err := dockerClient.NodeInspectWithRaw(ctx, nodeID)
+		if err != nil {
+			return err
+		}
+
+		if nodeInfo.Spec.Role != swarm.NodeRoleManager {
+			return fmt.Errorf("not a manager: %v", nodeID)
+		}
+
+		// change to worker
+		nodeInfo.Spec.Role = swarm.NodeRoleWorker
+
+		log.Debug("Docker NodeDemote", "id", nodeID)
+		err = dockerClient.NodeUpdate(
+			ctx,
+			nodeID,
+			version,
+			nodeInfo.Spec)
+		if err != nil {
+			return err
+		}
+
+		// If running on the same node (self), then do docker swarm leave
+		// otherwise, remove the node
+		if s.isSelf(inst) {
+			log.Debug("Docker SwarmLeave", "id", nodeID)
+
+			err := dockerClient.SwarmLeave(ctx, true)
+			if err != nil {
+				return err
+			}
+
+		} else {
+			log.Debug("Docker NodeRemote", "id", nodeID)
+
+			err := dockerClient.NodeRemove(
+				ctx,
+				nodeID,
+				docker_types.NodeRemoveOptions{Force: true})
+			if err != nil {
+				return err
+			}
+		}
+
+		return nil
+
+	default:
+		return fmt.Errorf("Expected at most one node with label %s, but found %v", link.Value(), nodes)
+	}
 }

--- a/pkg/plugin/flavor/swarm/manager_test.go
+++ b/pkg/plugin/flavor/swarm/manager_test.go
@@ -1,0 +1,109 @@
+package swarm
+
+import (
+	"fmt"
+	"testing"
+
+	docker_types "github.com/docker/docker/api/types"
+	"github.com/docker/docker/api/types/filters"
+	"github.com/docker/docker/api/types/swarm"
+	mock_client "github.com/docker/infrakit/pkg/mock/docker/docker/client"
+	"github.com/docker/infrakit/pkg/spi/group"
+	"github.com/docker/infrakit/pkg/spi/instance"
+	"github.com/docker/infrakit/pkg/types"
+	"github.com/docker/infrakit/pkg/util/docker"
+	"github.com/golang/mock/gomock"
+	"github.com/stretchr/testify/require"
+)
+
+func TestManagerDrain(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	selfAddr := "10.20.100.1"
+	self := instance.LogicalID(selfAddr)
+	managerStop := make(chan struct{})
+
+	client := mock_client.NewMockAPIClientCloser(ctrl)
+
+	flavorImpl := NewManagerFlavor(scp, func(Spec) (docker.APIClientCloser, error) {
+		return client, nil
+	}, templ(DefaultManagerInitScriptTemplate), managerStop, &self)
+
+	version := swarm.Version{Index: uint64(9999)}
+	swarmInfo := swarm.Swarm{
+		ClusterInfo: swarm.ClusterInfo{
+			ID: "ClusterUUID",
+			Meta: swarm.Meta{
+				Version: version,
+			},
+		},
+		JoinTokens: swarm.JoinTokens{
+			Manager: "ManagerToken",
+			Worker:  "WorkerToken",
+		},
+	}
+
+	client.EXPECT().Close().AnyTimes()
+	client.EXPECT().SwarmInspect(gomock.Any()).Return(swarmInfo, nil).AnyTimes()
+	client.EXPECT().Info(gomock.Any()).Return(infoResponse, nil).AnyTimes()
+
+	flavorProperties := types.AnyString(`
+{
+  "Attachments" : {
+    "10.20.100.1" : [ { "ID" : "disk01", "Type" : "disk" }, { "ID" : "nic01", "Type" : "nic" } ],
+    "10.20.100.2" : [ { "ID" : "disk02", "Type" : "disk" }, { "ID" : "nic02", "Type" : "nic" } ],
+    "10.20.100.3" : [ { "ID" : "disk03", "Type" : "disk" }, { "ID" : "nic03", "Type" : "nic" } ]
+  }
+}
+`)
+	index := group.Index{Group: group.ID("group"), Sequence: 0}
+	id := self
+
+	// manager self info
+	nodeInfo := swarm.Node{ManagerStatus: &swarm.ManagerStatus{Addr: selfAddr}}
+	client.EXPECT().NodeInspectWithRaw(gomock.Any(), nodeID).Return(nodeInfo, nil, nil)
+
+	details, err := flavorImpl.Prepare(flavorProperties,
+		instance.Spec{Tags: map[string]string{"a": "b"}, LogicalID: &id},
+		group.AllocationMethod{LogicalIDs: []instance.LogicalID{id}},
+		index)
+	require.NoError(t, err)
+
+	link := types.NewLinkFromMap(details.Tags)
+	associationID := link.Value()
+	associationTag := link.Label()
+
+	filter, err := filters.FromParam(fmt.Sprintf(`{"label": {"%s=%s": true}}`, associationTag, associationID))
+	require.NoError(t, err)
+
+	// Do a drain
+	swarmNodeID := "swarm-id-1"
+	client.EXPECT().NodeList(gomock.Any(),
+		docker_types.NodeListOptions{Filters: filter}).Return(
+		[]swarm.Node{
+			{ID: swarmNodeID},
+		},
+		nil)
+	client.EXPECT().NodeInspectWithRaw(gomock.Any(), swarmNodeID).Return(
+		swarm.Node{
+			ID:   swarmNodeID,
+			Spec: swarm.NodeSpec{Role: swarm.NodeRoleManager},
+		},
+		nil,
+		nil,
+	)
+	client.EXPECT().NodeUpdate(gomock.Any(), swarmNodeID, version, swarm.NodeSpec{Role: swarm.NodeRoleWorker}).Return(nil)
+
+	// Because this is the self node....
+	client.EXPECT().SwarmLeave(gomock.Any(), true)
+
+	err = flavorImpl.Drain(flavorProperties,
+		instance.Description{
+			LogicalID: &id,
+			Tags:      map[string]string{associationTag: associationID},
+		})
+	require.NoError(t, err)
+
+	close(managerStop)
+}

--- a/pkg/plugin/group/rollingupdate.go
+++ b/pkg/plugin/group/rollingupdate.go
@@ -19,6 +19,13 @@ func minInt(a, b int) int {
 	return b
 }
 
+func selfUpdatePolicy(settings groupSettings) group_types.PolicyLeaderSelfUpdate {
+	if settings.options.PolicyLeaderSelfUpdate == nil {
+		return group_types.PolicyLeaderSelfUpdateLast // default policy
+	}
+	return *settings.options.PolicyLeaderSelfUpdate
+}
+
 func isSelf(inst instance.Description, settings groupSettings) bool {
 	if settings.self != nil {
 		if inst.LogicalID != nil && *inst.LogicalID == *settings.self {
@@ -31,15 +38,13 @@ func isSelf(inst instance.Description, settings groupSettings) bool {
 	return false
 }
 
-func doNotDestroySelf(inst instance.Description, settings groupSettings) bool {
+func canDestroy(inst instance.Description, settings groupSettings) bool {
 	if !isSelf(inst, settings) {
-		return false
+		// not running on the same node, so ok to destroy
+		return true
 	}
-	if settings.options.PolicyLeaderSelfUpdate == nil {
-		return false
-	}
-
-	return *settings.options.PolicyLeaderSelfUpdate == group_types.PolicyLeaderSelfUpdateNever
+	// self update - never - means we'd never update the self node.
+	return selfUpdatePolicy(settings) != group_types.PolicyLeaderSelfUpdateNever
 }
 
 func desiredAndUndesiredInstances(
@@ -52,9 +57,9 @@ func desiredAndUndesiredInstances(
 	for _, inst := range instances {
 
 		actualConfig, specified := inst.Tags[group.ConfigSHATag]
-		if specified && actualConfig == desiredHash || doNotDestroySelf(inst, settings) {
+		if specified && actualConfig == desiredHash {
 			desired = append(desired, inst)
-		} else {
+		} else if canDestroy(inst, settings) {
 			undesired = append(undesired, inst)
 		}
 	}
@@ -193,7 +198,7 @@ func (r *rollingupdate) Run(pollInterval time.Duration) error {
 		sort.Sort(sortByID{list: undesiredInstances, settings: &r.updatingFrom})
 
 		// TODO(wfarner): Make the 'batch size' configurable.
-		if !isSelf(undesiredInstances[0], r.updatingFrom) {
+		if canDestroy(undesiredInstances[0], r.updatingFrom) {
 			// we do not self-destruct in any cases.
 			r.scaled.Destroy(undesiredInstances[0], instance.RollingUpdate)
 		}

--- a/pkg/plugin/group/rollingupdate.go
+++ b/pkg/plugin/group/rollingupdate.go
@@ -178,7 +178,10 @@ func (r *rollingupdate) Run(pollInterval time.Duration) error {
 		sort.Sort(sortByID{list: undesiredInstances, settings: &r.updatingFrom})
 
 		// TODO(wfarner): Make the 'batch size' configurable.
-		r.scaled.Destroy(undesiredInstances[0], instance.RollingUpdate)
+		if !isSelf(undesiredInstances[0], r.updatingFrom) {
+			// we do not self-destruct in any cases.
+			r.scaled.Destroy(undesiredInstances[0], instance.RollingUpdate)
+		}
 
 		expectedNewInstances++
 	}

--- a/pkg/plugin/group/state.go
+++ b/pkg/plugin/group/state.go
@@ -126,8 +126,7 @@ func (n sortByID) Swap(i, j int) {
 }
 
 func (n sortByID) Less(i, j int) bool {
-	if n.settings != nil && n.settings.options.PolicyLeaderSelfUpdate != nil &&
-		*n.settings.options.PolicyLeaderSelfUpdate == types.PolicyLeaderSelfUpdateLast {
+	if n.settings != nil && selfUpdatePolicy(*n.settings) == types.PolicyLeaderSelfUpdateLast {
 		if isSelf(n.list[i], *n.settings) {
 			return false
 		}


### PR DESCRIPTION
This PR address #838 by

  + Implement in swarm flavor's Drain for managers: 
    1. `docker node demote` the manager node
    2. either remove the node from swarm or leave the swarm:
      a. `docker node rm` if the node *is not* the current node -- this is the case when the control plane (where infrakit is running) is *not* the same as the manager node being updated.
      b. `docker swarm leave` if the node *is* the same as the node running the code (the self node).
  + Make sure in the Group controller, the 'self' node is never destroyed.


Signed-off-by: David Chung <david.chung@docker.com>