### PR TITLE
Add tests for IBM Cloud clients

### DIFF
--- a/pkg/provider/ibmcloud/client/fake_sl_client.go
+++ b/pkg/provider/ibmcloud/client/fake_sl_client.go
@@ -1,0 +1,80 @@
+package client
+
+import (
+	"sync"
+
+	"github.com/softlayer/softlayer-go/datatypes"
+)
+
+// FakeSoftlayer is used for testing
+type FakeSoftlayer struct {
+	GetVirtualGuestsStub  func(mask, filters *string) ([]datatypes.Virtual_Guest, error)
+	getVirtualGuestsMutex sync.RWMutex
+	GetVirtualGuestsArgs  []struct {
+		Mask    *string
+		Filters *string
+	}
+
+	AuthorizeToStorageStub  func(storageID, guestID int) error
+	authorizeToStorageMutex sync.RWMutex
+	AuthorizeToStorageArgs  []struct {
+		StorageID int
+		GuestID   int
+	}
+
+	DeauthorizeFromStorageStub  func(storageID, guestID int) error
+	deauthorizeFromStorageMutex sync.RWMutex
+	DeauthorizeFromStorageArgs  []struct {
+		StorageID int
+		GuestID   int
+	}
+
+	GetAllowedStorageVirtualGuestsStub  func(storageID int) ([]int, error)
+	getAllowedStorageVirtualGuestsMutex sync.RWMutex
+	GetAllowedStorageVirtualGuestsArgs  []struct {
+		StorageID int
+	}
+}
+
+// GetVirtualGuests .
+func (fake *FakeSoftlayer) GetVirtualGuests(mask, filters *string) ([]datatypes.Virtual_Guest, error) {
+	fake.getVirtualGuestsMutex.Lock()
+	defer fake.getVirtualGuestsMutex.Unlock()
+	fake.GetVirtualGuestsArgs = append(fake.GetVirtualGuestsArgs, struct {
+		Mask    *string
+		Filters *string
+	}{mask, filters})
+	return fake.GetVirtualGuestsStub(mask, filters)
+}
+
+// AuthorizeToStorage .
+func (fake *FakeSoftlayer) AuthorizeToStorage(storageID, guestID int) error {
+	fake.authorizeToStorageMutex.Lock()
+	defer fake.authorizeToStorageMutex.Unlock()
+	fake.AuthorizeToStorageArgs = append(fake.AuthorizeToStorageArgs, struct {
+		StorageID int
+		GuestID   int
+	}{storageID, guestID})
+	return fake.AuthorizeToStorageStub(storageID, guestID)
+}
+
+// DeauthorizeFromStorage .
+func (fake *FakeSoftlayer) DeauthorizeFromStorage(storageID, guestID int) error {
+	fake.deauthorizeFromStorageMutex.Lock()
+	defer fake.deauthorizeFromStorageMutex.Unlock()
+	fake.DeauthorizeFromStorageArgs = append(fake.DeauthorizeFromStorageArgs, struct {
+		StorageID int
+		GuestID   int
+	}{storageID, guestID})
+	return fake.DeauthorizeFromStorageStub(storageID, guestID)
+}
+
+// GetAllowedStorageVirtualGuests .
+func (fake *FakeSoftlayer) GetAllowedStorageVirtualGuests(storageID int) ([]int, error) {
+	fake.getAllowedStorageVirtualGuestsMutex.Lock()
+	defer fake.getAllowedStorageVirtualGuestsMutex.Unlock()
+	fake.GetAllowedStorageVirtualGuestsArgs = append(fake.GetAllowedStorageVirtualGuestsArgs, struct {
+		StorageID int
+	}{storageID})
+	return fake.GetAllowedStorageVirtualGuestsStub(storageID)
+}

--- a/pkg/provider/ibmcloud/client/softlayerclient.go
+++ b/pkg/provider/ibmcloud/client/softlayerclient.go
@@ -11,6 +11,14 @@ type SoftlayerClient struct {
 	sess *session.Session
 }
 
+// API is the Softlayer client API
+type API interface {
+	AuthorizeToStorage(storageID, guestID int) error
+	DeauthorizeFromStorage(storageID, guestID int) error
+	GetAllowedStorageVirtualGuests(storageID int) ([]int, error)
+	GetVirtualGuests(mask, filters *string) (resp []datatypes.Virtual_Guest, err error)
+}
+
 // GetClient returns a SoftlayerClient instance
 func GetClient(user, apiKey string) *SoftlayerClient {
 	client := &SoftlayerClient{
@@ -47,7 +55,7 @@ func (c *SoftlayerClient) GetAllowedStorageVirtualGuests(storageID int) ([]int, 
 }
 
 // GetVirtualGuests gets all VMs
-func (c *SoftlayerClient) GetVirtualGuests(username, apiKey string, mask, filters *string) (resp []datatypes.Virtual_Guest, err error) {
+func (c *SoftlayerClient) GetVirtualGuests(mask, filters *string) (resp []datatypes.Virtual_Guest, err error) {
 	acct := services.GetAccountService(c.sess)
 	if mask != nil {
 		acct = acct.Mask(*mask)

--- a/pkg/provider/ibmcloud/plugin/instance/volumeauthplugin.go
+++ b/pkg/provider/ibmcloud/plugin/instance/volumeauthplugin.go
@@ -17,7 +17,7 @@ var (
 )
 
 type plugin struct {
-	SoftlayerClient *client.SoftlayerClient
+	SoftlayerClient client.API
 	VolumeID        int
 }
 
@@ -49,9 +49,6 @@ func (p *plugin) Provision(spec instance.Spec) (*instance.ID, error) {
 	if err != nil {
 		return nil, err
 	}
-	if err != nil {
-		return nil, err
-	}
 	logger.Info("Authorizing instance", "volume", p.VolumeID, "instance", props.ID)
 	vmID, err := strconv.Atoi(props.ID)
 	if err != nil {
@@ -65,7 +62,7 @@ func (p *plugin) Destroy(id instance.ID, ctx instance.Context) error {
 	logger.Info("Deauthorizing instance", "volume", p.VolumeID, "instance", string(id))
 	vmID, err := strconv.Atoi(string(id))
 	if err != nil {
-		return nil
+		return err
 	}
 	return p.SoftlayerClient.DeauthorizeFromStorage(p.VolumeID, vmID)
 }
@@ -74,7 +71,7 @@ func (p *plugin) DescribeInstances(tags map[string]string, properties bool) ([]i
 	logger.Debug("Describing authorized VMs", "volume", p.VolumeID, "tags", tags, "V", debugV)
 	vmIDs, err := p.SoftlayerClient.GetAllowedStorageVirtualGuests(p.VolumeID)
 	if err != nil {
-		return []instance.Description{}, nil
+		return []instance.Description{}, err
 	}
 	result := []instance.Description{}
 	for _, vmID := range vmIDs {

--- a/pkg/provider/ibmcloud/plugin/instance/volumeauthplugin_test.go
+++ b/pkg/provider/ibmcloud/plugin/instance/volumeauthplugin_test.go
@@ -1,0 +1,197 @@
+package instance
+
+import (
+	"fmt"
+	"strconv"
+	"testing"
+
+	"github.com/docker/infrakit/pkg/provider/ibmcloud/client"
+	"github.com/docker/infrakit/pkg/spi/instance"
+	"github.com/docker/infrakit/pkg/types"
+	"github.com/stretchr/testify/require"
+)
+
+func getPlugin(fake *client.FakeSoftlayer, volumeID int) *plugin {
+	p := plugin{
+		SoftlayerClient: fake,
+		VolumeID:        volumeID,
+	}
+	return &p
+}
+
+func TestNewPlugin(t *testing.T) {
+	user := "user"
+	apiKey := "apiKey"
+	volumeID := 123
+	authPlugin := NewVolumeAuthPlugin(user, apiKey, volumeID)
+	p := authPlugin.(*plugin)
+	require.Equal(t, p.VolumeID, 123)
+}
+
+func TestValidate(t *testing.T) {
+	fake := client.FakeSoftlayer{}
+	p := getPlugin(&fake, 1)
+	require.NoError(t, p.Validate(nil))
+}
+
+func TestLabel(t *testing.T) {
+	fake := client.FakeSoftlayer{}
+	p := getPlugin(&fake, 1)
+	require.NoError(t, p.Label(instance.ID("some-id"), map[string]string{}))
+}
+
+func TestProvisionDecodeError(t *testing.T) {
+	fake := client.FakeSoftlayer{}
+	p := getPlugin(&fake, 1)
+	spec := instance.Spec{
+		Properties: types.AnyString("no-json"),
+	}
+	id, err := p.Provision(spec)
+	require.Error(t, err)
+	require.Nil(t, id)
+}
+
+func TestProvisionMissingID(t *testing.T) {
+	fake := client.FakeSoftlayer{}
+	p := getPlugin(&fake, 1)
+	props, err := types.AnyValue(map[string]string{"foo": "bar"})
+	require.NoError(t, err)
+	spec := instance.Spec{
+		Properties: props,
+	}
+	id, err := p.Provision(spec)
+	require.Error(t, err)
+	_, expectedErr := strconv.Atoi("")
+	require.Equal(t, expectedErr, err)
+	require.Nil(t, id)
+}
+
+func TestProvisionInvalidID(t *testing.T) {
+	fake := client.FakeSoftlayer{}
+	p := getPlugin(&fake, 1)
+	props, err := types.AnyValue(map[string]string{"id": "NaN"})
+	require.NoError(t, err)
+	spec := instance.Spec{
+		Properties: props,
+	}
+	id, err := p.Provision(spec)
+	require.Error(t, err)
+	_, expectedErr := strconv.Atoi("NaN")
+	require.Equal(t, expectedErr, err)
+	require.Nil(t, id)
+}
+
+func TestProvision(t *testing.T) {
+	fake := client.FakeSoftlayer{
+		AuthorizeToStorageStub: func(storageID, guestID int) error {
+			return nil
+		},
+	}
+	p := getPlugin(&fake, 1)
+	props, err := types.AnyValue(map[string]string{"id": "123"})
+	require.NoError(t, err)
+	spec := instance.Spec{
+		Properties: props,
+	}
+	id, err := p.Provision(spec)
+	require.NoError(t, err)
+	require.Nil(t, id)
+	require.Equal(t,
+		[]struct {
+			StorageID int
+			GuestID   int
+		}{{1, 123}},
+		fake.AuthorizeToStorageArgs)
+}
+
+func TestProvisionError(t *testing.T) {
+	fake := client.FakeSoftlayer{
+		AuthorizeToStorageStub: func(storageID, guestID int) error {
+			return fmt.Errorf("custom error")
+		},
+	}
+	p := getPlugin(&fake, 1)
+	props, err := types.AnyValue(map[string]string{"id": "123"})
+	require.NoError(t, err)
+	spec := instance.Spec{
+		Properties: props,
+	}
+	id, err := p.Provision(spec)
+	require.Error(t, err)
+	require.Equal(t, "custom error", err.Error())
+	require.Nil(t, id)
+}
+
+func TestDestroy(t *testing.T) {
+	fake := client.FakeSoftlayer{
+		DeauthorizeFromStorageStub: func(storageID, guestID int) error {
+			return nil
+		},
+	}
+	p := getPlugin(&fake, 1)
+	err := p.Destroy(instance.ID("123"), instance.RollingUpdate)
+	require.NoError(t, err)
+	require.Equal(t,
+		[]struct {
+			StorageID int
+			GuestID   int
+		}{{1, 123}},
+		fake.DeauthorizeFromStorageArgs)
+}
+
+func TestDestroyError(t *testing.T) {
+	fake := client.FakeSoftlayer{
+		DeauthorizeFromStorageStub: func(storageID, guestID int) error {
+			return fmt.Errorf("custom error")
+		},
+	}
+	p := getPlugin(&fake, 1)
+	err := p.Destroy(instance.ID("123"), instance.RollingUpdate)
+	require.Error(t, err)
+	require.Equal(t, "custom error", err.Error())
+}
+
+func TestDestroyInvalidId(t *testing.T) {
+	fake := client.FakeSoftlayer{}
+	p := getPlugin(&fake, 1)
+	err := p.Destroy(instance.ID("NaN"), instance.RollingUpdate)
+	require.Error(t, err)
+	_, expectedErr := strconv.Atoi("NaN")
+	require.Equal(t, expectedErr, err)
+}
+
+func TestDescribe(t *testing.T) {
+	fake := client.FakeSoftlayer{
+		GetAllowedStorageVirtualGuestsStub: func(storageID int) ([]int, error) {
+			return []int{111, 222, 333}, nil
+		},
+	}
+	p := getPlugin(&fake, 1)
+	insts, err := p.DescribeInstances(map[string]string{}, true)
+	require.NoError(t, err)
+	require.Equal(t,
+		[]instance.Description{
+			{ID: instance.ID("111")},
+			{ID: instance.ID("222")},
+			{ID: instance.ID("333")},
+		},
+		insts)
+	require.Equal(t,
+		[]struct {
+			StorageID int
+		}{{1}},
+		fake.GetAllowedStorageVirtualGuestsArgs)
+}
+
+func TestDescribeError(t *testing.T) {
+	fake := client.FakeSoftlayer{
+		GetAllowedStorageVirtualGuestsStub: func(storageID int) ([]int, error) {
+			return []int{}, fmt.Errorf("custom error")
+		},
+	}
+	p := getPlugin(&fake, 1)
+	insts, err := p.DescribeInstances(map[string]string{}, true)
+	require.Error(t, err)
+	require.Equal(t, "custom error", err.Error())
+	require.Equal(t, []instance.Description{}, insts)
+}

--- a/pkg/provider/terraform/instance/apply.go
+++ b/pkg/provider/terraform/instance/apply.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/deckarep/golang-set"
 	manager_discovery "github.com/docker/infrakit/pkg/manager/discovery"
+	ibmcloud_client "github.com/docker/infrakit/pkg/provider/ibmcloud/client"
 	"github.com/docker/infrakit/pkg/types"
 	"github.com/docker/infrakit/pkg/util/exec"
 	"github.com/spf13/afero"
@@ -508,7 +509,7 @@ func (p *plugin) getExistingResource(resType TResourceType, resName TResourceNam
 				}
 			}
 		}
-		id, err := GetIBMCloudVMByTag(username, apiKey, tags)
+		id, err := GetIBMCloudVMByTag(ibmcloud_client.GetClient(username, apiKey), tags)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/provider/terraform/instance/softlayer.go
+++ b/pkg/provider/terraform/instance/softlayer.go
@@ -56,8 +56,7 @@ func mergeLabelsIntoTagSlice(tags []interface{}, labels map[string]string) []str
 
 // GetIBMCloudVMByTag queries Softlayer for VMs that match all of the given tags. Returns
 // the single VM ID that matches or nil if there are no matches.
-func GetIBMCloudVMByTag(username, apiKey string, tags []string) (*int, error) {
-	c := client.GetClient(username, apiKey)
+func GetIBMCloudVMByTag(c client.API, tags []string) (*int, error) {
 	mask := "id,hostname,tagReferences[id,tag[name]]"
 	// Use the swarm ID as the filter
 	var filters *string
@@ -68,7 +67,7 @@ func GetIBMCloudVMByTag(username, apiKey string, tags []string) (*int, error) {
 			filters = &f
 		}
 	}
-	vms, err := c.GetVirtualGuests(username, apiKey, &mask, filters)
+	vms, err := c.GetVirtualGuests(&mask, filters)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Creates an `interface` for the backend API calls so that we can test the volume auth plugin and the terraform plugin's use of the client.

Creates a "fake" Softlayer client so that the data returned can be specified and the arguments tracked.

Lastly, this fixes the error handlings in the actual code (returning `nil` vs the error) that the new UT code detected.