### PR TITLE
Use node version ID during manager drain

### DIFF
--- a/pkg/plugin/flavor/swarm/manager.go
+++ b/pkg/plugin/flavor/swarm/manager.go
@@ -113,20 +113,12 @@ func (s *ManagerFlavor) Drain(flavorProperties *types.Any, inst instance.Descrip
 		// Do a swarm leave if and only if this is a manager
 
 		nodeID := nodes[0].ID
-
-		// first read the swarm version which is needed to update node
-		sw, err := dockerClient.SwarmInspect(ctx)
-		if err != nil {
-			return err
-		}
-
-		version := sw.ClusterInfo.Meta.Version
-
-		// then read the state of the node
+		// read the state of the node, getting the current version
 		nodeInfo, _, err := dockerClient.NodeInspectWithRaw(ctx, nodeID)
 		if err != nil {
 			return err
 		}
+		version := nodeInfo.Version
 
 		if nodeInfo.Spec.Role != swarm.NodeRoleManager {
 			return fmt.Errorf("not a manager: %v", nodeID)

--- a/pkg/plugin/flavor/swarm/manager_test.go
+++ b/pkg/plugin/flavor/swarm/manager_test.go
@@ -30,12 +30,11 @@ func TestManagerDrain(t *testing.T) {
 		return client, nil
 	}, templ(DefaultManagerInitScriptTemplate), managerStop, &self)
 
-	version := swarm.Version{Index: uint64(9999)}
 	swarmInfo := swarm.Swarm{
 		ClusterInfo: swarm.ClusterInfo{
 			ID: "ClusterUUID",
 			Meta: swarm.Meta{
-				Version: version,
+				Version: swarm.Version{Index: uint64(9999)},
 			},
 		},
 		JoinTokens: swarm.JoinTokens{
@@ -79,6 +78,7 @@ func TestManagerDrain(t *testing.T) {
 
 	// Do a drain
 	swarmNodeID := "swarm-id-1"
+	swarmNodeVersion := swarm.Version{Index: uint64(1234)}
 	client.EXPECT().NodeList(gomock.Any(),
 		docker_types.NodeListOptions{Filters: filter}).Return(
 		[]swarm.Node{
@@ -89,11 +89,12 @@ func TestManagerDrain(t *testing.T) {
 		swarm.Node{
 			ID:   swarmNodeID,
 			Spec: swarm.NodeSpec{Role: swarm.NodeRoleManager},
+			Meta: swarm.Meta{Version: swarmNodeVersion},
 		},
 		nil,
 		nil,
 	)
-	client.EXPECT().NodeUpdate(gomock.Any(), swarmNodeID, version, swarm.NodeSpec{Role: swarm.NodeRoleWorker}).Return(nil)
+	client.EXPECT().NodeUpdate(gomock.Any(), swarmNodeID, swarmNodeVersion, swarm.NodeSpec{Role: swarm.NodeRoleWorker}).Return(nil)
 
 	// Because this is the self node....
 	client.EXPECT().SwarmLeave(gomock.Any(), true)


### PR DESCRIPTION
Currently the **swarm** version is passed when issuing the `NodeUpdate`, resulting in:
```
EROR[02-01|21:23:15] Failed to drain
err="Error response from daemon: rpc error: code = 2 desc = update out of sequence"
```

The fix is to use the **node** version.