### PR TITLE
Expose Destroy error during rolling updates

### DIFF
--- a/pkg/plugin/group/rollingupdate.go
+++ b/pkg/plugin/group/rollingupdate.go
@@ -200,7 +200,10 @@ func (r *rollingupdate) Run(pollInterval time.Duration) error {
 		// TODO(wfarner): Make the 'batch size' configurable.
 		if canDestroy(undesiredInstances[0], r.updatingFrom) {
 			// we do not self-destruct in any cases.
-			r.scaled.Destroy(undesiredInstances[0], instance.RollingUpdate)
+			if err := r.scaled.Destroy(undesiredInstances[0], instance.RollingUpdate); err != nil {
+				log.Warn("Failed to destroy instance during rolling update", "ID", undesiredInstances[0].ID, "err", err)
+				return err
+			}
 		}
 
 		// Increment new instance count to replace the node that was just destroyed

--- a/pkg/plugin/group/testplugin.go
+++ b/pkg/plugin/group/testplugin.go
@@ -74,7 +74,9 @@ func (d *testplugin) Destroy(id instance.ID, ctx instance.Context) error {
 	if !exists {
 		return errors.New("Instance does not exist")
 	}
-
+	if _, has := spec.Tags["DestroyError"]; has {
+		return errors.New("DestroyError")
+	}
 	delete(d.instances, id)
 
 	d.destroyed = append(d.destroyed, spec)


### PR DESCRIPTION
Currently, when the instance `Destroy` fails, the error does not stop the loop that is waiting for the group is quiese. The loop then will never terminate because no replacment instance will ever be `Provision`'d because the `Destroy` failed.

The fix is to expose the `Destroy` error so that the loop is terminated.

This also updates the UT flow to use custom tag values to denote when the test plugin should return an error.
