### PR TITLE
Use instance hash to determine rolling update members

### DIFF
--- a/pkg/plugin/group/integration_test.go
+++ b/pkg/plugin/group/integration_test.go
@@ -319,7 +319,7 @@ func TestLeaderSelfRollingUpdatePolicyLast(t *testing.T) {
 	// is part of the group that is being updated
 	self := &leaderIDs[0]
 
-	// leader self rolling update should not destroy the running leader itself
+	// leader self rolling update should destroy itself (last)
 	plugin := newTestInstancePlugin(
 		newFakeInstanceDefault(leaders, &leaderIDs[0]),
 		newFakeInstanceDefault(leaders, &leaderIDs[1]),
@@ -417,11 +417,12 @@ func TestLeaderSelfRollingUpdatePolicyNever(t *testing.T) {
 
 	desc, err := grp.CommitGroup(updated, true) // pretend only
 	require.NoError(t, err)
-	require.Equal(t, "Performing a rolling update on 3 instances", desc)
+	// Only on 2 instances since we cannot update self
+	require.Equal(t, "Performing a rolling update on 2 instances", desc)
 
 	desc, err = grp.CommitGroup(updated, false)
 	require.NoError(t, err)
-	require.Equal(t, "Performing a rolling update on 3 instances", desc)
+	require.Equal(t, "Performing a rolling update on 2 instances", desc)
 
 	awaitGroupConvergence(t, grp)
 

--- a/pkg/plugin/group/scaler.go
+++ b/pkg/plugin/group/scaler.go
@@ -55,25 +55,14 @@ func (s *scaler) PlanUpdate(scaled Scaled, settings groupSettings, newSettings g
 	switch {
 	case sizeChange == 0:
 		rollCount := len(undesired)
-
 		if rollCount == 0 {
-			if settings.config.InstanceHash() == newSettings.config.InstanceHash() {
-
-				// This is a no-op update because:
-				//  - the instance configuration is unchanged
-				//  - the group contains no instances with an undesired state
-				//  - the group size is unchanged
-				return &noopUpdate{}, nil
-			}
-
-			// This case likely occurs because a group was created in a way that no instances are being
-			// created. We proceed with the update here, which will likely only change the target
-			// configuration in the scaler.
-
-			plan.desc = "Adjusting the instance configuration, no restarts necessary"
-			return &plan, nil
+			// This is a no-op update because:
+			//  - the instance configuration is unchanged
+			//  - the group contains no instances with an undesired state
+			//  - the group size is unchanged
+			return &noopUpdate{}, nil
 		}
-
+		// Perform a rolling update on the instances that do not match the desired
 		plan.desc = fmt.Sprintf("Performing a rolling update on %d instances", rollCount)
 
 	case sizeChange < 0:


### PR DESCRIPTION
The group hash is committed at the beginning of the update cycle, it it not guaranteed to reflect that actual instance hash of all members. During an update we cannot rely on the group hash to determine if any instances need to be updated; we need to check the instance hash on each member.