### PR TITLE
Issue second group commit on manager leadership change

### DIFF
--- a/pkg/manager/manager.go
+++ b/pkg/manager/manager.go
@@ -439,9 +439,6 @@ func (m *manager) onLostLeadership() error {
 }
 
 func (m *manager) doCommitAll(config globalSpec) error {
-	// Exec the plugins with groupReQueue=true since the initial group commit
-	// only defines the group. Once all groups are defined then issue another
-	// commit to handle any updates that have not completed
 	return m.execPlugins(config,
 		func(control controller.Controller, spec types.Spec) (bool, error) {
 
@@ -459,7 +456,10 @@ func (m *manager) doCommitAll(config globalSpec) error {
 			}
 			return true, err
 		},
-		true)
+		true) // Exec the plugins with groupRequeue=true since the initial group
+	// commit only defines the group. Once all groups are defined then issue
+	// another commit to handle any updates that have not completed (occurs
+	// if there in a update and leadership changes)
 }
 
 func (m *manager) doFreeAll(config globalSpec) error {

--- a/pkg/manager/manager_test.go
+++ b/pkg/manager/manager_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"sync"
 	"testing"
 	"time"
 
@@ -260,7 +261,9 @@ func TestChangeLeadership(t *testing.T) {
 	checkpoint1 := make(chan struct{})
 	checkpoint2 := make(chan struct{})
 	checkpoint3 := make(chan struct{})
+	lock := sync.Mutex{}
 
+	commitCountMgr1 := 0
 	manager1, stoppable1 := testEnsemble(t, testDiscoveryDir(t), "m1", leaderChans[0], ctrl,
 		func(s *store_mock.MockSnapshot) {
 			empty := &[]entry{}
@@ -279,14 +282,19 @@ func TestChangeLeadership(t *testing.T) {
 		func(g *group_mock.MockPlugin) {
 			g.EXPECT().CommitGroup(gomock.Any(), false).Do(
 				func(spec group.Spec, pretend bool) (string, error) {
-
-					defer close(checkpoint1)
+					// Close the checkout channel after the 2nd commit
+					lock.Lock()
+					defer lock.Unlock()
+					commitCountMgr1++
+					if commitCountMgr1 == 2 {
+						defer close(checkpoint1)
+					}
 
 					require.Equal(t, gs.ID, spec.ID)
 					require.Equal(t, testToStruct(gs.Properties), testToStruct(spec.Properties))
 					return "ok", nil
 				},
-			).Return("ok", nil)
+			).Return("ok", nil).Times(2)
 
 			// We will get a call to inspect what's being watched
 			g.EXPECT().InspectGroups().Return([]group.Spec{gs}, nil)
@@ -301,6 +309,8 @@ func TestChangeLeadership(t *testing.T) {
 				},
 			).Return(nil)
 		})
+
+	commitCountMgr2 := 0
 	manager2, stoppable2 := testEnsemble(t, testDiscoveryDir(t), "m2", leaderChans[1], ctrl,
 		func(s *store_mock.MockSnapshot) {
 			empty := &[]entry{}
@@ -319,14 +329,19 @@ func TestChangeLeadership(t *testing.T) {
 		func(g *group_mock.MockPlugin) {
 			g.EXPECT().CommitGroup(gomock.Any(), false).Do(
 				func(spec group.Spec, pretend bool) (string, error) {
-
-					defer close(checkpoint2)
+					// Close the checkout channel after the 2nd commit
+					lock.Lock()
+					defer lock.Unlock()
+					commitCountMgr2++
+					if commitCountMgr2 == 2 {
+						defer close(checkpoint2)
+					}
 
 					require.Equal(t, gs.ID, spec.ID)
 					require.Equal(t, testToStruct(gs.Properties), testToStruct(spec.Properties))
 					return "ok", nil
 				},
-			).Return("ok", nil)
+			).Return("ok", nil).Times(2)
 		})
 
 	manager1.Start()


### PR DESCRIPTION
Currently, the groups are committed on manager leadership change; this initial commit simply starts the group polling. A second commit is needed to complete and in progress updates (for example, completing a rolling update on a quorum group when leadership changes to a new manager).