### PR TITLE
Wait for node to be healthy for a period of time during update

### DIFF
--- a/pkg/controller/group/rollingupdate_test.go
+++ b/pkg/controller/group/rollingupdate_test.go
@@ -1,0 +1,73 @@
+package group
+
+import (
+	"testing"
+	"time"
+
+	group_types "github.com/docker/infrakit/pkg/controller/group/types"
+	"github.com/docker/infrakit/pkg/types"
+	"github.com/stretchr/testify/require"
+)
+
+func TestExceedsHealthyThresholdNoNewInsts(t *testing.T) {
+	// Count does not matter since there are no instances
+	five := 5
+	counts := updatingCount{healthyCount: &five}
+	require.True(t, exceedsHealthyThreshold(group_types.Updating{Count: 10}, 0, &counts))
+	require.Equal(t, updatingCount{healthyCount: &five}, counts)
+}
+
+func TestExceedsHealthyThresholdDefaults(t *testing.T) {
+	// Default (nil) values
+	counts := updatingCount{}
+	require.True(t, exceedsHealthyThreshold(group_types.Updating{}, 1, &counts))
+	require.Equal(t, updatingCount{}, counts)
+
+	// Explicit 0 count
+	zero := 0
+	counts = updatingCount{healthyCount: &zero}
+	require.True(t, exceedsHealthyThreshold(group_types.Updating{}, 1, &counts))
+	require.Equal(t, updatingCount{healthyCount: &zero}, counts)
+}
+
+func TestExceedsHealthyThresholdCount(t *testing.T) {
+	// Only healthy on the 3 count value
+	counts := updatingCount{}
+	require.False(t, exceedsHealthyThreshold(group_types.Updating{Count: 3}, 3, &counts))
+	one := 1
+	require.Equal(t, updatingCount{healthyCount: &one}, counts)
+
+	require.False(t, exceedsHealthyThreshold(group_types.Updating{Count: 3}, 3, &counts))
+	two := 2
+	require.Equal(t, updatingCount{healthyCount: &two}, counts)
+
+	require.True(t, exceedsHealthyThreshold(group_types.Updating{Count: 3}, 3, &counts))
+	three := 3
+	require.Equal(t, updatingCount{healthyCount: &three}, counts)
+}
+
+func TestExceedsHealthyThresholdDuration(t *testing.T) {
+	// Timestamp should be set the first time
+	counts := updatingCount{}
+	require.False(t, exceedsHealthyThreshold(group_types.Updating{
+		Duration: types.FromDuration(3 * time.Second)}, 3, &counts))
+	require.Nil(t, counts.healthyCount)
+	require.NotNil(t, counts.healthyTs)
+
+	// Change the timestamp to be a second before the threshold, should
+	// not be healthy
+	ts := time.Now().Add(-2 * time.Second)
+	counts.healthyTs = &ts
+	require.False(t, exceedsHealthyThreshold(group_types.Updating{
+		Duration: types.FromDuration(3 * time.Second)}, 3, &counts))
+	require.Nil(t, counts.healthyCount)
+	require.Equal(t, *counts.healthyTs, ts)
+
+	// Change the timestamp to at the threshold, should be healthy
+	ts = time.Now().Add(-3 * time.Second)
+	counts.healthyTs = &ts
+	require.True(t, exceedsHealthyThreshold(group_types.Updating{
+		Duration: types.FromDuration(3 * time.Second)}, 3, &counts))
+	require.Nil(t, counts.healthyCount)
+	require.Equal(t, *counts.healthyTs, ts)
+}

--- a/pkg/controller/group/scaler.go
+++ b/pkg/controller/group/scaler.go
@@ -125,7 +125,7 @@ func (s scalerUpdatePlan) Explain() string {
 	return s.desc
 }
 
-func (s scalerUpdatePlan) Run(pollInterval time.Duration) error {
+func (s scalerUpdatePlan) Run(pollInterval time.Duration, updating group_types.Updating) error {
 
 	// If the number of instances is being decreased, first lower the group size.  This eliminates
 	// instances that would otherwise be rolled first, avoiding unnecessary work.
@@ -135,7 +135,7 @@ func (s scalerUpdatePlan) Run(pollInterval time.Duration) error {
 		s.scaler.SetSize(s.newSize)
 	}
 
-	if err := s.rollingPlan.Run(pollInterval); err != nil {
+	if err := s.rollingPlan.Run(pollInterval, updating); err != nil {
 		return err
 	}
 

--- a/pkg/controller/group/types/types.go
+++ b/pkg/controller/group/types/types.go
@@ -109,6 +109,17 @@ type Spec struct {
 	Instance   InstancePlugin
 	Flavor     FlavorPlugin
 	Allocation group.AllocationMethod
+	Updating   Updating
+}
+
+// Updating is the configuration schema using on a rolling update and defines how long
+// a node must be healthy before the next node is updated. If Duration is set then the
+// node must be healthy for at least the specified time. If Count is set then the
+// node must be healthy for specified number of poll intervals. Both Duration and Count
+// cannot be non 0.
+type Updating struct {
+	Duration types.Duration
+	Count    int
 }
 
 // // AllocationMethod defines the type of allocation and supervision needed by a flavor's Group.


### PR DESCRIPTION
Adds a new `Updating` struct on the `group.Spec`:
```
type Updating struct {
	Duration types.Duration
	Count    int
}
```
This defines how long a node needs to be healthy on a rolling update before the update is applied to the next node in the group.