### PR TITLE
Clear terraform instance cache when not running on leader

### DIFF
--- a/pkg/provider/terraform/instance/apply.go
+++ b/pkg/provider/terraform/instance/apply.go
@@ -232,7 +232,7 @@ func (p *plugin) hasRecentDeltas(window int) (bool, error) {
 		}
 		logger.Info("hasRecentDeltas",
 			"msg",
-			fmt.Sprintf("Terraform file updates are within %v seconds (delta=%v)", window, now.Sub(modTime)))
+			fmt.Sprintf("Terraform file updates are outside %v seconds (delta=%v)", window, now.Sub(modTime)))
 	}
 	return false, nil
 }

--- a/pkg/provider/terraform/instance/apply_test.go
+++ b/pkg/provider/terraform/instance/apply_test.go
@@ -31,8 +31,9 @@ func TestRunTerraformApply(t *testing.T) {
 		Dir:          dir,
 		PollInterval: types.FromDuration(2 * time.Minute),
 	}
-	terraform, err := NewTerraformInstancePlugin(options, nil)
+	terraform, err := NewTerraformInstancePlugin(options, nil, false)
 	require.NoError(t, err)
+	require.False(t, terraform.(*plugin).pretend)
 	p, _ := terraform.(*plugin)
 	err = p.doTerraformApply()
 	require.NoError(t, err)
@@ -47,7 +48,7 @@ func TestContinuePollingStandalone(t *testing.T) {
 		Standalone:   true,
 		PollInterval: types.FromDuration(2 * time.Minute),
 	}
-	terraform, err := NewTerraformInstancePlugin(options, nil)
+	terraform, err := NewTerraformInstancePlugin(options, nil, false)
 	require.NoError(t, err)
 	p, _ := terraform.(*plugin)
 	shoudApply := p.shouldApply()

--- a/pkg/provider/terraform/instance/cmd/main.go
+++ b/pkg/provider/terraform/instance/cmd/main.go
@@ -107,6 +107,7 @@ func main() {
 				InstanceSpec: importInstSpec,
 				Resources:    resources,
 			},
+			false,
 		)
 		if err != nil {
 			log.Error("error initializing pluing", "err", err)

--- a/pkg/provider/terraform/instance/plugin.go
+++ b/pkg/provider/terraform/instance/plugin.go
@@ -109,7 +109,7 @@ type ImportOptions struct {
 }
 
 // NewTerraformInstancePlugin returns an instance plugin backed by disk files.
-func NewTerraformInstancePlugin(options terraform_types.Options, importOpts *ImportOptions) (instance.Plugin, error) {
+func NewTerraformInstancePlugin(options terraform_types.Options, importOpts *ImportOptions, pretend bool) (instance.Plugin, error) {
 	logger.Info("NewTerraformInstancePlugin", "dir", options.Dir)
 
 	var pluginLookup func() discovery.Plugins
@@ -139,6 +139,7 @@ func NewTerraformInstancePlugin(options terraform_types.Options, importOpts *Imp
 		pollInterval: options.PollInterval.Duration(),
 		pluginLookup: pluginLookup,
 		envs:         envs,
+		pretend:      pretend,
 	}
 	if err := p.processImport(importOpts); err != nil {
 		panic(err)

--- a/pkg/provider/terraform/instance/plugin_test.go
+++ b/pkg/provider/terraform/instance/plugin_test.go
@@ -66,23 +66,23 @@ func TestEnvs(t *testing.T) {
 		PollInterval: types.FromDuration(2 * time.Minute),
 		Envs:         *types.AnyString(`["k1=v1", "keyval"]`),
 	}
-	_, err = NewTerraformInstancePlugin(options, nil)
+	_, err = NewTerraformInstancePlugin(options, nil, true)
 	require.Error(t, err)
 
 	options.Envs = *types.AnyString(`["k1=v1", "k2=v2"]`)
-	tf, err := NewTerraformInstancePlugin(options, nil)
+	tf, err := NewTerraformInstancePlugin(options, nil, true)
 	require.NoError(t, err)
 	p, _ := tf.(*plugin)
 	require.Equal(t, []string{"k1=v1", "k2=v2"}, p.envs)
 
 	options.Envs = *types.AnyString("")
-	tf, err = NewTerraformInstancePlugin(options, nil)
+	tf, err = NewTerraformInstancePlugin(options, nil, true)
 	require.NoError(t, err)
 	p, _ = tf.(*plugin)
 	require.Equal(t, []string{}, p.envs)
 
 	options.Envs = nil
-	tf, err = NewTerraformInstancePlugin(options, nil)
+	tf, err = NewTerraformInstancePlugin(options, nil, true)
 	require.NoError(t, err)
 	p, _ = tf.(*plugin)
 	require.Equal(t, []string{}, p.envs)
@@ -97,9 +97,9 @@ func getPlugin(t *testing.T) (*plugin, string) {
 		Dir:          dir,
 		PollInterval: types.FromDuration(2 * time.Minute),
 	}
-	tf, err := NewTerraformInstancePlugin(options, nil)
+	tf, err := NewTerraformInstancePlugin(options, nil, true)
 	require.NoError(t, err)
-	tf.(*plugin).pretend = true
+	require.True(t, tf.(*plugin).pretend)
 	p, is := tf.(*plugin)
 	require.True(t, is)
 	return p, dir
@@ -119,9 +119,9 @@ func getPluginDirNotExists(t *testing.T) (*plugin, string) {
 		Dir:          dir,
 		PollInterval: types.FromDuration(2 * time.Minute),
 	}
-	tf, err := NewTerraformInstancePlugin(options, nil)
+	tf, err := NewTerraformInstancePlugin(options, nil, true)
 	require.NoError(t, err)
-	tf.(*plugin).pretend = true
+	require.True(t, tf.(*plugin).pretend)
 	p, is := tf.(*plugin)
 	require.True(t, is)
 	return p, dir
@@ -140,9 +140,9 @@ func getPluginDirNoPerms(t *testing.T) (*plugin, string) {
 		Dir:          dir,
 		PollInterval: types.FromDuration(2 * time.Minute),
 	}
-	tf, err := NewTerraformInstancePlugin(options, nil)
+	tf, err := NewTerraformInstancePlugin(options, nil, true)
 	require.NoError(t, err)
-	tf.(*plugin).pretend = true
+	require.True(t, tf.(*plugin).pretend)
 	p, is := tf.(*plugin)
 	require.True(t, is)
 	return p, dir

--- a/pkg/provider/terraform/instance/plugin_test.go
+++ b/pkg/provider/terraform/instance/plugin_test.go
@@ -163,7 +163,9 @@ func writeFileRaw(p *plugin, filename string, buff []byte) error {
 		return err
 	}
 	// Now that the file is written out we need to clear the cache
+	p.fsLock.Lock()
 	p.clearCachedInstances()
+	defer p.fsLock.Unlock()
 	return nil
 }
 
@@ -5447,7 +5449,9 @@ func TestCache(t *testing.T) {
 	require.Equal(t, []instance.Description{expectedInstDesc}, insts)
 
 	// Now clear it
+	tf.fsLock.Lock()
 	tf.clearCachedInstances()
+	tf.fsLock.Unlock()
 	require.True(t, tf.isCacheNil())
 
 	// Refresh, no files

--- a/pkg/run/v0/terraform/terraform.go
+++ b/pkg/run/v0/terraform/terraform.go
@@ -91,6 +91,7 @@ func Run(scope scope.Scope, name plugin.Name,
 			InstanceSpec: importInstSpec,
 			Resources:    resources,
 		},
+		false,
 	)
 	if err != nil {
 		log.Error("error initializing pluing", "err", err)


### PR DESCRIPTION
- If the tf plugin is not running on the leader then the cached instances may not be valid. We need to clear the cache whenever we detect that we are not running on the leader.
- Also fixes the locking when clearing the cache after the initial apply (the write lock is needed when clearing).
- Update tf log message for file deltas outside window.
- Update UT to prevent the `terraform apply` polling loop from running since it's asynchronous nature creates race conditions in the tests.