### PR TITLE
Remove config.hash=bootstrap tag on imported tf VM

### DIFF
--- a/pkg/provider/terraform/instance/types/types.go
+++ b/pkg/provider/terraform/instance/types/types.go
@@ -117,10 +117,7 @@ func (o Options) ParseInstanceSpecFromGroup(scope scope.Scope) (*instance.Spec, 
 		return nil, err
 	}
 
-	// Add in the bootstrap tag and (if set) the group ID
-	tags := map[string]string{
-		group.ConfigSHATag: "bootstrap",
-	}
+	tags := map[string]string{}
 	// The group ID should match the spec
 	if o.ImportGroupID != "" {
 		if string(groupSpec.ID) != o.ImportGroupID {

--- a/pkg/provider/terraform/instance/types/types_test.go
+++ b/pkg/provider/terraform/instance/types/types_test.go
@@ -103,8 +103,7 @@ func TestParseInstanceSpecFromGroup(t *testing.T) {
 		instance.Spec{
 			Properties: types.AnyString(`{"resource": {"aws_instance": {}}}`),
 			Tags: map[string]string{
-				group.ConfigSHATag: "bootstrap",
-				group.GroupTag:     groupID,
+				group.GroupTag: groupID,
 			},
 		},
 		*instSpec)
@@ -134,7 +133,6 @@ func TestParseInstanceSpecFromGroupLogicalID(t *testing.T) {
 		instance.Spec{
 			Properties: types.AnyString(`{"resource": {"aws_instance": {}}}`),
 			Tags: map[string]string{
-				group.ConfigSHATag:    "bootstrap",
 				group.GroupTag:        groupID,
 				instance.LogicalIDTag: "mgr1",
 			},
@@ -161,9 +159,7 @@ func TestParseInstanceSpecFromGroupNoGroupIDSpecified(t *testing.T) {
 	require.Equal(t,
 		instance.Spec{
 			Properties: types.AnyString(`{"resource": {"aws_instance": {}}}`),
-			Tags: map[string]string{
-				group.ConfigSHATag: "bootstrap",
-			},
+			Tags:       map[string]string{},
 		},
 		*instSpec)
 }


### PR DESCRIPTION
We want to keep the import flow generic. Currently, the tf plugin assumes that the VM being imported is the initial manager and it sets the `infrakit.config.hash=bootstrap` tag. Instead of doing this in the plugin, the initial VM should simply be created with this tag; this is consistent with how the `infrakit-link=bootstrap` tag needs to be set.
