### PR TITLE
Remove Flavor Options.Self

### DIFF
--- a/pkg/plugin/flavor/swarm/flavor.go
+++ b/pkg/plugin/flavor/swarm/flavor.go
@@ -69,24 +69,10 @@ func DockerClient(spec Spec) (docker.APIClientCloser, error) {
 
 // baseFlavor is the base implementation.  The manager / worker implementations will provide override.
 type baseFlavor struct {
-	self            *instance.LogicalID
 	getDockerClient func(Spec) (docker.APIClientCloser, error)
 	initScript      *template.Template
 	metadataPlugin  metadata.Plugin
 	scope           scope.Scope
-}
-
-// isSelf determines if the code is being executed on the given instance
-func (s *baseFlavor) isSelf(inst instance.Description) bool {
-	if s.self != nil {
-		if inst.LogicalID != nil && *inst.LogicalID == *s.self {
-			return true
-		}
-		if v, has := inst.Tags[instance.LogicalIDTag]; has {
-			return string(*s.self) == v
-		}
-	}
-	return false
 }
 
 // Runs a poller that periodically samples the swarm status and node info.

--- a/pkg/plugin/flavor/swarm/flavor_test.go
+++ b/pkg/plugin/flavor/swarm/flavor_test.go
@@ -43,10 +43,9 @@ func TestValidate(t *testing.T) {
 	managerStop := make(chan struct{})
 	workerStop := make(chan struct{})
 
-	self := instance.LogicalID("172.164.100.101")
 	managerFlavor := NewManagerFlavor(scp, func(Spec) (docker.APIClientCloser, error) {
 		return mock_client.NewMockAPIClientCloser(ctrl), nil
-	}, templ(DefaultManagerInitScriptTemplate), managerStop, &self)
+	}, templ(DefaultManagerInitScriptTemplate), managerStop)
 	workerFlavor := NewWorkerFlavor(scp, func(Spec) (docker.APIClientCloser, error) {
 		return mock_client.NewMockAPIClientCloser(ctrl), nil
 	}, templ(DefaultWorkerInitScriptTemplate), workerStop)
@@ -202,14 +201,13 @@ func TestManager(t *testing.T) {
 	defer ctrl.Finish()
 
 	selfAddr := "1.2.3.4"
-	self := instance.LogicalID(selfAddr)
 	managerStop := make(chan struct{})
 
 	client := mock_client.NewMockAPIClientCloser(ctrl)
 
 	flavorImpl := NewManagerFlavor(scp, func(Spec) (docker.APIClientCloser, error) {
 		return client, nil
-	}, templ(DefaultManagerInitScriptTemplate), managerStop, &self)
+	}, templ(DefaultManagerInitScriptTemplate), managerStop)
 
 	swarmInfo := swarm.Swarm{
 		ClusterInfo: swarm.ClusterInfo{ID: "ClusterUUID"},
@@ -373,15 +371,13 @@ func TestTemplateFunctions(t *testing.T) {
 	defer ctrl.Finish()
 
 	selfAddr := "1.2.3.4"
-	self := instance.LogicalID(selfAddr)
-
 	managerStop := make(chan struct{})
 
 	client := mock_client.NewMockAPIClientCloser(ctrl)
 
 	flavorImpl := NewManagerFlavor(scp, func(Spec) (docker.APIClientCloser, error) {
 		return client, nil
-	}, templ(DefaultManagerInitScriptTemplate), managerStop, &self)
+	}, templ(DefaultManagerInitScriptTemplate), managerStop)
 
 	swarmInfo := swarm.Swarm{
 		ClusterInfo: swarm.ClusterInfo{ID: "ClusterUUID"},
@@ -428,7 +424,7 @@ func TestInitScriptMultipass(t *testing.T) {
 
 	flavorImpl := NewManagerFlavor(scp, func(Spec) (docker.APIClientCloser, error) {
 		return client, nil
-	}, templ(DefaultManagerInitScriptTemplate), managerStop, nil)
+	}, templ(DefaultManagerInitScriptTemplate), managerStop)
 
 	client.EXPECT().SwarmInspect(gomock.Any()).Return(swarm.Swarm{}, nil).AnyTimes()
 	client.EXPECT().Info(gomock.Any()).Return(infoResponse, nil).AnyTimes()

--- a/pkg/plugin/flavor/swarm/manager.go
+++ b/pkg/plugin/flavor/swarm/manager.go
@@ -20,9 +20,9 @@ import (
 // NewManagerFlavor creates a flavor.Plugin that creates manager and worker nodes connected in a swarm.
 func NewManagerFlavor(scope scope.Scope, connect func(Spec) (docker.APIClientCloser, error),
 	templ *template.Template,
-	stop <-chan struct{}, self *instance.LogicalID) *ManagerFlavor {
+	stop <-chan struct{}) *ManagerFlavor {
 
-	base := &baseFlavor{initScript: templ, getDockerClient: connect, scope: scope, self: self}
+	base := &baseFlavor{initScript: templ, getDockerClient: connect, scope: scope}
 	base.metadataPlugin = metadata.NewPluginFromChannel(base.runMetadataSnapshot(stop))
 	return &ManagerFlavor{baseFlavor: base}
 }

--- a/pkg/plugin/flavor/swarm/manager_test.go
+++ b/pkg/plugin/flavor/swarm/manager_test.go
@@ -28,7 +28,7 @@ func TestManagerDrain(t *testing.T) {
 
 	flavorImpl := NewManagerFlavor(scp, func(Spec) (docker.APIClientCloser, error) {
 		return client, nil
-	}, templ(DefaultManagerInitScriptTemplate), managerStop, &self)
+	}, templ(DefaultManagerInitScriptTemplate), managerStop)
 
 	swarmInfo := swarm.Swarm{
 		ClusterInfo: swarm.ClusterInfo{
@@ -111,7 +111,7 @@ func TestManagerDrainNotInSwarm(t *testing.T) {
 
 	flavorImpl := NewManagerFlavor(scp, func(Spec) (docker.APIClientCloser, error) {
 		return client, nil
-	}, templ(DefaultManagerInitScriptTemplate), managerStop, &self)
+	}, templ(DefaultManagerInitScriptTemplate), managerStop)
 
 	swarmInfo := swarm.Swarm{
 		ClusterInfo: swarm.ClusterInfo{
@@ -178,7 +178,7 @@ func TestManagerDrainNotManager(t *testing.T) {
 
 	flavorImpl := NewManagerFlavor(scp, func(Spec) (docker.APIClientCloser, error) {
 		return client, nil
-	}, templ(DefaultManagerInitScriptTemplate), managerStop, &self)
+	}, templ(DefaultManagerInitScriptTemplate), managerStop)
 
 	swarmInfo := swarm.Swarm{
 		ClusterInfo: swarm.ClusterInfo{

--- a/pkg/run/v0/swarm/swarm.go
+++ b/pkg/run/v0/swarm/swarm.go
@@ -6,10 +6,8 @@ import (
 	"github.com/docker/infrakit/pkg/plugin"
 	"github.com/docker/infrakit/pkg/plugin/flavor/swarm"
 	"github.com/docker/infrakit/pkg/run"
-	"github.com/docker/infrakit/pkg/run/local"
 	"github.com/docker/infrakit/pkg/run/scope"
 	"github.com/docker/infrakit/pkg/spi/flavor"
-	"github.com/docker/infrakit/pkg/spi/instance"
 	"github.com/docker/infrakit/pkg/spi/metadata"
 	"github.com/docker/infrakit/pkg/template"
 	"github.com/docker/infrakit/pkg/types"
@@ -43,24 +41,12 @@ type Options struct {
 	// This is overridden by the value provided in the spec.
 	WorkerInitScriptTemplate string
 
-	// Self is the logical ID of the node running this code.
-	Self *instance.LogicalID
-
 	// Docker is the connection info for the Docker client
 	Docker docker.ConnectInfo
 }
 
-func nilLogicalIDIfEmptyString(s string) *instance.LogicalID {
-	if s == "" {
-		return nil
-	}
-	id := instance.LogicalID(s)
-	return &id
-}
-
 // DefaultOptions return an Options with default values filled in.
 var DefaultOptions = Options{
-	Self: nilLogicalIDIfEmptyString(local.Getenv(EnvSelfLogicalID, "")),
 	Options: template.Options{
 		MultiPass: true,
 	},
@@ -92,7 +78,7 @@ func Run(scope scope.Scope, name plugin.Name,
 	managerStop := make(chan struct{})
 	workerStop := make(chan struct{})
 
-	managerFlavor := swarm.NewManagerFlavor(scope, swarm.DockerClient, mt, managerStop, options.Self)
+	managerFlavor := swarm.NewManagerFlavor(scope, swarm.DockerClient, mt, managerStop)
 	workerFlavor := swarm.NewWorkerFlavor(scope, swarm.DockerClient, wt, workerStop)
 	instancePlugin := swarm.NewInstancePlugin(swarm.DockerClient, options.Docker)
 


### PR DESCRIPTION
This value was only used when removing a manager node from the swarm and this function was removed in https://github.com/docker/infrakit/pull/859

Since the `Self` value is no longer needed, this commit removes the option.