### PR TITLE
Only invoke flavor "Drain" on self during rolling update

### DIFF
--- a/pkg/controller/group/group.go
+++ b/pkg/controller/group/group.go
@@ -388,3 +388,17 @@ func (p *gController) validate(config group.Spec) (groupSettings, error) {
 		config:         parsed,
 	}, nil
 }
+
+// isSelf returns true if the configured "self" LogicalID Option matches the
+// either the given instance's LogicalID or the associated logical ID tag
+func isSelf(inst instance.Description, settings groupSettings) bool {
+	if settings.self != nil {
+		if inst.LogicalID != nil && *inst.LogicalID == *settings.self {
+			return true
+		}
+		if v, has := inst.Tags[instance.LogicalIDTag]; has {
+			return string(*settings.self) == v
+		}
+	}
+	return false
+}

--- a/pkg/controller/group/integration_test.go
+++ b/pkg/controller/group/integration_test.go
@@ -933,21 +933,17 @@ func TestDestroyGroupSelfLast(t *testing.T) {
 
 	require.NoError(t, grp.DestroyGroup(minions.ID))
 
-	// 2 of the 3 should have been removed
+	// All instance should have been removed (since this is a group destroy)
 	instances, err := plugin.DescribeInstances(memberTags(minions.ID), false)
 	require.NoError(t, err)
-	require.Equal(t, 1, len(instances))
-	require.Equal(t, *self, *instances[0].LogicalID)
+	require.Equal(t, 0, len(instances))
 
-	// Everything drained but self should not have been destroyed
+	// Everything drained and destroyed
 	require.Len(t, flavorPlugin.drained, 3)
-	require.Len(t, plugin.destroyed, 2)
+	require.Len(t, plugin.destroyed, 3)
 
-	// Self should not have been removed
-	require.Len(t, plugin.destroyed, 2)
-	for _, d := range plugin.destroyed {
-		require.NotEqual(t, *self, *d.LogicalID)
-	}
+	// Self should have been removed last
+	require.Equal(t, *self, *plugin.destroyed[2].LogicalID)
 }
 
 func TestSuperviseQuorum(t *testing.T) {

--- a/pkg/controller/group/rollingupdate.go
+++ b/pkg/controller/group/rollingupdate.go
@@ -232,7 +232,7 @@ func (r *rollingupdate) Run(pollInterval time.Duration, updating group_types.Upd
 		// Never invoke the instance Destroy on "self", the group Destroy only invokes the flavor
 		// Drain. Since we will never get a replacement VM for "self" we need to exit the loop.
 		if isSelf(undesiredInstances[0], r.updatingFrom) {
-			log.Info("RollingUpdate-Run", "Terminating after Destroy self", "self", *undesiredInstances[0].LogicalID)
+			log.Info("Terminating update, current instance is all that remains", "self", *undesiredInstances[0].LogicalID)
 			return nil
 		}
 

--- a/pkg/controller/group/rollingupdate.go
+++ b/pkg/controller/group/rollingupdate.go
@@ -18,18 +18,6 @@ func minInt(a, b int) int {
 	return b
 }
 
-func isSelf(inst instance.Description, settings groupSettings) bool {
-	if settings.self != nil {
-		if inst.LogicalID != nil && *inst.LogicalID == *settings.self {
-			return true
-		}
-		if v, has := inst.Tags[instance.LogicalIDTag]; has {
-			return string(*settings.self) == v
-		}
-	}
-	return false
-}
-
 func desiredAndUndesiredInstances(
 	instances []instance.Description, settings groupSettings) ([]instance.Description, []instance.Description) {
 

--- a/pkg/controller/group/rollingupdate.go
+++ b/pkg/controller/group/rollingupdate.go
@@ -18,13 +18,6 @@ func minInt(a, b int) int {
 	return b
 }
 
-func selfUpdatePolicy(settings groupSettings) group_types.PolicyLeaderSelfUpdate {
-	if settings.options.PolicyLeaderSelfUpdate == nil {
-		return group_types.PolicyLeaderSelfUpdateLast // default policy
-	}
-	return *settings.options.PolicyLeaderSelfUpdate
-}
-
 func isSelf(inst instance.Description, settings groupSettings) bool {
 	if settings.self != nil {
 		if inst.LogicalID != nil && *inst.LogicalID == *settings.self {
@@ -35,15 +28,6 @@ func isSelf(inst instance.Description, settings groupSettings) bool {
 		}
 	}
 	return false
-}
-
-func canDestroy(inst instance.Description, settings groupSettings) bool {
-	if !isSelf(inst, settings) {
-		// not running on the same node, so ok to destroy
-		return true
-	}
-	// self update - never - means we'd never update the self node.
-	return selfUpdatePolicy(settings) != group_types.PolicyLeaderSelfUpdateNever
 }
 
 func desiredAndUndesiredInstances(
@@ -58,7 +42,7 @@ func desiredAndUndesiredInstances(
 		actualConfig, specified := inst.Tags[group.ConfigSHATag]
 		if specified && actualConfig == desiredHash {
 			desired = append(desired, inst)
-		} else if canDestroy(inst, settings) {
+		} else {
 			undesired = append(undesired, inst)
 		}
 	}
@@ -248,22 +232,20 @@ func (r *rollingupdate) Run(pollInterval time.Duration, updating group_types.Upd
 			break
 		}
 
-		// Sort instances first to ensure predictable destroy order.
+		// Sort instances first to ensure predictable destroy order (if "self" is set then it
+		// is always sorted last)
 		sort.Sort(sortByID{list: undesiredInstances, settings: &r.updatingFrom})
 
 		// TODO(wfarner): Make the 'batch size' configurable.
-		if canDestroy(undesiredInstances[0], r.updatingFrom) {
-			if err := r.scaled.Destroy(undesiredInstances[0], instance.RollingUpdate); err != nil {
-				log.Warn("Failed to destroy instance during rolling update", "ID", undesiredInstances[0].ID, "err", err)
-				return err
-			}
-			// We never invoke the instance Destroy on the "self", the group Destroy only
-			// invokes the flavor Drain. Since we will never get a replacement VM for "self"
-			// we need to exit the loop.
-			if isSelf(undesiredInstances[0], r.updatingFrom) {
-				log.Info("RollingUpdate-Run", "Terminating after Destroy self", "self", *undesiredInstances[0].LogicalID)
-				return nil
-			}
+		if err := r.scaled.Destroy(undesiredInstances[0], instance.RollingUpdate); err != nil {
+			log.Warn("Failed to destroy instance during rolling update", "ID", undesiredInstances[0].ID, "err", err)
+			return err
+		}
+		// Never invoke the instance Destroy on "self", the group Destroy only invokes the flavor
+		// Drain. Since we will never get a replacement VM for "self" we need to exit the loop.
+		if isSelf(undesiredInstances[0], r.updatingFrom) {
+			log.Info("RollingUpdate-Run", "Terminating after Destroy self", "self", *undesiredInstances[0].LogicalID)
+			return nil
 		}
 
 		// Increment new instance count to replace the node that was just destroyed

--- a/pkg/controller/group/scaled.go
+++ b/pkg/controller/group/scaled.go
@@ -126,6 +126,11 @@ func (s *scaledGroup) Destroy(inst instance.Description, ctx instance.Context) e
 		return err
 	}
 
+	// Do not destroy the current VM
+	if isSelf(inst, s.settings) {
+		log.Info("Not destroying self", "LogicalID", *inst.LogicalID)
+		return nil
+	}
 	log.Info("Destroying instance", "id", inst.ID)
 	if err := settings.instancePlugin.Destroy(inst.ID, ctx); err != nil {
 		log.Error("Failed to destroy instance", "id", inst.ID, "err", err)

--- a/pkg/controller/group/scaled.go
+++ b/pkg/controller/group/scaled.go
@@ -122,12 +122,16 @@ func (s *scaledGroup) Destroy(inst instance.Description, ctx instance.Context) e
 
 	flavorProperties := types.AnyCopy(settings.config.Flavor.Properties)
 	if err := settings.flavorPlugin.Drain(flavorProperties, inst); err != nil {
-		log.Error("Failed to drain", "id", inst.ID, "err", err)
-		return err
+		// Only error out on a rolling update
+		if ctx == instance.RollingUpdate {
+			log.Error("Failed to drain", "id", inst.ID, "err", err)
+			return err
+		}
+		log.Warn("Failed to drain, processing with termination", "id", inst.ID, "err", err)
 	}
 
-	// Do not destroy the current VM
-	if isSelf(inst, s.settings) {
+	// Do not destroy the current VM during a rolling update
+	if ctx == instance.RollingUpdate && isSelf(inst, s.settings) {
 		log.Info("Not destroying self", "LogicalID", *inst.LogicalID)
 		return nil
 	}

--- a/pkg/controller/group/state.go
+++ b/pkg/controller/group/state.go
@@ -126,7 +126,7 @@ func (n sortByID) Swap(i, j int) {
 }
 
 func (n sortByID) Less(i, j int) bool {
-	if n.settings != nil && selfUpdatePolicy(*n.settings) == types.PolicyLeaderSelfUpdateLast {
+	if n.settings != nil {
 		if isSelf(n.list[i], *n.settings) {
 			return false
 		}

--- a/pkg/controller/group/state_test.go
+++ b/pkg/controller/group/state_test.go
@@ -41,10 +41,8 @@ func TestSortByID(t *testing.T) {
 
 		sort.Sort(sortByID{list: list,
 			settings: &groupSettings{
-				self: logicalID("1"),
-				options: group_types.Options{
-					PolicyLeaderSelfUpdate: &group_types.PolicyLeaderSelfUpdateLast,
-				}}})
+				self:    logicalID("1"),
+				options: group_types.Options{}}})
 
 		require.Equal(t,
 			[]instance.Description{
@@ -66,10 +64,8 @@ func TestSortByID(t *testing.T) {
 
 		sort.Sort(sortByID{list: list,
 			settings: &groupSettings{
-				self: logicalID("3"),
-				options: group_types.Options{
-					PolicyLeaderSelfUpdate: &group_types.PolicyLeaderSelfUpdateLast,
-				}}})
+				self:    logicalID("3"),
+				options: group_types.Options{}}})
 
 		require.Equal(t,
 			[]instance.Description{
@@ -97,10 +93,8 @@ func TestSortByID(t *testing.T) {
 
 		sort.Sort(sortByID{list: list,
 			settings: &groupSettings{
-				self: logicalID("1"),
-				options: group_types.Options{
-					PolicyLeaderSelfUpdate: &group_types.PolicyLeaderSelfUpdateLast,
-				}}})
+				self:    logicalID("1"),
+				options: group_types.Options{}}})
 
 		require.Equal(t,
 			[]instance.Description{

--- a/pkg/controller/group/types/types.go
+++ b/pkg/controller/group/types/types.go
@@ -35,10 +35,6 @@ type Options struct {
 
 	// PollIntervalGroupDetail polls for group details at this interval to update the metadata paths
 	PollIntervalGroupDetail types.Duration
-
-	// PolicyLeaderSelfUpdate sets the policy for updating self when the node is the leader.
-	// If not specified, it defaults to 'last'
-	PolicyLeaderSelfUpdate *PolicyLeaderSelfUpdate
 }
 
 // ResolveDependencies returns a list of dependencies by parsing the opaque Properties blob.
@@ -218,45 +214,4 @@ func (c Spec) InstanceHash() string {
 	// Remove extra padding
 	encoded = strings.TrimRight(encoded, "=")
 	return encoded
-}
-
-// PolicyLeaderSelfUpdate is the policy for leader updating self during a rolling update.
-// Two values are possible: never or last
-type PolicyLeaderSelfUpdate string
-
-var (
-	// PolicyLeaderSelfUpdateNever is the policy that the leader never destroy itself
-	// during a rolling update
-	PolicyLeaderSelfUpdateNever = PolicyLeaderSelfUpdate("never")
-
-	// PolicyLeaderSelfUpdateLast is the policy that the leader will destroy itself
-	// only after all the nodes in the group have been updated
-	PolicyLeaderSelfUpdateLast = PolicyLeaderSelfUpdate("last")
-)
-
-// MarshalJSON returns the json representation
-func (p PolicyLeaderSelfUpdate) MarshalJSON() ([]byte, error) {
-	v := string(p)
-	if _, has := map[string]int{"never": 1, "last": 1}[v]; !has {
-		return nil, fmt.Errorf("invalid value %v", p)
-	}
-
-	if v == "" {
-		v = "last"
-	}
-	return []byte("\"" + v + "\""), nil
-}
-
-// UnmarshalJSON unmarshals the buffer to this struct
-func (p *PolicyLeaderSelfUpdate) UnmarshalJSON(buff []byte) error {
-	parsed := strings.Trim(string(buff), "\"")
-	switch parsed {
-	case "never":
-		*p = PolicyLeaderSelfUpdateNever
-		return nil
-	case "last":
-		*p = PolicyLeaderSelfUpdateLast
-		return nil
-	}
-	return fmt.Errorf("not valid: %v", *p)
 }

--- a/pkg/run/v0/group/group.go
+++ b/pkg/run/v0/group/group.go
@@ -33,10 +33,6 @@ const (
 	// EnvSelfLogicalID sets the self id of this controller. This will avoid
 	// the self node to be updated.
 	EnvSelfLogicalID = "INFRAKIT_GROUP_SELF_LOGICAL_ID"
-
-	// EnvPolicyLeaderSelfUpdate is either 'last' or 'never' which determines
-	// if the leader ever destroys itself, or lastly, in a rolling update.
-	EnvPolicyLeaderSelfUpdate = "INFRAKIT_GROUP_POLICY_LEADER_SELF_UPDATE"
 )
 
 var log = logutil.New("module", "run/group")
@@ -53,21 +49,9 @@ func nilLogicalIDIfEmptyString(s string) *instance.LogicalID {
 	return &id
 }
 
-func leaderSelfUpdatePolicy(v string) *group_types.PolicyLeaderSelfUpdate {
-	switch v {
-	case "never":
-		return &group_types.PolicyLeaderSelfUpdateNever
-	case "last":
-		return &group_types.PolicyLeaderSelfUpdateLast
-	default:
-		panic("invalid policy:" + v)
-	}
-}
-
 // DefaultOptions return an Options with default values filled in.
 var DefaultOptions = group_types.Options{
-	Self: nilLogicalIDIfEmptyString(local.Getenv(EnvSelfLogicalID, "")),
-	PolicyLeaderSelfUpdate:  leaderSelfUpdatePolicy(local.Getenv(EnvPolicyLeaderSelfUpdate, "last")),
+	Self:                    nilLogicalIDIfEmptyString(local.Getenv(EnvSelfLogicalID, "")),
 	PollInterval:            types.MustParseDuration(local.Getenv(EnvPollInterval, "10s")),
 	MaxParallelNum:          types.MustParseUint(local.Getenv(EnvMaxParallelNum, "0")),
 	PollIntervalGroupSpec:   types.MustParseDuration(local.Getenv(EnvPollInterval, "10s")),


### PR DESCRIPTION
Instead of using a complex policy that defines how the current instance should be handled during a rolling update, this simplifies the logic so that the following occurs **if `Options.Self` is configured**:
- The `Self` instance is sorted last (so that it is the last node to have the rolling update applied)
- Flavor `Drain` is invoked
- Instance `Destroy` is **never** invoked

This allows the newly elected leader to resume the rolling update, destroying the "old" leader instance and provisioning a replacement.

Note that this only affects the rolling update flow; in the group deletion flow the "self" instance will be `Drain`'d and `Destroy`'d last.