### PR TITLE
Populate LogicalID in DigitalOcean DescribeInstances

### DIFF
--- a/docs/plugin/instance.md
+++ b/docs/plugin/instance.md
@@ -1,6 +1,6 @@
 # Instance plugin API
 
-<!-- SOURCE-CHECKSUM pkg/spi/instance/* c29fb64f4d6cbd56d7a085fb02568d1f8c4e141242feea094dea14f9cb93608308ec2f8c4867131e03bfa69728c94e4cfcbffee847776cfaf562f2d517c82f21a8ae7d45773a1db15dbfeb7b52420f4f -->
+<!-- SOURCE-CHECKSUM pkg/spi/instance/* c29fb64f4d6cbd56d7a085fb02568d1f8c4e141227794ff667edbe7b8ca10b371af8a87f5205cfb203bfa69728c94e4cfcbffee847776cfaf562f2d517c82f21a8ae7d45773a1db15dbfeb7b52420f4f -->
 
 
 

--- a/pkg/provider/digitalocean/plugin/instance/plugin.go
+++ b/pkg/provider/digitalocean/plugin/instance/plugin.go
@@ -212,8 +212,9 @@ func (p *plugin) DescribeInstances(tags map[string]string, properties bool) ([]i
 		}
 
 		description := instance.Description{
-			ID:   instance.ID(fmt.Sprintf("%d", droplet.ID)),
-			Tags: instTags,
+			ID:        instance.ID(fmt.Sprintf("%d", droplet.ID)),
+			LogicalID: logicalID(instTags),
+			Tags:      instTags,
 		}
 
 		if properties {
@@ -228,6 +229,16 @@ func (p *plugin) DescribeInstances(tags map[string]string, properties bool) ([]i
 	}
 
 	return result, nil
+}
+
+func logicalID(tags map[string]string) *instance.LogicalID {
+	logicalID, present := tags[instance_types.InfrakitLogicalID]
+	if present {
+		id := instance.LogicalID(logicalID)
+		return &id
+	}
+
+	return nil
 }
 
 func (p *plugin) listDroplets() ([]godo.Droplet, error) {

--- a/pkg/spi/instance/description_test.go
+++ b/pkg/spi/instance/description_test.go
@@ -78,3 +78,13 @@ func TestDifference2(t *testing.T) {
 	require.Equal(t, Descriptions{a[1], a[4]}, aIndex.Select(aIndex.Keys.Difference(bIndex.Keys)))
 	require.Equal(t, Descriptions{b[3], b[4]}, bIndex.Select(bIndex.Keys.Difference(aIndex.Keys)))
 }
+
+func TestCompare(t *testing.T) {
+
+	a := Description{ID: ID("1")}
+	b := Description{ID: ID("2")}
+
+	require.Equal(t, 0, a.Compare(a))
+	require.Equal(t, -1, a.Compare(b))
+	require.Equal(t, 1, b.Compare(a))
+}


### PR DESCRIPTION
Prior to this PR the `LogicalID` wasn't being populated in the `instance.Description` structs returned by `DescribeInstances()`.

This change sets the `LogicalID` if found in the listed Droplets.