### PR TITLE
Terraform plugin updates to support multiple tf version

### DIFF
--- a/pkg/provider/terraform/instance/apply.go
+++ b/pkg/provider/terraform/instance/apply.go
@@ -414,14 +414,14 @@ func (p *plugin) handleFilePruning(
 							resName))
 					pruneFiles[resFilenameProps.FileName] = struct{}{}
 				} else {
-					// Import resource
+					// Import resource. Note that the input tf.json file is already on disk.
 					logger.Info("handleFilePruning",
 						"msg",
 						fmt.Sprintf("Importing %v %v into terraform as resource %v ...",
 							string(resType),
 							*importID,
 							string(resName)))
-					if err = p.terraform.doTerraformImport(resType, string(resName), *importID); err != nil {
+					if err = p.terraform.doTerraformImport(p.fs, resType, string(resName), *importID, false); err != nil {
 						return err
 					}
 				}

--- a/pkg/provider/terraform/instance/apply_test.go
+++ b/pkg/provider/terraform/instance/apply_test.go
@@ -31,7 +31,7 @@ func TestRunTerraformApply(t *testing.T) {
 		Dir:          dir,
 		PollInterval: types.FromDuration(2 * time.Minute),
 	}
-	terraform, err := NewTerraformInstancePlugin(options, nil, false)
+	terraform, err := NewTerraformInstancePlugin(options, nil)
 	require.NoError(t, err)
 	require.False(t, terraform.(*plugin).pretend)
 	p, _ := terraform.(*plugin)
@@ -48,7 +48,7 @@ func TestContinuePollingStandalone(t *testing.T) {
 		Standalone:   true,
 		PollInterval: types.FromDuration(2 * time.Minute),
 	}
-	terraform, err := NewTerraformInstancePlugin(options, nil, false)
+	terraform, err := NewTerraformInstancePlugin(options, nil)
 	require.NoError(t, err)
 	p, _ := terraform.(*plugin)
 	shoudApply := p.shouldApply()

--- a/pkg/provider/terraform/instance/apply_test.go
+++ b/pkg/provider/terraform/instance/apply_test.go
@@ -588,10 +588,11 @@ func TestHandleFilePruningPruneExistingResourceError(t *testing.T) {
 
 func TestHandleFilePruningPruneImportError(t *testing.T) {
 	fake := FakeTerraform{
-		doTerraformImportStub: func(resType TResourceType, resName, resID string) error {
+		doTerraformImportStub: func(fs afero.Fs, resType TResourceType, resName, resID string, createDummyFile bool) error {
 			require.Equal(t, VMIBMCloud, resType)
 			require.Equal(t, "instance-123", resName)
 			require.Equal(t, "some-id", resID)
+			require.False(t, createDummyFile)
 			return fmt.Errorf("Custom import error")
 		},
 	}
@@ -663,8 +664,9 @@ func TestHandleFilePruningRemovedFromBackend(t *testing.T) {
 
 func TestHandleFilePruningImportSuccess(t *testing.T) {
 	fake := FakeTerraform{
-		doTerraformImportStub: func(resType TResourceType, resName, resID string) error {
+		doTerraformImportStub: func(fs afero.Fs, resType TResourceType, resName, resID string, createDummyFile bool) error {
 			// Import is successful
+			require.False(t, createDummyFile)
 			return nil
 		},
 	}
@@ -796,7 +798,7 @@ func internalTestHandleFilesPruneMultipleVMTypes(t *testing.T, pruneType int) {
 			// Return all of 1 type, 1 of another type, 0 of the last type
 			return result, nil
 		},
-		doTerraformImportStub: func(resType TResourceType, resName, resID string) error {
+		doTerraformImportStub: func(fs afero.Fs, resType TResourceType, resName, resID string, createDummyFile bool) error {
 			// Should only invoked if the resources exist in the backend
 			if pruneType == Prune2ExistsInBackend {
 				if resType == VMAmazon && resName == "instance-105" {

--- a/pkg/provider/terraform/instance/cmd/main.go
+++ b/pkg/provider/terraform/instance/cmd/main.go
@@ -107,7 +107,6 @@ func main() {
 				InstanceSpec: importInstSpec,
 				Resources:    resources,
 			},
-			false,
 		)
 		if err != nil {
 			log.Error("error initializing pluing", "err", err)

--- a/pkg/provider/terraform/instance/plugin.go
+++ b/pkg/provider/terraform/instance/plugin.go
@@ -83,6 +83,7 @@ type plugin struct {
 	pluginLookup    func() discovery.Plugins
 	envs            []string
 	cachedInstances *[]instance.Description
+	terraform       tf
 }
 
 // ImportResource defines a resource that should be imported
@@ -109,12 +110,17 @@ type ImportOptions struct {
 
 // NewTerraformInstancePlugin returns an instance plugin backed by disk files.
 func NewTerraformInstancePlugin(options terraform_types.Options, importOpts *ImportOptions) (instance.Plugin, error) {
-	return newPlugin(options, importOpts, false)
+	return newPlugin(options, importOpts, false, terraformLookup)
 }
 
 // newPlugin is the internal function that returns an instance plugin backed by disk files. This function
 // allows us to override the pretend flag for testing.
-func newPlugin(options terraform_types.Options, importOpts *ImportOptions, pretend bool) (instance.Plugin, error) {
+func newPlugin(
+	options terraform_types.Options,
+	importOpts *ImportOptions,
+	pretend bool,
+	tfLookup func(string, []string) (tf, error)) (instance.Plugin, error) {
+
 	logger.Info("newPlugin", "dir", options.Dir)
 
 	var pluginLookup func() discovery.Plugins
@@ -130,13 +136,20 @@ func newPlugin(options terraform_types.Options, importOpts *ImportOptions, prete
 			return plugins
 		}
 	}
-	// // Environment varables to include when invoking terraform
+	// Environment varables to include when invoking terraform
 	envs, err := options.ParseOptionsEnvs()
 	if err != nil {
-		logger.Error("NewTerraformInstancePlugin",
+		logger.Error("newPlugin",
 			"msg", "error parsing configuration Env Options",
 			"err", err)
 		return nil, err
+	}
+	tf, err := tfLookup(options.Dir, envs)
+	if err != nil {
+		logger.Error("newPlugin",
+			"msg", "error looking up terraform",
+			"err", err)
+		panic(err)
 	}
 	p := plugin{
 		Dir:          options.Dir,
@@ -145,15 +158,13 @@ func newPlugin(options terraform_types.Options, importOpts *ImportOptions, prete
 		pluginLookup: pluginLookup,
 		envs:         envs,
 		pretend:      pretend,
+		terraform:    tf,
 	}
 	if err := p.processImport(importOpts); err != nil {
 		panic(err)
 	}
 	// Populate the instance cache
-	fns := describeFns{
-		tfShow: p.doTerraformShow,
-	}
-	p.refreshNilInstanceCache(fns)
+	p.refreshNilInstanceCache()
 	// Ensure that tha apply goroutine is always running; it will only run "terraform apply"
 	// if the current node is the leader. However, when leadership changes, a Provision is
 	// not guaranteed to be executed so we need to create the goroutine now.
@@ -192,14 +203,7 @@ func (p *plugin) processImport(importOpts *ImportOptions) error {
 		}
 	}
 
-	// Define the functions for import and import the VM
-	fns := importFns{
-		tfShow:     p.doTerraformShow,
-		tfImport:   p.doTerraformImport,
-		tfShowInst: p.doTerraformShowForInstance,
-		tfStateRm:  p.doTerraformStateRemove,
-	}
-	err := p.importResources(fns, importOpts.Resources, importOpts.InstanceSpec)
+	err := p.importResources(importOpts.Resources, importOpts.InstanceSpec)
 	if err != nil {
 		logger.Error("processImport", "msg", "Failed to import instances", "error", err)
 		return err
@@ -1151,25 +1155,17 @@ func parseAttachTag(tf *TFormat) ([]string, error) {
 	return []string{}, nil
 }
 
-// External functions using during describe; broken out for testing
-type describeFns struct {
-	tfShow func(resTypes []TResourceType, propFilter []string) (map[TResourceType]map[TResourceName]TResourceProperties, error)
-}
-
 // DescribeInstances returns descriptions of all instances matching all of the provided tags.
 func (p *plugin) DescribeInstances(tags map[string]string, properties bool) ([]instance.Description, error) {
-	fns := describeFns{
-		tfShow: p.doTerraformShow,
-	}
-	return p.doDescribeInstances(fns, tags, properties)
+	return p.doDescribeInstances(tags, properties)
 }
 
 // doDescribeInstances returns descriptions of all instances matching all of the provided tags.
-func (p *plugin) doDescribeInstances(fns describeFns, tags map[string]string, properties bool) ([]instance.Description, error) {
+func (p *plugin) doDescribeInstances(tags map[string]string, properties bool) ([]instance.Description, error) {
 	logger.Debug("DescribeInstances", "tags", tags, "V", debugV1)
 	// The cache may have been nil-ified, check and refresh
 	if p.isCacheNil() {
-		p.refreshNilInstanceCache(fns)
+		p.refreshNilInstanceCache()
 	}
 	// Should have a cache, acquire read lock
 	p.fsLock.RLock()
@@ -1214,7 +1210,7 @@ func (p *plugin) clearCachedInstances() {
 }
 
 // refreshNilInstanceCache re-populates the cache if it is nil
-func (p *plugin) refreshNilInstanceCache(fns describeFns) {
+func (p *plugin) refreshNilInstanceCache() {
 	p.fsLock.Lock()
 	defer p.fsLock.Unlock()
 	if p.cachedInstances != nil {
@@ -1246,7 +1242,7 @@ func (p *plugin) refreshNilInstanceCache(fns describeFns) {
 		resFilter = append(resFilter, resType)
 	}
 	if len(resFilter) > 0 {
-		if result, err := fns.tfShow(resFilter, nil); err == nil {
+		if result, err := p.terraform.doTerraformShow(resFilter, nil); err == nil {
 			terraformShowResult = result
 		} else {
 			logger.Warn("refreshCachedInstances", "terraform show error", err)
@@ -1361,17 +1357,9 @@ func terraformLogicalID(props TResourceProperties) *instance.LogicalID {
 	return nil
 }
 
-// External functions using during import; broken out for testing
-type importFns struct {
-	tfShow     func(resTypes []TResourceType, propFilter []string) (map[TResourceType]map[TResourceName]TResourceProperties, error)
-	tfImport   func(resType TResourceType, filename, resID string) error
-	tfShowInst func(id string) (TResourceProperties, error)
-	tfStateRm  func(resType TResourceType, resName string) error
-}
-
 // importResource imports the resource with the given ID into terraform and creates a
 // .tf.json.new file based on the given spec
-func (p *plugin) importResources(fns importFns, resources []*ImportResource, spec *instance.Spec) error {
+func (p *plugin) importResources(resources []*ImportResource, spec *instance.Spec) error {
 	// Acquire lock since we are creating a tf.json.new file and updating terraform state
 	p.fsLock.Lock()
 	defer p.fsLock.Unlock()
@@ -1417,7 +1405,7 @@ func (p *plugin) importResources(fns importFns, resources []*ImportResource, spe
 	for resType := range showResourceTypesMap {
 		showResourceTypes = append(showResourceTypes, resType)
 	}
-	existingResources, err := fns.tfShow(showResourceTypes, []string{"id"})
+	existingResources, err := p.terraform.doTerraformShow(showResourceTypes, []string{"id"})
 	if err != nil {
 		return err
 	}
@@ -1501,7 +1489,7 @@ func (p *plugin) importResources(fns importFns, resources []*ImportResource, spe
 			"msg",
 			fmt.Sprintf("Importing %v %v into terraform as resource %v ...", string(*r.ResourceType), string(*r.ResourceID), string(r.FinalResourceName)))
 		r.SuccessfullyImported = true
-		if err = fns.tfImport(*r.ResourceType, string(r.FinalResourceName), *r.ResourceID); err != nil {
+		if err = p.terraform.doTerraformImport(*r.ResourceType, string(r.FinalResourceName), *r.ResourceID); err != nil {
 			errorToThrow = err
 			break
 		}
@@ -1510,7 +1498,7 @@ func (p *plugin) importResources(fns importFns, resources []*ImportResource, spe
 	// Parse the terraform show output
 	if errorToThrow == nil {
 		for _, r := range resources {
-			importedProps, err := fns.tfShowInst(fmt.Sprintf("%v.%v", string(*r.ResourceType), r.FinalResourceName))
+			importedProps, err := p.terraform.doTerraformShowForInstance(fmt.Sprintf("%v.%v", string(*r.ResourceType), r.FinalResourceName))
 			if err != nil {
 				errorToThrow = err
 				break
@@ -1552,7 +1540,7 @@ func (p *plugin) importResources(fns importFns, resources []*ImportResource, spe
 	if errorToThrow != nil {
 		for _, r := range resources {
 			if r.SuccessfullyImported {
-				fns.tfStateRm(*r.ResourceType, string(r.FinalResourceName))
+				p.terraform.doTerraformStateRemove(*r.ResourceType, string(r.FinalResourceName))
 			}
 		}
 		for _, path := range paths {

--- a/pkg/provider/terraform/instance/plugin.go
+++ b/pkg/provider/terraform/instance/plugin.go
@@ -1489,7 +1489,7 @@ func (p *plugin) importResources(resources []*ImportResource, spec *instance.Spe
 			"msg",
 			fmt.Sprintf("Importing %v %v into terraform as resource %v ...", string(*r.ResourceType), string(*r.ResourceID), string(r.FinalResourceName)))
 		r.SuccessfullyImported = true
-		if err = p.terraform.doTerraformImport(*r.ResourceType, string(r.FinalResourceName), *r.ResourceID); err != nil {
+		if err = p.terraform.doTerraformImport(p.fs, *r.ResourceType, string(r.FinalResourceName), *r.ResourceID, true); err != nil {
 			errorToThrow = err
 			break
 		}

--- a/pkg/provider/terraform/instance/plugin.go
+++ b/pkg/provider/terraform/instance/plugin.go
@@ -191,7 +191,7 @@ func (p *plugin) processImport(importOpts *ImportOptions) error {
 		tfShow:     p.doTerraformShow,
 		tfImport:   p.doTerraformImport,
 		tfShowInst: p.doTerraformShowForInstance,
-		tfClean:    p.cleanupFailedImport,
+		tfStateRm:  p.doTerraformStateRemove,
 	}
 	err := p.importResources(fns, importOpts.Resources, importOpts.InstanceSpec)
 	if err != nil {
@@ -1360,7 +1360,7 @@ type importFns struct {
 	tfShow     func(resTypes []TResourceType, propFilter []string) (map[TResourceType]map[TResourceName]TResourceProperties, error)
 	tfImport   func(resType TResourceType, filename, resID string) error
 	tfShowInst func(id string) (TResourceProperties, error)
-	tfClean    func(resType TResourceType, resName string) error
+	tfStateRm  func(resType TResourceType, resName string) error
 }
 
 // importResource imports the resource with the given ID into terraform and creates a
@@ -1546,7 +1546,7 @@ func (p *plugin) importResources(fns importFns, resources []*ImportResource, spe
 	if errorToThrow != nil {
 		for _, r := range resources {
 			if r.SuccessfullyImported {
-				fns.tfClean(*r.ResourceType, string(r.FinalResourceName))
+				fns.tfStateRm(*r.ResourceType, string(r.FinalResourceName))
 			}
 		}
 		for _, path := range paths {

--- a/pkg/provider/terraform/instance/plugin.go
+++ b/pkg/provider/terraform/instance/plugin.go
@@ -108,8 +108,14 @@ type ImportOptions struct {
 }
 
 // NewTerraformInstancePlugin returns an instance plugin backed by disk files.
-func NewTerraformInstancePlugin(options terraform_types.Options, importOpts *ImportOptions, pretend bool) (instance.Plugin, error) {
-	logger.Info("NewTerraformInstancePlugin", "dir", options.Dir)
+func NewTerraformInstancePlugin(options terraform_types.Options, importOpts *ImportOptions) (instance.Plugin, error) {
+	return newPlugin(options, importOpts, false)
+}
+
+// newPlugin is the internal function that returns an instance plugin backed by disk files. This function
+// allows us to override the pretend flag for testing.
+func newPlugin(options terraform_types.Options, importOpts *ImportOptions, pretend bool) (instance.Plugin, error) {
+	logger.Info("newPlugin", "dir", options.Dir)
 
 	var pluginLookup func() discovery.Plugins
 	if !options.Standalone {

--- a/pkg/provider/terraform/instance/plugin_test.go
+++ b/pkg/provider/terraform/instance/plugin_test.go
@@ -66,23 +66,23 @@ func TestEnvs(t *testing.T) {
 		PollInterval: types.FromDuration(2 * time.Minute),
 		Envs:         *types.AnyString(`["k1=v1", "keyval"]`),
 	}
-	_, err = NewTerraformInstancePlugin(options, nil, true)
+	_, err = newPlugin(options, nil, true)
 	require.Error(t, err)
 
 	options.Envs = *types.AnyString(`["k1=v1", "k2=v2"]`)
-	tf, err := NewTerraformInstancePlugin(options, nil, true)
+	tf, err := newPlugin(options, nil, true)
 	require.NoError(t, err)
 	p, _ := tf.(*plugin)
 	require.Equal(t, []string{"k1=v1", "k2=v2"}, p.envs)
 
 	options.Envs = *types.AnyString("")
-	tf, err = NewTerraformInstancePlugin(options, nil, true)
+	tf, err = newPlugin(options, nil, true)
 	require.NoError(t, err)
 	p, _ = tf.(*plugin)
 	require.Equal(t, []string{}, p.envs)
 
 	options.Envs = nil
-	tf, err = NewTerraformInstancePlugin(options, nil, true)
+	tf, err = newPlugin(options, nil, true)
 	require.NoError(t, err)
 	p, _ = tf.(*plugin)
 	require.Equal(t, []string{}, p.envs)
@@ -97,7 +97,7 @@ func getPlugin(t *testing.T) (*plugin, string) {
 		Dir:          dir,
 		PollInterval: types.FromDuration(2 * time.Minute),
 	}
-	tf, err := NewTerraformInstancePlugin(options, nil, true)
+	tf, err := newPlugin(options, nil, true)
 	require.NoError(t, err)
 	require.True(t, tf.(*plugin).pretend)
 	p, is := tf.(*plugin)
@@ -119,7 +119,7 @@ func getPluginDirNotExists(t *testing.T) (*plugin, string) {
 		Dir:          dir,
 		PollInterval: types.FromDuration(2 * time.Minute),
 	}
-	tf, err := NewTerraformInstancePlugin(options, nil, true)
+	tf, err := newPlugin(options, nil, true)
 	require.NoError(t, err)
 	require.True(t, tf.(*plugin).pretend)
 	p, is := tf.(*plugin)
@@ -140,7 +140,7 @@ func getPluginDirNoPerms(t *testing.T) (*plugin, string) {
 		Dir:          dir,
 		PollInterval: types.FromDuration(2 * time.Minute),
 	}
-	tf, err := NewTerraformInstancePlugin(options, nil, true)
+	tf, err := newPlugin(options, nil, true)
 	require.NoError(t, err)
 	require.True(t, tf.(*plugin).pretend)
 	p, is := tf.(*plugin)

--- a/pkg/provider/terraform/instance/plugin_test.go
+++ b/pkg/provider/terraform/instance/plugin_test.go
@@ -4024,10 +4024,11 @@ func TestImportTfImportError(t *testing.T) {
 			require.Equal(t, "123", id)
 			return fmt.Errorf("Custom import error")
 		},
-		tfClean: func(resType TResourceType, name string) {
+		tfClean: func(resType TResourceType, name string) error {
 			require.Equal(t, VMAmazon, resType)
 			require.True(t, strings.HasPrefix(name, "instance-"))
 			cleanVals = append(cleanVals, fmt.Sprintf("%s.%s", resType, name))
+			return nil
 		},
 	}
 	spec := instance.Spec{
@@ -4078,10 +4079,11 @@ func TestImportTfShowInstError(t *testing.T) {
 		tfShowInst: func(id string) (TResourceProperties, error) {
 			return nil, fmt.Errorf("Custom show inst error")
 		},
-		tfClean: func(resType TResourceType, name string) {
+		tfClean: func(resType TResourceType, name string) error {
 			require.Equal(t, VMAmazon, resType)
 			require.True(t, strings.HasPrefix(name, "instance-"))
 			cleanVals = append(cleanVals, fmt.Sprintf("%s.%s", resType, name))
+			return nil
 		},
 	}
 	spec := instance.Spec{
@@ -4144,8 +4146,9 @@ func TestImportResourceTagMap(t *testing.T) {
 			}
 			return props, nil
 		},
-		tfClean: func(vmType TResourceType, vmName string) {
+		tfClean: func(vmType TResourceType, vmName string) error {
 			cleanInvoked = true
+			return nil
 		},
 	}
 	spec := instance.Spec{
@@ -4236,8 +4239,9 @@ func TestImportResourceTagSlice(t *testing.T) {
 			}
 			return props, nil
 		},
-		tfClean: func(vmType TResourceType, vmName string) {
+		tfClean: func(vmType TResourceType, vmName string) error {
 			cleanInvoked = true
+			return nil
 		},
 	}
 	spec := instance.Spec{
@@ -4421,8 +4425,9 @@ func internalTestImportResourceDedicatedGlobal(t *testing.T, options importOptio
 			}
 			return nil, fmt.Errorf("Unknown show ID: %v", id)
 		},
-		tfClean: func(vmType TResourceType, vmName string) {
+		tfClean: func(vmType TResourceType, vmName string) error {
 			cleanInvoked = true
+			return nil
 		},
 	}
 	// Conditionally create existing files

--- a/pkg/provider/terraform/instance/plugin_test.go
+++ b/pkg/provider/terraform/instance/plugin_test.go
@@ -4024,7 +4024,7 @@ func TestImportTfImportError(t *testing.T) {
 			require.Equal(t, "123", id)
 			return fmt.Errorf("Custom import error")
 		},
-		tfClean: func(resType TResourceType, name string) error {
+		tfStateRm: func(resType TResourceType, name string) error {
 			require.Equal(t, VMAmazon, resType)
 			require.True(t, strings.HasPrefix(name, "instance-"))
 			cleanVals = append(cleanVals, fmt.Sprintf("%s.%s", resType, name))
@@ -4079,7 +4079,7 @@ func TestImportTfShowInstError(t *testing.T) {
 		tfShowInst: func(id string) (TResourceProperties, error) {
 			return nil, fmt.Errorf("Custom show inst error")
 		},
-		tfClean: func(resType TResourceType, name string) error {
+		tfStateRm: func(resType TResourceType, name string) error {
 			require.Equal(t, VMAmazon, resType)
 			require.True(t, strings.HasPrefix(name, "instance-"))
 			cleanVals = append(cleanVals, fmt.Sprintf("%s.%s", resType, name))
@@ -4146,7 +4146,7 @@ func TestImportResourceTagMap(t *testing.T) {
 			}
 			return props, nil
 		},
-		tfClean: func(vmType TResourceType, vmName string) error {
+		tfStateRm: func(vmType TResourceType, vmName string) error {
 			cleanInvoked = true
 			return nil
 		},
@@ -4239,7 +4239,7 @@ func TestImportResourceTagSlice(t *testing.T) {
 			}
 			return props, nil
 		},
-		tfClean: func(vmType TResourceType, vmName string) error {
+		tfStateRm: func(vmType TResourceType, vmName string) error {
 			cleanInvoked = true
 			return nil
 		},
@@ -4425,7 +4425,7 @@ func internalTestImportResourceDedicatedGlobal(t *testing.T, options importOptio
 			}
 			return nil, fmt.Errorf("Unknown show ID: %v", id)
 		},
-		tfClean: func(vmType TResourceType, vmName string) error {
+		tfStateRm: func(vmType TResourceType, vmName string) error {
 			cleanInvoked = true
 			return nil
 		},

--- a/pkg/provider/terraform/instance/show.go
+++ b/pkg/provider/terraform/instance/show.go
@@ -8,8 +8,6 @@ import (
 	"sort"
 	"strconv"
 	"strings"
-
-	"github.com/docker/infrakit/pkg/util/exec"
 )
 
 // title matches a line like: "aws_security_group.default:"
@@ -275,45 +273,4 @@ func convertToType(val string) interface{} {
 		return boolVar
 	}
 	return val
-}
-
-// doTerraformShow shells out to run `terraform show` and parses the result
-func (p *plugin) doTerraformShow(resTypes []TResourceType,
-	propFilter []string) (result map[TResourceType]map[TResourceName]TResourceProperties, err error) {
-
-	command := exec.Command("terraform show -no-color").
-		InheritEnvs(true).
-		WithEnvs(p.envs...).
-		WithDir(p.Dir)
-	command.StartWithHandlers(
-		nil,
-		func(r io.Reader) error {
-			found, err := parseTerraformShowOutput(resTypes, propFilter, r)
-			result = found
-			return err
-		},
-		nil)
-
-	err = command.Wait()
-	return
-}
-
-// doTerraformShowForInstance shells out to run `terraform state show <instance>` and parses the result
-func (p *plugin) doTerraformShowForInstance(instance string) (result TResourceProperties, err error) {
-
-	command := exec.Command(fmt.Sprintf("terraform state show %v -no-color", instance)).
-		InheritEnvs(true).
-		WithEnvs(p.envs...).
-		WithDir(p.Dir)
-	command.StartWithHandlers(
-		nil,
-		func(r io.Reader) error {
-			props, err := parseTerraformShowForInstanceOutput(r)
-			result = props
-			return err
-		},
-		nil)
-
-	err = command.Wait()
-	return
 }

--- a/pkg/provider/terraform/instance/show_test.go
+++ b/pkg/provider/terraform/instance/show_test.go
@@ -694,7 +694,7 @@ func TestRunTerraformShow(t *testing.T) {
 	defer os.RemoveAll(dir)
 	dir = path.Join(dir, "aws-two-tier")
 
-	found, err := tf.doTerraformShow([]TResourceType{TResourceType("aws_vpc")}, nil)
+	found, err := tf.terraform.doTerraformShow([]TResourceType{TResourceType("aws_vpc")}, nil)
 	require.NoError(t, err)
 	require.Equal(t, 1, len(found))
 	T(100).Infoln(found)

--- a/pkg/provider/terraform/instance/terraform.go
+++ b/pkg/provider/terraform/instance/terraform.go
@@ -129,8 +129,8 @@ func (p *plugin) doTerraformImport(resType TResourceType, resName, id string) er
 	return command.Wait()
 }
 
-// cleanupFailedImport removes the resource from the terraform state file
-func (p *plugin) cleanupFailedImport(vmType TResourceType, vmName string) error {
+// doTerraformStateRemove removes the resource from the terraform state file
+func (p *plugin) doTerraformStateRemove(vmType TResourceType, vmName string) error {
 	command := exec.Command(fmt.Sprintf("terraform state rm %v.%v", vmType, vmName)).
 		InheritEnvs(true).
 		WithEnvs(p.envs...).

--- a/pkg/provider/terraform/instance/terraform.go
+++ b/pkg/provider/terraform/instance/terraform.go
@@ -1,0 +1,142 @@
+package instance
+
+import (
+	"bufio"
+	"fmt"
+	"io"
+	"os"
+	"strings"
+
+	"github.com/docker/infrakit/pkg/util/exec"
+)
+
+// doTerraformStateList shells out to run `terraform state list` and parses the result
+func (p *plugin) doTerraformStateList() (map[TResourceType]map[TResourceName]struct{}, error) {
+	result := map[TResourceType]map[TResourceName]struct{}{}
+	command := exec.Command("terraform state list -no-color").
+		InheritEnvs(true).
+		WithEnvs(p.envs...).
+		WithDir(p.Dir)
+	command.StartWithHandlers(
+		nil,
+		func(r io.Reader) error {
+			reader := bufio.NewReader(r)
+			for {
+				lineBytes, _, err := reader.ReadLine()
+				if err != nil {
+					break
+				}
+				line := string(lineBytes)
+				logger.Debug("doTerraformStateList", "output", line, "V", debugV3)
+				// Every line should have <resource-type>.<resource-name>
+				if !strings.Contains(line, ".") {
+					logger.Error("doTerraformStateList", "msg", "Invalid line from 'terraform state list'", "line", line)
+					continue
+				}
+				split := strings.Split(strings.TrimSpace(line), ".")
+				resType := TResourceType(split[0])
+				resName := TResourceName(split[1])
+				if resourceMap, has := result[resType]; has {
+					resourceMap[resName] = struct{}{}
+				} else {
+					result[resType] = map[TResourceName]struct{}{resName: {}}
+				}
+			}
+			return nil
+		},
+		nil)
+
+	err := command.Wait()
+	return result, err
+}
+
+// doTerraformApply executes "terraform refresh"
+func (p *plugin) doTerraformRefresh() error {
+	logger.Info("doTerraformRefresh")
+	command := exec.Command("terraform refresh").
+		InheritEnvs(true).
+		WithEnvs(p.envs...).
+		WithDir(p.Dir)
+	if err := command.WithStdout(os.Stdout).WithStderr(os.Stdout).Start(); err != nil {
+		return err
+	}
+	return command.Wait()
+}
+
+// doTerraformApply executes "terraform apply"
+func (p *plugin) doTerraformApply() error {
+	logger.Info("doTerraformApply", "msg", "Applying plan")
+	command := exec.Command("terraform apply -refresh=false").
+		InheritEnvs(true).
+		WithEnvs(p.envs...).
+		WithDir(p.Dir)
+	if err := command.WithStdout(os.Stdout).WithStderr(os.Stdout).Start(); err != nil {
+		return err
+	}
+	return command.Wait()
+}
+
+// doTerraformShow shells out to run `terraform show` and parses the result
+func (p *plugin) doTerraformShow(resTypes []TResourceType,
+	propFilter []string) (result map[TResourceType]map[TResourceName]TResourceProperties, err error) {
+
+	command := exec.Command("terraform show -no-color").
+		InheritEnvs(true).
+		WithEnvs(p.envs...).
+		WithDir(p.Dir)
+	command.StartWithHandlers(
+		nil,
+		func(r io.Reader) error {
+			found, err := parseTerraformShowOutput(resTypes, propFilter, r)
+			result = found
+			return err
+		},
+		nil)
+
+	err = command.Wait()
+	return
+}
+
+// doTerraformShowForInstance shells out to run `terraform state show <instance>` and parses the result
+func (p *plugin) doTerraformShowForInstance(instance string) (result TResourceProperties, err error) {
+
+	command := exec.Command(fmt.Sprintf("terraform state show %v -no-color", instance)).
+		InheritEnvs(true).
+		WithEnvs(p.envs...).
+		WithDir(p.Dir)
+	command.StartWithHandlers(
+		nil,
+		func(r io.Reader) error {
+			props, err := parseTerraformShowForInstanceOutput(r)
+			result = props
+			return err
+		},
+		nil)
+
+	err = command.Wait()
+	return
+}
+
+// doTerraformImport shells out to run `terraform import`
+func (p *plugin) doTerraformImport(resType TResourceType, resName, id string) error {
+	command := exec.Command(fmt.Sprintf("terraform import %v.%v %s", resType, resName, id)).
+		InheritEnvs(true).
+		WithEnvs(p.envs...).
+		WithDir(p.Dir)
+	if err := command.WithStdout(os.Stdout).WithStderr(os.Stdout).Start(); err != nil {
+		return err
+	}
+	return command.Wait()
+}
+
+// cleanupFailedImport removes the resource from the terraform state file
+func (p *plugin) cleanupFailedImport(vmType TResourceType, vmName string) error {
+	command := exec.Command(fmt.Sprintf("terraform state rm %v.%v", vmType, vmName)).
+		InheritEnvs(true).
+		WithEnvs(p.envs...).
+		WithDir(p.Dir)
+	if err := command.WithStdout(os.Stdout).WithStderr(os.Stdout).Start(); err != nil {
+		return err
+	}
+	return command.Wait()
+}

--- a/pkg/provider/terraform/instance/terraform.go
+++ b/pkg/provider/terraform/instance/terraform.go
@@ -5,18 +5,93 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"regexp"
+	"strconv"
 	"strings"
 
 	"github.com/docker/infrakit/pkg/util/exec"
 )
 
+type tf interface {
+	doTerraformStateList() (map[TResourceType]map[TResourceName]struct{}, error)
+	doTerraformRefresh() error
+	doTerraformApply() error
+	doTerraformShow([]TResourceType, []string) (result map[TResourceType]map[TResourceName]TResourceProperties, err error)
+	doTerraformShowForInstance(string) (result TResourceProperties, err error)
+	doTerraformImport(TResourceType, string, string) error
+	doTerraformStateRemove(TResourceType, string) error
+}
+
+// terraformLookup returns a tf struct based on the currently installed version of terraform
+func terraformLookup(dir string, envs []string) (tf, error) {
+	command := exec.Command("terraform version").
+		InheritEnvs(true).
+		WithEnvs(envs...).
+		WithDir(dir)
+	versionRegex := regexp.MustCompile("^Terraform v([0-9]*).([0-9]*).([0-9]*)$")
+	major, minor := -1, -1
+	command.StartWithHandlers(
+		nil,
+		func(r io.Reader) error {
+			reader := bufio.NewReader(r)
+			lines := []string{}
+			for {
+				lineBytes, _, err := reader.ReadLine()
+				if err != nil {
+					break
+				}
+				line := string(lineBytes)
+				lines = append(lines, line)
+				if m := versionRegex.FindAllStringSubmatch(line, -1); len(m) > 0 {
+					logger.Info("terraformLookup", "Version", line)
+					if v, err := strconv.Atoi(m[0][1]); err == nil {
+						major = v
+					} else {
+						logger.Error("terraformLookup", "Failed to parse major version", "value", m[0][1], "error", err)
+					}
+					if v, err := strconv.Atoi(m[0][2]); err == nil {
+						minor = v
+					} else {
+						logger.Error("terraformLookup", "Failed to parse minor version", "value", m[0][2], "error", err)
+					}
+				}
+			}
+			if major == -1 || minor == -1 {
+				logger.Error("Failed to determine terraform version", "output", lines)
+			}
+			return nil
+		},
+		nil)
+	if err := command.Wait(); err != nil {
+		return nil, err
+	}
+	// Unable to retrieve the version
+	if major == -1 || minor == -1 {
+		return nil, fmt.Errorf("Unable to determine terraform version")
+	}
+	// Only support v0.9+
+	if major != 0 {
+		return nil, fmt.Errorf("Unsupported major version: %d", major)
+	}
+	if minor >= 9 {
+		return &terraformBase{dir: dir, envs: envs}, nil
+	}
+	return nil, fmt.Errorf("Unsupported minor version: %d", minor)
+}
+
+// terraformBase is base implementation and is compatible with terravorm v0.9.x
+type terraformBase struct {
+	envs []string
+	dir  string
+}
+
 // doTerraformStateList shells out to run `terraform state list` and parses the result
-func (p *plugin) doTerraformStateList() (map[TResourceType]map[TResourceName]struct{}, error) {
+func (tf *terraformBase) doTerraformStateList() (map[TResourceType]map[TResourceName]struct{}, error) {
 	result := map[TResourceType]map[TResourceName]struct{}{}
 	command := exec.Command("terraform state list -no-color").
 		InheritEnvs(true).
-		WithEnvs(p.envs...).
-		WithDir(p.Dir)
+		WithEnvs(tf.envs...).
+		WithDir(tf.dir)
 	command.StartWithHandlers(
 		nil,
 		func(r io.Reader) error {
@@ -51,12 +126,12 @@ func (p *plugin) doTerraformStateList() (map[TResourceType]map[TResourceName]str
 }
 
 // doTerraformApply executes "terraform refresh"
-func (p *plugin) doTerraformRefresh() error {
+func (tf *terraformBase) doTerraformRefresh() error {
 	logger.Info("doTerraformRefresh")
 	command := exec.Command("terraform refresh").
 		InheritEnvs(true).
-		WithEnvs(p.envs...).
-		WithDir(p.Dir)
+		WithEnvs(tf.envs...).
+		WithDir(tf.dir)
 	if err := command.WithStdout(os.Stdout).WithStderr(os.Stdout).Start(); err != nil {
 		return err
 	}
@@ -64,12 +139,12 @@ func (p *plugin) doTerraformRefresh() error {
 }
 
 // doTerraformApply executes "terraform apply"
-func (p *plugin) doTerraformApply() error {
+func (tf *terraformBase) doTerraformApply() error {
 	logger.Info("doTerraformApply", "msg", "Applying plan")
 	command := exec.Command("terraform apply -refresh=false").
 		InheritEnvs(true).
-		WithEnvs(p.envs...).
-		WithDir(p.Dir)
+		WithEnvs(tf.envs...).
+		WithDir(tf.dir)
 	if err := command.WithStdout(os.Stdout).WithStderr(os.Stdout).Start(); err != nil {
 		return err
 	}
@@ -77,13 +152,13 @@ func (p *plugin) doTerraformApply() error {
 }
 
 // doTerraformShow shells out to run `terraform show` and parses the result
-func (p *plugin) doTerraformShow(resTypes []TResourceType,
+func (tf *terraformBase) doTerraformShow(resTypes []TResourceType,
 	propFilter []string) (result map[TResourceType]map[TResourceName]TResourceProperties, err error) {
 
 	command := exec.Command("terraform show -no-color").
 		InheritEnvs(true).
-		WithEnvs(p.envs...).
-		WithDir(p.Dir)
+		WithEnvs(tf.envs...).
+		WithDir(tf.dir)
 	command.StartWithHandlers(
 		nil,
 		func(r io.Reader) error {
@@ -98,12 +173,11 @@ func (p *plugin) doTerraformShow(resTypes []TResourceType,
 }
 
 // doTerraformShowForInstance shells out to run `terraform state show <instance>` and parses the result
-func (p *plugin) doTerraformShowForInstance(instance string) (result TResourceProperties, err error) {
-
+func (tf *terraformBase) doTerraformShowForInstance(instance string) (result TResourceProperties, err error) {
 	command := exec.Command(fmt.Sprintf("terraform state show %v -no-color", instance)).
 		InheritEnvs(true).
-		WithEnvs(p.envs...).
-		WithDir(p.Dir)
+		WithEnvs(tf.envs...).
+		WithDir(tf.dir)
 	command.StartWithHandlers(
 		nil,
 		func(r io.Reader) error {
@@ -118,11 +192,11 @@ func (p *plugin) doTerraformShowForInstance(instance string) (result TResourcePr
 }
 
 // doTerraformImport shells out to run `terraform import`
-func (p *plugin) doTerraformImport(resType TResourceType, resName, id string) error {
+func (tf *terraformBase) doTerraformImport(resType TResourceType, resName, id string) error {
 	command := exec.Command(fmt.Sprintf("terraform import %v.%v %s", resType, resName, id)).
 		InheritEnvs(true).
-		WithEnvs(p.envs...).
-		WithDir(p.Dir)
+		WithEnvs(tf.envs...).
+		WithDir(tf.dir)
 	if err := command.WithStdout(os.Stdout).WithStderr(os.Stdout).Start(); err != nil {
 		return err
 	}
@@ -130,11 +204,11 @@ func (p *plugin) doTerraformImport(resType TResourceType, resName, id string) er
 }
 
 // doTerraformStateRemove removes the resource from the terraform state file
-func (p *plugin) doTerraformStateRemove(vmType TResourceType, vmName string) error {
+func (tf *terraformBase) doTerraformStateRemove(vmType TResourceType, vmName string) error {
 	command := exec.Command(fmt.Sprintf("terraform state rm %v.%v", vmType, vmName)).
 		InheritEnvs(true).
-		WithEnvs(p.envs...).
-		WithDir(p.Dir)
+		WithEnvs(tf.envs...).
+		WithDir(tf.dir)
 	if err := command.WithStdout(os.Stdout).WithStderr(os.Stdout).Start(); err != nil {
 		return err
 	}

--- a/pkg/run/v0/terraform/terraform.go
+++ b/pkg/run/v0/terraform/terraform.go
@@ -91,7 +91,6 @@ func Run(scope scope.Scope, name plugin.Name,
 			InstanceSpec: importInstSpec,
 			Resources:    resources,
 		},
-		false,
 	)
 	if err != nil {
 		log.Error("error initializing pluing", "err", err)


### PR DESCRIPTION
The CLI semantics of terraform changed between v0.9.x and v0.10.x+. In order to handle updates this PR does the following:

- Moves all external `terraform` command execs to a new `terraform.go` file and creates a common `tf` `interface`. A `terraformBase` `stuct` implements the interface for terraform v0.9.x and `terraformV10` `struct` implements the interface for terraform v0.10.x+ (currently supports v0.10.x and v0.11.x).
- Updates the UT flow to create a `FakeTerraform` `struct` that implements the `tf` interface so that we can simply implement the interface functions that are needed for testing
- Adds support in v0.10.x for the new `-auto-approve=true` CLI arg on `terraform apply`
- Adds support in v0.10.x to create the required `tf.json` file _before_ invoking `terraform import`