### PR TITLE
Fix interval calculation for minimum tick size

### DIFF
--- a/pkg/controller/gc/model/swarm/fsm_test.go
+++ b/pkg/controller/gc/model/swarm/fsm_test.go
@@ -16,23 +16,24 @@ func TestSwarmEntities(t *testing.T) {
 	gcProperties := new(gc_types.Properties)
 
 	err := types.Decode([]byte(`
-observeinterval : 10s
 Model : swarm
 ModelProperties:
   TickUnit: 1s
   NoData: 20
   RmNodeBufferSize: 20
+NodeObserver:
+  ObserveInterval: 10s
+InstanceObserver:
+  ObserveInterval: 5s
 `), gcProperties)
 
 	require.NoError(t, err)
-
-	require.Equal(t, 10*time.Second, gcProperties.ObserveInterval.Duration())
 
 	m, err := BuildModel(*gcProperties)
 	require.NoError(t, err)
 
 	model := m.(*model)
-	require.Equal(t, 10*time.Second, model.ObserveInterval.Duration())
+
 	require.Equal(t, fsm.Tick(20), model.NoData)
 	require.Equal(t, 1*time.Second, model.TickUnit.Duration())
 	require.Equal(t, 10*time.Second, model.tickSize) // must take the slower of the two durations of 10s vs 1s

--- a/pkg/controller/gc/types/types.go
+++ b/pkg/controller/gc/types/types.go
@@ -5,7 +5,6 @@ import (
 
 	"github.com/docker/infrakit/pkg/controller/internal"
 	logutil "github.com/docker/infrakit/pkg/log"
-	"github.com/docker/infrakit/pkg/plugin"
 	"github.com/docker/infrakit/pkg/run/depends"
 	"github.com/docker/infrakit/pkg/spi/controller"
 	"github.com/docker/infrakit/pkg/types"
@@ -52,23 +51,8 @@ func ResolveDependencies(spec types.Spec) (depends.Runnables, error) {
 	}, nil
 }
 
-// PluginSpec has information about the plugin
-type PluginSpec struct {
-	// Plugin is the name of the instance plugin
-	Plugin plugin.Name
-
-	// Labels are the labels to use when querying for instances. This is the namespace.
-	Labels map[string]string
-
-	// Properties is the properties to configure the instance with.
-	Properties *types.Any `json:",omitempty" yaml:",omitempty"`
-}
-
 // Properties is the schema of the configuration in the types.Spec.Properties
 type Properties struct {
-
-	// ObserveInterval is the polling interval for checking nodes and instances
-	ObserveInterval types.Duration
 
 	// Model is the workflow model to use
 	Model string


### PR DESCRIPTION
GC controller uses a FSM model that requires a clock to determine how long to wait before terminating instances, etc.  This PR makes sure that the clock tick is sized to be largest of the sampling interval between the NodeObserver, InstanceObserver, and the configured tick size.

Signed-off-by: David Chung <david.chung@docker.com>