### PR TITLE
Refactor common template view code; add CLI option to render view

### DIFF
--- a/docs/plugin/instance.md
+++ b/docs/plugin/instance.md
@@ -1,6 +1,6 @@
 # Instance plugin API
 
-<!-- SOURCE-CHECKSUM pkg/spi/instance/* 8b370c08314a9f0eae9850acb8f80a3c09a70e0a27794ff667edbe7b8ca10b371af8a87f5205cfb203bfa69728c94e4cfcbffee847776cfaf562f2d517c82f21a8ae7d45773a1db15dbfeb7b52420f4f -->
+<!-- SOURCE-CHECKSUM pkg/spi/instance/* b7d7100e6261e912addc2aa4d928eefab416a3a5636a80371ab23060e44d57bbf51df065992de83003bfa69728c94e4cfcbffee847776cfaf562f2d517c82f21a8ae7d45773a1db15dbfeb7b52420f4f -->
 
 
 

--- a/docs/plugin/instance.md
+++ b/docs/plugin/instance.md
@@ -1,6 +1,6 @@
 # Instance plugin API
 
-<!-- SOURCE-CHECKSUM pkg/spi/instance/* c29fb64f4d6cbd56d7a085fb02568d1f8c4e141227794ff667edbe7b8ca10b371af8a87f5205cfb203bfa69728c94e4cfcbffee847776cfaf562f2d517c82f21a8ae7d45773a1db15dbfeb7b52420f4f -->
+<!-- SOURCE-CHECKSUM pkg/spi/instance/* 8b370c08314a9f0eae9850acb8f80a3c09a70e0a27794ff667edbe7b8ca10b371af8a87f5205cfb203bfa69728c94e4cfcbffee847776cfaf562f2d517c82f21a8ae7d45773a1db15dbfeb7b52420f4f -->
 
 
 

--- a/pkg/spi/instance/description.go
+++ b/pkg/spi/instance/description.go
@@ -35,7 +35,26 @@ func (d Description) View(viewTemplate string) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	return t.Render(d)
+	// this is a substitute struct type to make the Properties searchable
+	type desc struct {
+		ID         ID
+		LogicalID  *LogicalID
+		Tags       map[string]string
+		Properties interface{}
+	}
+
+	var p interface{}
+	if err := d.Properties.Decode(&p); err != nil {
+		return "", err
+	}
+
+	v := desc{
+		ID:         d.ID,
+		LogicalID:  d.LogicalID,
+		Tags:       d.Tags,
+		Properties: p,
+	}
+	return t.Render(v)
 }
 
 // Descriptions is a collection of descriptions

--- a/pkg/spi/instance/description.go
+++ b/pkg/spi/instance/description.go
@@ -4,6 +4,7 @@ import (
 	"sort"
 
 	"github.com/deckarep/golang-set"
+	"github.com/docker/infrakit/pkg/template"
 	"github.com/docker/infrakit/pkg/types"
 )
 
@@ -21,6 +22,20 @@ func (d Description) Compare(other Description) int {
 		return 1
 	}
 	return 0
+}
+
+// View returns a view of the Description given the text template. The text template
+// can contain escaped \{\{\}\} template expression delimiters.
+func (d Description) View(viewTemplate string) (string, error) {
+	buff := template.Unescape([]byte(viewTemplate))
+	t, err := template.NewTemplate(
+		"str://"+string(buff),
+		template.Options{MultiPass: false, MissingKey: template.MissingKeyError},
+	)
+	if err != nil {
+		return "", err
+	}
+	return t.Render(d)
 }
 
 // Descriptions is a collection of descriptions

--- a/pkg/spi/instance/description_test.go
+++ b/pkg/spi/instance/description_test.go
@@ -3,8 +3,48 @@ package instance
 import (
 	"testing"
 
+	"github.com/docker/infrakit/pkg/types"
 	"github.com/stretchr/testify/require"
 )
+
+func testView(d Description, v string) string {
+	vv, err := d.View(v)
+	if err != nil {
+		panic(err)
+	}
+	return vv
+}
+
+func TestView(t *testing.T) {
+
+	require.Equal(t, "id", testView(Description{
+		ID: ID("id"),
+	}, `{{.ID}}`))
+
+	require.Equal(t, "id", testView(Description{
+		LogicalID: LogicalIDFromString("id"),
+	}, `{{.LogicalID}}`))
+
+	require.Equal(t, "foo", testView(Description{
+		Tags: map[string]string{
+			"bar": "foo",
+		},
+	}, `{{.Tags.bar}}`))
+
+	require.Equal(t, "foo", testView(Description{
+		Tags: map[string]string{
+			"bar-bar": "foo",
+		},
+	}, `{{ index .Tags "bar-bar" }}`))
+
+	// Note that we can index into a types.Any
+	require.Equal(t, "foobar", testView(Description{
+		Tags: map[string]string{
+			"bar-bar": "foo",
+		},
+		Properties: types.AnyValueMust(map[string]interface{}{"Bar": "bar"}),
+	}, `{{ index .Tags "bar-bar" }}{{ .Properties.Bar }}`))
+}
 
 func TestDifference(t *testing.T) {
 

--- a/pkg/template/funcs.go
+++ b/pkg/template/funcs.go
@@ -288,25 +288,6 @@ func (t *Template) Fetch(p string, opt ...interface{}) (string, error) {
 
 // Source 'sources' the input file at url, also inherits all the variables.
 func (t *Template) Source(p string, opt ...interface{}) (string, error) {
-	// headers, context := headersAndContext(opt...)
-	// loc := p
-	// if strings.Index(loc, "str://") == -1 {
-	// 	u, err := GetURL(t.url, p)
-	// 	if err != nil {
-	// 		return "", err
-	// 	}
-	// 	loc = u.String()
-	// }
-
-	// prev := t.options.CustomizeFetch
-	// t.options.CustomizeFetch = func(req *http.Request) {
-	// 	setHeaders(req, headers)
-	// 	if prev != nil {
-	// 		prev(req)
-	// 	}
-	// }
-	// sourced, err := NewTemplate(loc, t.options)
-
 	_, context, sourced, err := t.raw(p, opt...)
 	if err != nil {
 		return "", err
@@ -325,26 +306,6 @@ func (t *Template) Source(p string, opt ...interface{}) (string, error) {
 
 // Include includes the template at the url inline.
 func (t *Template) Include(p string, opt ...interface{}) (string, error) {
-	// headers, context := headersAndContext(opt...)
-	// loc := p
-	// if strings.Index(loc, "str://") == -1 {
-	// 	u, err := GetURL(t.url, p)
-	// 	if err != nil {
-	// 		return "", err
-	// 	}
-	// 	loc = u.String()
-	// }
-
-	// prev := t.options.CustomizeFetch
-	// t.options.CustomizeFetch = func(req *http.Request) {
-	// 	setHeaders(req, headers)
-	// 	if prev != nil {
-	// 		prev(req)
-	// 	}
-	// }
-
-	// included, err := NewTemplate(loc, t.options)
-
 	_, context, included, err := t.raw(p, opt...)
 	if err != nil {
 		return "", err
@@ -451,22 +412,11 @@ func (t *Template) DefaultFuncs() []Function {
 			Func: t.Var,
 		},
 		{
-			Name: "k",
-			Description: []string{
-				"Get value from dictionary by key.",
-				"First arg is the key, second must be a map[string]interface{}",
-			},
-			Func: // MapIndex gets the value of key from map
-			func(k interface{}, m map[string]interface{}) interface{} {
-				return m[fmt.Sprintf("%v", k)]
-			},
-		},
-		{
 			Name: "q",
 			Description: []string{
 				"Runs a JMESPath (http://jmespath.org/) query (first arg) on the object (second arg).",
 				"The return value is an object which needs to be rendered properly for the format of the document.",
-				"Example: {{ include \"https://httpbin.org/get\" | from_json | q \"origin\" }}",
+				"Example: {{ include \"https://httpbin.org/get\" | jsonDecode | q \"origin\" }}",
 				"returns the origin of http request.",
 			},
 			Func: QueryObject,


### PR DESCRIPTION
There is a common pattern of using a template expression to compute a view on an `instance.Description`.   This shows up in
  + "selecting" a custom property from the instance description (e.g. an IP address in the Properties)
  + "selecting" a join key (e.g. in GC controller #876 and enrollment controller and resource controller #880 )

So it makes sense to move this common template rendering code to the instance.Description.  Also, the CLI has been updated so that a `describe` on an instance plugin can now accept
a view template `-z {{ index .Tags "infrakit-link" }}` and will render just two columns per row / instance:  the id and the resulting view.


Signed-off-by: David Chung <david.chung@docker.com>