### PR TITLE
Fix broken Docker image infrakit/devbundle

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -102,60 +102,60 @@ endef
 $(call define_binary_target,infrakit,github.com/docker/infrakit/cmd/infrakit)
 
 
-# preserves the build/* binaries but use script to call 'infrakit plugin start' instead:
-define plugin_start_template
-build/$(1): $(SRCS)
-	@echo "#!/bin/sh\n# invoke plugin $(1) as $(2)\ninfrakit plugin start $(2) --log 5" > build/$(1)$(EXE_EXT)
-	@chmod a+x build/$(1)$(EXE_EXT)
-endef
-define define_plugin_start_target
-	$(eval $(call plugin_start_template,$(1),$(2)))
-endef
+# # preserves the build/* binaries but use script to call 'infrakit plugin start' instead:
+# define plugin_start_template
+# build/$(1): $(SRCS)
+# 	@echo "#!/bin/sh\n# invoke plugin $(1) as $(2)\ninfrakit plugin start $(2) --log 5" > build/$(1)$(EXE_EXT)
+# 	@chmod a+x build/$(1)$(EXE_EXT)
+# endef
+# define define_plugin_start_target
+# 	$(eval $(call plugin_start_template,$(1),$(2)))
+# endef
 
-$(call define_plugin_start_target,infrakit-group-default,group)
-$(call define_plugin_start_target,infrakit-instance-aws,aws)
-$(call define_plugin_start_target,infrakit-instance-digitalocean,digitalocean)
-$(call define_plugin_start_target,infrakit-instance-docker,docker)
-$(call define_plugin_start_target,infrakit-instance-gcp,google)
-$(call define_plugin_start_target,infrakit-instance-hyperkit,hyperkit)
-$(call define_plugin_start_target,infrakit-instance-image,image)
-$(call define_plugin_start_target,infrakit-instance-maas,maas)
-$(call define_plugin_start_target,infrakit-instance-packet,packet)
-$(call define_plugin_start_target,infrakit-instance-rackhd,rackhd)
-$(call define_plugin_start_target,infrakit-instance-terraform,terraform)
-$(call define_plugin_start_target,infrakit-instance-vagrant,vagrant)
-$(call define_plugin_start_target,infrakit-instance-vsphere,vsphere)
-$(call define_plugin_start_target,infrakit-flavor-kubernetes,kubernetes)
-$(call define_plugin_start_target,infrakit-flavor-swarm,swarm)
-$(call define_plugin_start_target,infrakit-metadata-aws,aws)
+# $(call define_plugin_start_target,infrakit-group-default,group)
+# $(call define_plugin_start_target,infrakit-instance-aws,aws)
+# $(call define_plugin_start_target,infrakit-instance-digitalocean,digitalocean)
+# $(call define_plugin_start_target,infrakit-instance-docker,docker)
+# $(call define_plugin_start_target,infrakit-instance-gcp,google)
+# $(call define_plugin_start_target,infrakit-instance-hyperkit,hyperkit)
+# $(call define_plugin_start_target,infrakit-instance-image,image)
+# $(call define_plugin_start_target,infrakit-instance-maas,maas)
+# $(call define_plugin_start_target,infrakit-instance-packet,packet)
+# $(call define_plugin_start_target,infrakit-instance-rackhd,rackhd)
+# $(call define_plugin_start_target,infrakit-instance-terraform,terraform)
+# $(call define_plugin_start_target,infrakit-instance-vagrant,vagrant)
+# $(call define_plugin_start_target,infrakit-instance-vsphere,vsphere)
+# $(call define_plugin_start_target,infrakit-flavor-kubernetes,kubernetes)
+# $(call define_plugin_start_target,infrakit-flavor-swarm,swarm)
+# $(call define_plugin_start_target,infrakit-metadata-aws,aws)
 
-build-plugin-start-scripts: build/infrakit \
-		build/infrakit-instance-aws \
-		build/infrakit-instance-digitalocean \
-		build/infrakit-instance-docker \
-		build/infrakit-instance-gcp \
-		build/infrakit-instance-hyperkit \
-		build/infrakit-instance-image \
-		build/infrakit-instance-maas \
-		build/infrakit-instance-packet \
-		build/infrakit-instance-rackhd \
-		build/infrakit-instance-terraform \
-		build/infrakit-instance-vagrant \
-		build/infrakit-instance-vsphere \
-		build/infrakit-flavor-kubernetes \
-		build/infrakit-flavor-swarm \
-		build/infrakit-group-default \
-		build/infrakit-metadata-aws \
+# build-plugin-start-scripts: build/infrakit \
+# 		build/infrakit-instance-aws \
+# 		build/infrakit-instance-digitalocean \
+# 		build/infrakit-instance-docker \
+# 		build/infrakit-instance-gcp \
+# 		build/infrakit-instance-hyperkit \
+# 		build/infrakit-instance-image \
+# 		build/infrakit-instance-maas \
+# 		build/infrakit-instance-packet \
+# 		build/infrakit-instance-rackhd \
+# 		build/infrakit-instance-terraform \
+# 		build/infrakit-instance-vagrant \
+# 		build/infrakit-instance-vsphere \
+# 		build/infrakit-flavor-kubernetes \
+# 		build/infrakit-flavor-swarm \
+# 		build/infrakit-group-default \
+# 		build/infrakit-metadata-aws \
 
-ifeq ($(OS),Windows_NT)
-build/infrakit-instance-libvirt:
-# noop on windows
-else
-$(call define_plugin_start_target,infrakit-instance-libvirt,libvirt)
-endif
+# ifeq ($(OS),Windows_NT)
+# build/infrakit-instance-libvirt:
+# # noop on windows
+# else
+# $(call define_plugin_start_target,infrakit-instance-libvirt,libvirt)
+# endif
 
 
-binaries: clean build-binaries build-plugin-start-scripts
+binaries: clean build-binaries #build-plugin-start-scripts
 build-binaries:	build/infrakit
 	@echo "+ $@"
 ifneq (,$(findstring .m,$(VERSION)))

--- a/Makefile
+++ b/Makefile
@@ -101,61 +101,12 @@ endef
 # actual binaries that need to be built:
 $(call define_binary_target,infrakit,github.com/docker/infrakit/cmd/infrakit)
 
-
-# # preserves the build/* binaries but use script to call 'infrakit plugin start' instead:
-# define plugin_start_template
-# build/$(1): $(SRCS)
-# 	@echo "#!/bin/sh\n# invoke plugin $(1) as $(2)\ninfrakit plugin start $(2) --log 5" > build/$(1)$(EXE_EXT)
-# 	@chmod a+x build/$(1)$(EXE_EXT)
-# endef
-# define define_plugin_start_target
-# 	$(eval $(call plugin_start_template,$(1),$(2)))
-# endef
-
-# $(call define_plugin_start_target,infrakit-group-default,group)
-# $(call define_plugin_start_target,infrakit-instance-aws,aws)
-# $(call define_plugin_start_target,infrakit-instance-digitalocean,digitalocean)
-# $(call define_plugin_start_target,infrakit-instance-docker,docker)
-# $(call define_plugin_start_target,infrakit-instance-gcp,google)
-# $(call define_plugin_start_target,infrakit-instance-hyperkit,hyperkit)
-# $(call define_plugin_start_target,infrakit-instance-image,image)
-# $(call define_plugin_start_target,infrakit-instance-maas,maas)
-# $(call define_plugin_start_target,infrakit-instance-packet,packet)
-# $(call define_plugin_start_target,infrakit-instance-rackhd,rackhd)
-# $(call define_plugin_start_target,infrakit-instance-terraform,terraform)
-# $(call define_plugin_start_target,infrakit-instance-vagrant,vagrant)
-# $(call define_plugin_start_target,infrakit-instance-vsphere,vsphere)
-# $(call define_plugin_start_target,infrakit-flavor-kubernetes,kubernetes)
-# $(call define_plugin_start_target,infrakit-flavor-swarm,swarm)
-# $(call define_plugin_start_target,infrakit-metadata-aws,aws)
-
-# build-plugin-start-scripts: build/infrakit \
-# 		build/infrakit-instance-aws \
-# 		build/infrakit-instance-digitalocean \
-# 		build/infrakit-instance-docker \
-# 		build/infrakit-instance-gcp \
-# 		build/infrakit-instance-hyperkit \
-# 		build/infrakit-instance-image \
-# 		build/infrakit-instance-maas \
-# 		build/infrakit-instance-packet \
-# 		build/infrakit-instance-rackhd \
-# 		build/infrakit-instance-terraform \
-# 		build/infrakit-instance-vagrant \
-# 		build/infrakit-instance-vsphere \
-# 		build/infrakit-flavor-kubernetes \
-# 		build/infrakit-flavor-swarm \
-# 		build/infrakit-group-default \
-# 		build/infrakit-metadata-aws \
-
-# ifeq ($(OS),Windows_NT)
-# build/infrakit-instance-libvirt:
-# # noop on windows
-# else
-# $(call define_plugin_start_target,infrakit-instance-libvirt,libvirt)
-# endif
+infrakit-linux: $(SRCS)
+	CGO_ENABLED=0 go build -a -installsuffix cgo -o build/infrakit -tags "netgo $(GO_BUILD_TAGS)" \
+		-ldflags "-X github.com/docker/infrakit/pkg/cli.Version=$(VERSION) -X github.com/docker/infrakit/pkg/cli.Revision=$(REVISION) -X github.com/docker/infrakit/pkg/util/docker.ClientVersion=$(DOCKER_CLIENT_VERSION) -linkmode external -s -w -extldflags \"-static\" " github.com/docker/infrakit/cmd/infrakit
 
 
-binaries: clean build-binaries #build-plugin-start-scripts
+binaries: clean build-binaries
 build-binaries:	build/infrakit
 	@echo "+ $@"
 ifneq (,$(findstring .m,$(VERSION)))

--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ git clone git@github.com:docker/infrakit.git
 cd infrakit
 ```
 
-We recommended go version 1.7.1 or greater for all platforms.
+We recommended go version 1.9 or greater for all platforms.
 
 Also install a few build tools:
 ```shell
@@ -126,34 +126,8 @@ $ make ci
 ```shell
 $ make binaries
 ```
-Executables will be placed in the `./build` directory.
-This will produce binaries for tools and several reference Plugin implementations:
-  + [`infrakit`](cmd/infrakit/README.md): a command line interface to interact with plugins
-  + [`infrakit-group-default`](cmd/group/README.md): the default [Group plugin](./pkg/spi/group)
-  + [`infrakit-instance-file`](examples/instance/file): an Instance plugin using dummy files to represent instances
-  + [`infrakit-instance-terraform`](pkg/provider/terraform/instance):
-    an Instance plugin integrating [Terraform](https://www.terraform.io)
-  + [`infrakit-instance-vagrant`](examples/instance/vagrant):
-    an Instance plugin using [Vagrant](https://www.vagrantup.com/)
-  + [`infrakit-instance-docker`](examples/instance/docker):
-    an Instance plugin for provisioning Docker containers via the Docker API
-  + [`infrakit-instance-maas`](examples/instance/maas):
-    an Instance plugin using [MaaS](https://maas.io) to provision bare metal servers
-  + [`infrakit-instance-hyperkit`](pkg/plugin/instance/hyperkit):
-    an Instance plugin using [HyperKit](https://github.com/docker/hyperkit) to provision Xhyve-based guest vm's on Mac OSX
-  + [`infrakit-instance-libvirt`](pkg/plugin/instance/libvirt):
-    an Instance plugin using libvirt to provision KVM / QEMU vm instances
-  + [`infrakit-instance-packet`](pkg/plugin/instance/packet):
-    an Instance plugin for provisioning bare-metal servers from [Packet.net](https://packet.net)
-  + [`infrakit-flavor-vanilla`](examples/flavor/vanilla):
-    a Flavor plugin for plain vanilla set up with user data and labels
-  + [`infrakit-flavor-zookeeper`](examples/flavor/zookeeper):
-    a Flavor plugin for [Apache ZooKeeper](https://zookeeper.apache.org/) ensemble members
-  + [`infrakit-flavor-swarm`](examples/flavor/swarm):
-    a Flavor plugin for Docker in [Swarm mode](https://docs.docker.com/engine/swarm/).
-
-All provided binaries have a `help` sub-command to get usage and a `version` sub-command to identify the build revision.
-
+Executables will be placed in the `./build` directory.  There is only one executable `infrakit` which can
+be used as CLI and as server, based on the CLI verbs and flags.
 
 # Design
 

--- a/dockerfiles/Dockerfile.build
+++ b/dockerfiles/Dockerfile.build
@@ -1,6 +1,6 @@
-FROM golang:1.8-alpine
+FROM golang:1.10.0-alpine3.7
 
-RUN apk add --update git make gcc musl-dev wget ca-certificates openssl libvirt-dev
+RUN apk add --update git make gcc musl-dev wget ca-certificates openssl libvirt-dev libvirt-static
 RUN go get github.com/rancher/trash
 
 WORKDIR /go/src/github.com/docker/infrakit
@@ -8,6 +8,5 @@ WORKDIR /go/src/github.com/docker/infrakit
 VOLUME [ "/go/src/github.com/docker/infrakit/build" ]
 
 COPY . ./
-RUN trash  # Force updating the vendored sources per spec; this slows the build but is most correct.
 
 CMD make build-binaries terraform-linux

--- a/dockerfiles/Dockerfile.build
+++ b/dockerfiles/Dockerfile.build
@@ -1,7 +1,6 @@
 FROM golang:1.10.0-alpine3.7
 
 RUN apk add --update git make gcc musl-dev wget ca-certificates openssl libvirt-dev libvirt-static
-RUN go get github.com/rancher/trash
 
 WORKDIR /go/src/github.com/docker/infrakit
 
@@ -9,4 +8,4 @@ VOLUME [ "/go/src/github.com/docker/infrakit/build" ]
 
 COPY . ./
 
-CMD make build-binaries terraform-linux
+CMD make infrakit-linux terraform-linux

--- a/dockerfiles/Dockerfile.bundle
+++ b/dockerfiles/Dockerfile.bundle
@@ -1,8 +1,11 @@
 FROM alpine:latest
 
-RUN apk add --update wget ca-certificates openssl libvirt-dev openssh
+RUN apk add --update wget ca-certificates openssl libvirt-dev libvirt-static openssh
 
 RUN mkdir -p /infrakit/plugins /infrakit/configs /infrakit/logs /infrakit/cli /infrakit/instance/terraform
+
+# Default single node leader file
+RUN echo manager1 > /infrakit/leader
 
 VOLUME /infrakit
 WORKDIR /infrakit

--- a/dockerfiles/Dockerfile.bundle
+++ b/dockerfiles/Dockerfile.bundle
@@ -1,6 +1,6 @@
 FROM alpine:latest
 
-RUN apk add --update wget ca-certificates openssl libvirt-dev libvirt-static openssh
+RUN apk add --update wget ca-certificates openssl libvirt-dev libvirt-static openssh file
 
 RUN mkdir -p /infrakit/plugins /infrakit/configs /infrakit/logs /infrakit/cli /infrakit/instance/terraform
 

--- a/dockerfiles/Dockerfile.installer
+++ b/dockerfiles/Dockerfile.installer
@@ -1,6 +1,6 @@
-FROM golang:1.8-alpine
+FROM golang:1.10.0-alpine3.7
 
-RUN apk add --update git make gcc musl-dev wget ca-certificates openssl libvirt-dev libvirt-lxc libvirt-qemu git openssh
+RUN apk add --update git make gcc musl-dev wget ca-certificates openssl libvirt-static libvirt-dev libvirt-lxc libvirt-qemu git openssh file
 
 ENV GOPATH /go
 ENV PATH /go/bin:$PATH


### PR DESCRIPTION
This PR upgrades the build/compile container to use Golang 1.10 and Alpine 3.7, which now has libvirt dependencies.

```
docker run --rm infrakit/devbundle:dev file /usr/local/bin/infrakit
/usr/local/bin/infrakit: ELF 64-bit LSB executable, x86-64, version 1 (SYSV), statically linked, stripped
```

Verify the binary works:

```
docker run --rm infrakit/devbundle:dev infrakit template 'str://{{include `https://httpbin.org/get` | jsonDecode | q `origin`}}'
```
should print your IP address as seen by the service `httpbin.org`.

Signed-off-by: David Chung <david.chung@docker.com>