### PR TITLE
Inventory controller 

### DIFF
--- a/cmd/infrakit/builtin.go
+++ b/cmd/infrakit/builtin.go
@@ -10,6 +10,7 @@ import (
 	_ "github.com/docker/infrakit/pkg/run/v0/group"
 	_ "github.com/docker/infrakit/pkg/run/v0/image"
 	_ "github.com/docker/infrakit/pkg/run/v0/ingress"
+	_ "github.com/docker/infrakit/pkg/run/v0/inventory"
 	_ "github.com/docker/infrakit/pkg/run/v0/manager"
 	_ "github.com/docker/infrakit/pkg/run/v0/resource"
 	_ "github.com/docker/infrakit/pkg/run/v0/selector"

--- a/docs/controller/inventory/README.md
+++ b/docs/controller/inventory/README.md
@@ -1,0 +1,46 @@
+Inventory Controller
+===================
+
+The Inventory Controller (`resource` kind) is a controller that can monitors collections of resources.
+You can specify how to observe and take inventory of your resources by first tagging them (using the
+infrastructure tools your platform vendor provides and then specify the tags in the config file.
+In the config file, you can specify targets, which are plugin references with a set of label/tag filters.
+The inventory controller exposes all the discovered resources via the Metadata interface so you can
+use `infrakit local inventory keys -al` and `cat` to list and see their properties.  There's also an
+event interface you can subscribe to and watch as resources are found and gone.
+
+## Walk-Through
+
+In the walk-through we use the simulator to different resource types on different providers.  We also
+will use the `resource` controller to create resources which are discovered and tracked by the inventory
+controller.
+
+A playbook is included for you play along.
+
+Add the playbook (assuming your working directory is here):
+
+```
+infrakit playbook add inventory file://$(pwd)/playbook.yml
+```
+
+Start infrakit:
+
+```
+infrakit use inventory start
+```
+This starts up the manager as `mystack` and the resource controller, the inventory controller, and
+simulator plugins simulating providers in `az` and another in `az2`.
+
+To see events from the controller, in a separate terminal:
+
+```
+infrakit local inventory tail / --view 'str://{{.Type}} - {{.ID}} - {{.Message}}'
+```
+
+This will subscribe to all events from the top `/`.
+
+Now commit the configuration for resources:
+
+```
+infrakit local mystack/inventory commit -y ./inventory.yml
+```

--- a/docs/controller/inventory/README.md
+++ b/docs/controller/inventory/README.md
@@ -39,8 +39,37 @@ infrakit local inventory tail / --view 'str://{{.Type}} - {{.ID}} - {{.Message}}
 
 This will subscribe to all events from the top `/`.
 
-Now commit the configuration for resources:
+Now commit the configuration `inventory.yml` to start monitoring the resources.  This example
+watches the resources provisioned by the `resource` plugin via  the `az1/net`, `az2/net`, and `az1/disk`
+and `az2/disk` plugins:
 
 ```
-infrakit local mystack/inventory commit -y ./inventory.yml
+infrakit local mystack/inventory commit -y <(infrakit use inventory inventory.yml)
+```
+
+Now we can provision in az1:
+```
+infrakit local mystack/resource commit -y <(infrakit use inventory az1.yml)
+```
+
+in az2
+```
+infrakit local mystack/resource commit -y <(infrakit use inventory az2.yml)
+```
+
+The inventory controller will report events as resource show up and if you destroy resources
+you will see the 'gone' events.  The resource controller will detect that the resources
+have disappeared and reprovision them, at which point you will see events as well.
+
+The inventory controller also exposes all the known resources via the metatadata api. So to list:
+
+```
+infrakit local inventory/mystack-inventory  keys -al
+```
+
+And to see the values:
+
+```
+$ infrakit local inventory/mystack-inventory cat az2-resources/az2-net1/Properties/cidr
+10.20.200.0/24
 ```

--- a/docs/controller/inventory/az1.yml
+++ b/docs/controller/inventory/az1.yml
@@ -1,0 +1,125 @@
+{{/* =% text %= */}}
+kind: resource
+metadata:
+  name: az1-resources
+properties:
+  az1-net1:
+    plugin: az1/net
+    labels:
+      az: az1
+      type: network
+    ObserveInterval: 1s                               # optional - specified here to control polling interval
+    KeySelector: \{\{.Tags.infrakit_instance\}\}      # optional specified here to control key extraction
+    Properties:
+      cidr: 10.20.100.0/24
+      gateway: 10.20.0.1
+  az1-disk0:
+    plugin: az1/disk
+    labels:
+      az: az1
+      type: storage
+    Properties:
+      dep: {{ depend `az1-net1/ID` }}
+      depname: {{ depend `az1-net1/Tags/infrakit_instance` }}
+      gw: {{ depend `az1-net1/Properties/gateway` }}
+      fs: ext4
+      size: 1TB
+  az1-disk1:
+    plugin: az1/disk
+    labels:
+      az: az1
+      type: storage
+    Properties:
+      dep: {{ depend `az1-disk0/ID` }}
+      depname: {{ depend `az1-disk0/Tags/infrakit_instance` }}
+      gw: {{ depend `az1-net1/Properties/gateway` }}
+      fs: ext4
+      size: 2TB
+  az1-disk2:
+    plugin: az1/disk
+    labels:
+      az: az1
+      type: storage
+    Properties:
+      dep: {{ depend `az1-disk1/ID` }}
+      depname: {{ depend `az1-disk1/Tags/infrakit_instance` }}
+      gw: {{ depend `az1-net1/Properties/gateway` }}
+      fs: ext4
+      size: 3TB
+  az1-disk3:
+    plugin: az1/disk
+    labels:
+      az: az1
+      type: storage
+    Properties:
+      dep: {{ depend `az1-disk2/ID` }}
+      depname: {{ depend `az1-disk2/Tags/infrakit_instance` }}
+      gw: {{ depend `az1-net1/Properties/gateway` }}
+      fs: ext4
+      size: 4TB
+  az1-disk4:
+    plugin: az1/disk
+    labels:
+      az: az1
+      type: storage
+    Properties:
+      dep: {{ depend `az1-disk3/ID` }}
+      depname: {{ depend `az1-disk3/Tags/infrakit_instance` }}
+      gw: {{ depend `az1-net1/Properties/gateway` }}
+      fs: ext4
+      size: 5TB
+  az1-disk5:
+    plugin: az1/disk
+    labels:
+      az: az1
+      type: storage
+    Properties:
+      dep: {{ depend `az1-disk4/ID` }}
+      depname: {{ depend `az1-disk4/Tags/infrakit_instance` }}
+      gw: {{ depend `az1-net1/Properties/gateway` }}
+      fs: ext4
+      size: 6TB
+  az1-disk6:
+    plugin: az1/disk
+    labels:
+      az: az1
+      type: storage
+    Properties:
+      dep: {{ depend `az1-disk5/ID` }}
+      depname: {{ depend `az1-disk5/Tags/infrakit_instance` }}
+      gw: {{ depend `az1-net1/Properties/gateway` }}
+      fs: ext4
+      size: 7TB
+  az1-disk7:
+    plugin: az1/disk
+    labels:
+      az: az1
+      type: storage
+    Properties:
+      dep: {{ depend `az1-disk6/ID` }}
+      depname: {{ depend `az1-disk6/Tags/infrakit_instance` }}
+      gw: {{ depend `az1-net1/Properties/gateway` }}
+      fs: ext4
+      size: 8TB
+  az1-disk8:
+    plugin: az1/disk
+    labels:
+      az: az1
+      type: storage
+    Properties:
+      dep: {{ depend `az1-disk7/ID` }}
+      depname: {{ depend `az1-disk7/Tags/infrakit_instance` }}
+      gw: {{ depend `az1-net1/Properties/gateway` }}
+      fs: ext4
+      size: 9TB
+  az1-disk9:
+    plugin: az1/disk
+    labels:
+      az: az1
+      type: storage
+    Properties:
+      dep: {{ depend `az1-disk8/ID` }}
+      depname: {{ depend `az1-disk8/Tags/infrakit_instance` }}
+      gw: {{ depend `az1-net1/Properties/gateway` }}
+      fs: ext4
+      size: 10TB

--- a/docs/controller/inventory/az2.yml
+++ b/docs/controller/inventory/az2.yml
@@ -1,0 +1,71 @@
+{{/* =% text %= */}}
+kind: resource
+metadata:
+  name: az2-resources
+options:
+  WaitBeforeProvision: 5
+  WaitBeforeDestroy: 5
+properties:
+  az2-net1:
+    plugin: az2/net
+    labels:
+      az: az2
+      type: network
+    Properties:
+      cidr: 10.20.200.0/24
+      gateway: 10.20.0.1
+  az2-disk0:
+    plugin: az2/disk
+    labels:
+      az: az2
+      type: storage
+    Properties:
+      dep: {{ depend `az2-net1/ID` }}
+      depname: {{ depend `az2-net1/Tags/infrakit_instance` }}
+      gw: {{ depend `az2-net1/Properties/gateway` }}
+      fs: ext4
+      size: 1TB
+  az2-disk1:
+    plugin: az2/disk
+    labels:
+      az: az2
+      type: storage
+    Properties:
+      dep: {{ depend `az2-disk0/ID` }}
+      depname: {{ depend `az2-disk0/Tags/infrakit_instance` }}
+      gw: {{ depend `az2-net1/Properties/gateway` }}
+      fs: ext4
+      size: 2TB
+  az2-disk2:
+    plugin: az2/disk
+    labels:
+      az: az2
+      type: storage
+    Properties:
+      dep: {{ depend `az2-disk1/ID` }}
+      depname: {{ depend `az2-disk1/Tags/infrakit_instance` }}
+      gw: {{ depend `az2-net1/Properties/gateway` }}
+      fs: ext4
+      size: 3TB
+  az2-disk3:
+    plugin: az2/disk
+    labels:
+      az: az2
+      type: storage
+    Properties:
+      dep: {{ depend `az2-disk2/ID` }}
+      depname: {{ depend `az2-disk2/Tags/infrakit_instance` }}
+      gw: {{ depend `az2-net1/Properties/gateway` }}
+      fs: ext4
+      size: 4TB
+  az2-disk4:
+    plugin: az2/disk
+    labels:
+      az: az2
+      type: storage
+    Properties:
+      dep: {{ depend `az2-disk3/ID` }}
+      depname: {{ depend `az2-disk3/Tags/infrakit_instance` }}
+      gw: {{ depend `az2-net1/Properties/gateway` }}
+      fs: ext4
+      size: 5TB

--- a/docs/controller/inventory/inventory.yml
+++ b/docs/controller/inventory/inventory.yml
@@ -1,0 +1,24 @@
+{{/* =% text %= */}}
+kind: inventory
+metadata:
+  name: mystack-inventory
+options:
+  WaitBeforeRetryTerminate: 1
+properties:
+  network:
+    - plugin: az1/net
+      labels:
+        az: az1
+        type: network
+        infrakit_collection_name: az1-resources
+    - plugin: az2/net
+      labels:
+        az: az2
+        type: network
+        infrakit_collection_name: az2-resources
+  disks:
+    - plugin: az1/disk
+      labels:
+        az: az1
+        type: storage
+        infrakit_collection_name: az1-resources

--- a/docs/controller/inventory/inventory.yml
+++ b/docs/controller/inventory/inventory.yml
@@ -5,20 +5,17 @@ metadata:
 options:
   WaitBeforeRetryTerminate: 1
 properties:
-  network:
-    - plugin: az1/net
-      labels:
-        az: az1
-        type: network
-        infrakit_collection_name: az1-resources
-    - plugin: az2/net
-      labels:
-        az: az2
-        type: network
-        infrakit_collection_name: az2-resources
   disks:
     - plugin: az1/disk
       labels:
-        az: az1
-        type: storage
-        infrakit_collection_name: az1-resources
+        infrakit_collection: az1-resources
+    - plugin: az2/disk
+      labels:
+        infrakit_collection: az2-resources
+  network:
+    - plugin: az1/net
+      labels:
+        infrakit_collection: az1-resources
+    - plugin: az2/net
+      labels:
+        infrakit_collection: az2-resources

--- a/docs/controller/inventory/inventory.yml
+++ b/docs/controller/inventory/inventory.yml
@@ -3,7 +3,7 @@ kind: inventory
 metadata:
   name: mystack-inventory
 options:
-  WaitBeforeRetryTerminate: 1
+  ObserveInterval: 10s
 properties:
   disks:
     - plugin: az1/disk

--- a/docs/controller/inventory/playbook.yml
+++ b/docs/controller/inventory/playbook.yml
@@ -1,0 +1,8 @@
+
+# Start infrakit
+start : start.sh
+
+az1.yml : az1.yml
+az2.yml : az2.yml
+
+inventory.yml : inventory.yml

--- a/docs/controller/inventory/start.sh
+++ b/docs/controller/inventory/start.sh
@@ -1,0 +1,18 @@
+{{/* =% sh %= */}}
+
+{{ $clearState := flag "clear-state" "bool" "Clear stored states" | prompt "Clear state?" "bool" true }}
+
+{{ if $clearState }}
+rm -rf ~/.infrakit/plugins/* # remove sockets, pid files, etc.
+rm -rf ~/.infrakit/configs/global.config # for file based manager
+# Since we are using file based leader detection, write the default name (manager1) to the leader file.
+echo manager1 > ~/.infrakit/leader
+{{ end }}
+
+# The simulators are started up with different names to mimic different resources
+INFRAKIT_MANAGER_CONTROLLERS=resource,inventory \
+infrakit plugin start manager:mystack vars group resource simulator:az1 simulator:az2 time inventory \
+	 --log 5 --log-stack --log-debug-V 500 \
+	 --log-debug-match module=controller/inventory \
+	 --log-debug-match module=controller/internal \
+	 --log-debug-match module=manager \

--- a/pkg/controller/internal/controller.go
+++ b/pkg/controller/internal/controller.go
@@ -210,6 +210,7 @@ func (c *Controller) Commit(operation controller.Operation, spec types.Spec) (ob
 	copy := spec
 	m, err = c.getManaged(&spec.Metadata, &copy)
 	if err != nil {
+		log.Error("err", "err", err)
 		return
 	}
 

--- a/pkg/controller/internal/observer.go
+++ b/pkg/controller/internal/observer.go
@@ -60,10 +60,11 @@ var (
 
 // Validate validates the receiver with default values provided if some optional fields are not set.
 func (o *InstanceObserver) Validate(defaults *InstanceObserver) error {
-	if err := mergo.Merge(o, defaults); err != nil {
-		return err
+	if defaults != nil {
+		if err := mergo.Merge(o, defaults); err != nil {
+			return err
+		}
 	}
-
 	// critical checks
 	if o.Plugin.Zero() {
 		return fmt.Errorf("missing plugin name")

--- a/pkg/controller/internal/observer.go
+++ b/pkg/controller/internal/observer.go
@@ -112,7 +112,7 @@ func (o *InstanceObserver) Init(scope scope.Scope, retry time.Duration) error {
 		func() bool {
 			o.lock.RLock()
 			defer o.lock.RUnlock()
-			log.Debug("polling", "V", debugV2, "freed", o.paused)
+
 			return !o.paused
 		},
 		// This does the work
@@ -122,6 +122,12 @@ func (o *InstanceObserver) Init(scope scope.Scope, retry time.Duration) error {
 			if err != nil {
 				return err
 			}
+
+			log.Debug("polling", "V", debugV2,
+				"freed", o.paused,
+				"plugin", o.Plugin,
+				"labels", o.Labels,
+				"observed", len(instances))
 
 			// send the current observations
 			select {

--- a/pkg/controller/internal/types.go
+++ b/pkg/controller/internal/types.go
@@ -9,9 +9,11 @@ import (
 )
 
 var (
-	log     = logutil.New("module", "controller/internal")
-	debugV  = logutil.V(500)
-	debugV2 = logutil.V(900)
+	log = logutil.New("module", "controller/internal")
+
+	// this is lower level, with 1 level up (the actual controllers), so give a scaling factor for the verbosity level
+	debugV  = logutil.V(2 * 500)
+	debugV2 = logutil.V(2 * 1000)
 )
 
 // ControlLoop gives status and means to stop the object

--- a/pkg/controller/inventory/collection.go
+++ b/pkg/controller/inventory/collection.go
@@ -1,0 +1,463 @@
+package inventory
+
+import (
+	"context"
+	"time"
+
+	"github.com/docker/infrakit/pkg/controller/internal"
+	inventory "github.com/docker/infrakit/pkg/controller/inventory/types"
+	"github.com/docker/infrakit/pkg/run/scope"
+	"github.com/docker/infrakit/pkg/spi/event"
+	"github.com/docker/infrakit/pkg/spi/instance"
+	"github.com/docker/infrakit/pkg/types"
+	"github.com/imdario/mergo"
+)
+
+type resources map[string]instance.Description
+
+type collection struct {
+	*internal.Collection
+
+	options inventory.Options
+	model   *Model
+
+	resources resources
+
+	accessors map[string]*internal.InstanceAccess
+	deleted   map[string]*internal.InstanceAccess
+
+	cancel func()
+}
+
+var (
+	// TopicFound is the topic for resource found
+	TopicFound = types.PathFromString("ready")
+
+	// TopicLost is the topic for resource lost
+	TopicLost = types.PathFromString("lost")
+
+	// TopicTerminate is the topic for starting to terminate the resource
+	TopicTerminate = types.PathFromString("terminate")
+
+	// TopicErr is the topic for errors
+	TopicErr = types.PathFromString("error")
+)
+
+func newCollection(scope scope.Scope, options inventory.Options) (internal.Managed, error) {
+
+	if err := mergo.Merge(&options, DefaultOptions); err != nil {
+		return nil, err
+	}
+
+	if err := options.Validate(context.Background()); err != nil {
+		return nil, err
+	}
+
+	base, err := internal.NewCollection(scope,
+		TopicFound,
+		TopicLost,
+		TopicErr,
+	)
+	if err != nil {
+		return nil, err
+	}
+	c := &collection{
+		Collection: base,
+		options:    options,
+		resources:  resources{},
+		deleted:    map[string]*internal.InstanceAccess{},
+	}
+	// set the behaviors
+	base.StartFunc = c.run
+	base.StopFunc = c.stop
+	base.UpdateSpecFunc = c.updateSpec
+
+	return c, nil
+}
+
+func (c *collection) updateSpec(spec types.Spec, previous *types.Spec) (err error) {
+
+	prev := spec
+	if previous != nil {
+		prev = *previous
+	}
+
+	log.Debug("updateSpec", "spec", spec, "prev", prev)
+
+	// parse input, then select the model to use
+	properties := inventory.Properties{}
+	err = spec.Properties.Decode(&properties)
+	if err != nil {
+		return
+	}
+
+	prevProperties := inventory.Properties{}
+	err = prev.Properties.Decode(&prevProperties)
+	if err != nil {
+		return
+	}
+
+	options := c.options // the plugin options at initialization are the defaults
+	err = spec.Options.Decode(&options)
+	if err != nil {
+		return
+	}
+
+	ctx := context.Background()
+
+	if err = properties.Validate(ctx); err != nil {
+		return
+	}
+
+	if err = options.Validate(ctx); err != nil {
+		return
+	}
+
+	// NOTE - we are using one client per instance accessor.  This is not the most efficient
+	// if there are resources sharing the same backends.
+
+	accessors := map[string]*internal.InstanceAccess{}
+
+	for name, accessList := range properties {
+
+		for _, access := range accessList {
+			copy := access
+
+			err = c.configureAccessor(spec, name, &copy)
+			if err != nil {
+				return err
+			}
+
+			accessors[name] = &copy
+
+			log.Debug("Initialized INCLUDED accessor", "name", name, "spec", spec, "access", access, "V", debugV2)
+		}
+	}
+
+	deleted := map[string]*internal.InstanceAccess{}
+
+	// For each in the previous spec that's not in the new spec, we need to start up the observation
+	// so that we can detect whether there are real instances that needs to be terminated to match
+	// the deletion in the new spec.
+	for name, accessList := range prevProperties {
+
+		for _, access := range accessList {
+			if _, has := properties[name]; !has {
+
+				// this is no longer in the newer version of the spec, so it's a deletion.
+				// we need to have this still.
+
+				copy := access
+
+				if err := c.configureAccessor(prev, name, &copy); err != nil {
+					return err
+				}
+
+				deleted[name] = &copy
+				log.Debug("Initialize DELETED accessor", "name", name, "spec", spec, "access", access, "V", debugV2)
+			}
+		}
+	}
+
+	c.deleted = deleted
+
+	// build the fsm model
+	var model *Model
+	model, err = BuildModel(properties, options)
+	if err != nil {
+		return
+	}
+
+	c.model = model
+	c.accessors = accessors
+	c.options = options
+	return
+}
+
+func (c *collection) run(ctx context.Context) {
+
+	// Start the model
+	c.model.Start()
+
+	// channels that aggregate from all the instance accessors
+	type observation struct {
+		name      string
+		instances []instance.Description
+	}
+
+	accessors := map[string]*internal.InstanceAccess{}
+
+	for n, a := range c.accessors {
+		accessors[n] = a
+	}
+	for n, a := range c.deleted {
+		accessors[n] = a
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	c.cancel = cancel
+
+	// Start all the instance accessors and wire up the observations.
+	lostInstances := make(chan *observation, c.options.ChannelBufferSize)  // ch to aggregate all lost observations
+	foundInstances := make(chan *observation, c.options.ChannelBufferSize) // ch to aggregate all found observations
+
+	for k, a := range accessors {
+
+		log.Debug("Set up events from instance accessor", "name", k, "V", debugV)
+		go func(name string, accessor *internal.InstanceAccess) {
+
+			for {
+				select {
+				case list, ok := <-accessor.Observations():
+					if !ok {
+						log.Debug("found observations done", "name", name, "V", debugV2)
+						return
+					}
+					if len(list) > 0 {
+						foundInstances <- &observation{name: name, instances: list}
+						log.Debug("accessor found instances", "name", name, "count", len(list), "V", debugV)
+					}
+				case list, ok := <-accessor.Lost():
+					if !ok {
+						log.Debug("lost events done", "name", name, "V", debugV2)
+						return
+					}
+					if len(list) > 0 {
+						lostInstances <- &observation{name: name, instances: list}
+						log.Debug("accessor lost instances", "name", name, "count", len(list), "V", debugV)
+					}
+				}
+			}
+		}(k, a)
+
+		a.Start()
+		log.Debug("accessor started", "key", k)
+	}
+
+	go func() {
+
+	loop:
+		for {
+
+			select {
+
+			case f, ok := <-c.model.Cleanup():
+				if !ok {
+					return
+				}
+				item := c.Collection.GetByFSM(f)
+				if item != nil {
+					c.Collection.Delete(item.Key)
+				}
+			case f, ok := <-c.model.Found():
+				if !ok {
+					return
+				}
+				item := c.Collection.GetByFSM(f)
+				if item != nil {
+					c.EventCh() <- event.Event{
+						Topic:   c.Topic(TopicFound),
+						Type:    event.Type("Found"),
+						ID:      c.EventID(item.Key),
+						Message: "resource found",
+					}.Init()
+				}
+
+			case f, ok := <-c.model.Lost():
+				if !ok {
+					return
+				}
+				item := c.Collection.GetByFSM(f)
+				if item != nil {
+					c.EventCh() <- event.Event{
+						Topic:   c.Topic(TopicLost),
+						Type:    event.Type("Lost"),
+						ID:      c.EventID(item.Key),
+						Message: "resource lost",
+					}.Init()
+				}
+
+			case f, ok := <-c.model.Destroy():
+				if !ok {
+					return
+				}
+
+				item := c.Collection.GetByFSM(f)
+				if item != nil {
+
+					accessor := c.accessors[item.Key]
+					log.Info("Destroy", "fsm", f.ID(), "item", item, "accessor", accessor)
+
+					// !!!! This actually is *always* nil in the case where the accessor
+					// section has been removed and we discover an instance that doesn't
+					// correspond to anything.
+					// The correct approach would be to use the *previous* version of the spec
+					if accessor == nil {
+						found, has := c.deleted[item.Key]
+						if has {
+							accessor = found
+						}
+					}
+
+					if accessor == nil {
+						log.Error("cannot find accessor for key", "key", item.Key)
+						continue loop
+					}
+
+					// TODO - call instancePlugin.Destroy
+					d := item.Data["instance"]
+					if d == nil {
+						log.Error("cannot find instance", "item", item.Key)
+						continue loop
+					}
+
+					if dd, is := d.(instance.Description); is {
+
+						log.Info("Destroy", "instanceID", dd.ID, "key", item.Key)
+						err := accessor.Destroy(dd.ID, instance.Termination)
+						log.Debug("destroy", "instanceID", dd.ID, "key", item.Key, "err", err)
+
+						if err != nil {
+							c.EventCh() <- event.Event{
+								Topic:   c.Topic(TopicErr),
+								Type:    event.Type("TerminateErr"),
+								ID:      c.EventID(item.Key),
+								Message: "destroying resource error",
+							}.Init().WithError(err)
+						} else {
+							c.EventCh() <- event.Event{
+								Topic:   c.Topic(TopicTerminate),
+								Type:    event.Type("Terminate"),
+								ID:      c.EventID(item.Key),
+								Message: "destroyed resource",
+							}.Init()
+						}
+					}
+				}
+
+			case lost, ok := <-lostInstances:
+				if !ok {
+					log.Info("Lost aggregator done")
+					return
+				}
+
+				accessor, has := accessors[lost.name]
+				if !has {
+					log.Warn("cannot find accessor for lost instance", "name", lost.name)
+					break
+				}
+
+				// Update the view in the metadata plugin
+				c.MetadataGone(accessor.KeyOf, lost.instances)
+
+				for _, n := range lost.instances {
+					k, err := accessor.KeyOf(n)
+					if err != nil {
+						log.Error("error getting key", "err", err, "instance", n)
+						break
+					}
+
+					if item := c.Collection.Get(k); item != nil {
+						log.Error("lost", "instance", n, "name", lost.name, "key", k)
+						item.State.Signal(resourceLost)
+					}
+					delete(c.resources, k)
+				}
+
+			case found, ok := <-foundInstances:
+				if !ok {
+					log.Info("Found aggregator done")
+					return
+				}
+
+				accessor, has := accessors[found.name]
+				if !has {
+					log.Warn("cannot find accessor for found instance", "name", found.name)
+					break
+				}
+
+				// Update the view in the metadata plugin
+				export := []instance.Description{}
+
+				for _, n := range found.instances {
+					k, err := accessor.KeyOf(n)
+					if err != nil {
+						log.Error("error getting key", "err", err, "instance", n)
+						break
+					}
+					item := c.Collection.Get(k)
+					if item == nil {
+
+						// In this case, the fsm isn't requested.. it's something we get out of band
+						// that somehow shows up (or from previous runs but now the user has
+						// removed it from the spec and performed a commit.
+						f := c.model.New()
+						item = c.Put(k, f, c.model.Spec(), map[string]interface{}{
+							"instance": n,
+						})
+
+						log.Debug("New instance", "fsm", f, "instance", n, "V", debugV)
+
+						export = append(export, n) // export to metadata
+
+					} else {
+						// if we already have entries stored, then see if the data changed
+						prev := item.Data["instance"]
+						if prev == nil {
+							export = append(export, n)
+						} else if dd, is := prev.(instance.Description); is {
+							if dd.Fingerprint() != n.Fingerprint() {
+								export = append(export, n)
+							}
+						}
+					}
+
+					c.resources[k] = n
+
+					log.Debug("found", "instance", n, "name", found.name, "key", k, "V", debugV2)
+					item.State.Signal(resourceFound)
+					item.Data["instance"] = n
+				}
+
+				c.MetadataExport(accessor.KeyOf, export)
+			}
+		}
+	}()
+
+}
+
+func (c *collection) stop() error {
+	log.Info("stop")
+
+	if c.model != nil {
+
+		c.cancel()
+
+		for k, accessor := range c.accessors {
+			log.Debug("Stopping", "name", k, "V", debugV)
+			accessor.Stop()
+		}
+
+		for k, accessor := range c.deleted {
+			log.Debug("Stopping", "name", k, "V", debugV)
+			accessor.Stop()
+		}
+
+		c.model.Stop()
+		c.model = nil
+	}
+	return nil
+}
+
+func (c *collection) configureAccessor(spec types.Spec, name string, access *internal.InstanceAccess) error {
+	if access.Labels == nil {
+		access.Labels = map[string]string{}
+	}
+
+	err := access.InstanceObserver.Validate(DefaultAccessProperties)
+	if err != nil {
+		return err
+	}
+
+	return access.Init(c.Scope(), c.options.PluginRetryInterval.AtLeast(1*time.Second))
+}

--- a/pkg/controller/inventory/collection.go
+++ b/pkg/controller/inventory/collection.go
@@ -121,6 +121,7 @@ func (c *collection) updateSpec(spec types.Spec, previous *types.Spec) (err erro
 	for name, accessList := range properties {
 
 		for _, access := range accessList {
+
 			copy := access
 
 			err = c.configureAccessor(spec, name, &copy)
@@ -128,9 +129,11 @@ func (c *collection) updateSpec(spec types.Spec, previous *types.Spec) (err erro
 				return err
 			}
 
-			accessors[name] = &copy
+			key := types.Path([]string{name, copy.InstanceObserver.Plugin.String()})
+			accessors[key.String()] = &copy
 
-			log.Debug("Initialized INCLUDED accessor", "name", name, "spec", spec, "access", access, "V", debugV2)
+			log.Debug("Initialized INCLUDED accessor", "name", name, "key", key,
+				"spec", spec, "access", access, "V", debugV2)
 		}
 	}
 
@@ -153,8 +156,11 @@ func (c *collection) updateSpec(spec types.Spec, previous *types.Spec) (err erro
 					return err
 				}
 
-				deleted[name] = &copy
-				log.Debug("Initialize DELETED accessor", "name", name, "spec", spec, "access", access, "V", debugV2)
+				key := types.Path([]string{name, copy.InstanceObserver.Plugin.String()})
+				deleted[key.String()] = &copy
+
+				log.Debug("Initialize DELETED accessor", "name", name, "key", key,
+					"spec", spec, "access", access, "V", debugV2)
 			}
 		}
 	}
@@ -193,6 +199,8 @@ func (c *collection) run(ctx context.Context) {
 	for n, a := range c.deleted {
 		accessors[n] = a
 	}
+
+	log.Info("starting up accessors", "len", len(accessors))
 
 	ctx, cancel := context.WithCancel(context.Background())
 	c.cancel = cancel

--- a/pkg/controller/inventory/controller.go
+++ b/pkg/controller/inventory/controller.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/docker/infrakit/pkg/controller/internal"
 	inventory "github.com/docker/infrakit/pkg/controller/inventory/types"
-	"github.com/docker/infrakit/pkg/fsm"
 	logutil "github.com/docker/infrakit/pkg/log"
 	"github.com/docker/infrakit/pkg/run/scope"
 	"github.com/docker/infrakit/pkg/spi/controller"
@@ -23,6 +22,11 @@ var (
 
 	// DefaultOptions return an Options with default values filled in.
 	DefaultOptions = inventory.Options{
+		InstanceObserver: &internal.InstanceObserver{
+			ObserveInterval: types.Duration(1 * time.Second),
+			KeySelector: template.EscapeString(fmt.Sprintf(`{{.Tags.%s}}/{{.Tags.%s}}`,
+				internal.CollectionLabel, internal.InstanceLabel)),
+		},
 		PluginRetryInterval:  types.Duration(1 * time.Second),
 		MinChannelBufferSize: 10,
 		ModelProperties:      DefaultModelProperties,
@@ -30,21 +34,12 @@ var (
 
 	// DefaultModelProperties is the default properties for the fsm model
 	DefaultModelProperties = inventory.ModelProperties{
-		TickUnit:                 types.FromDuration(1 * time.Second),
-		WaitBeforeRetryTerminate: fsm.Tick(10),
-		WaitBeforeCleanup:        fsm.Tick(10),
-		ChannelBufferSize:        10,
+		TickUnit:          types.FromDuration(1 * time.Second),
+		ChannelBufferSize: 10,
 	}
 
 	// DefaultProperties is the default properties for the controller, this is per collection / commit
 	DefaultProperties = inventory.Properties{}
-
-	// DefaultAccessProperties specifies some default parameters
-	DefaultAccessProperties = &internal.InstanceObserver{
-		ObserveInterval: types.Duration(1 * time.Second),
-		KeySelector: template.EscapeString(fmt.Sprintf(`{{.Tags.%s}}/{{.Tags.%s}}`,
-			internal.CollectionLabel, internal.InstanceLabel)),
-	}
 )
 
 // Components contains a set of components in this controller.

--- a/pkg/controller/inventory/controller.go
+++ b/pkg/controller/inventory/controller.go
@@ -1,0 +1,76 @@
+package inventory
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/docker/infrakit/pkg/controller/internal"
+	inventory "github.com/docker/infrakit/pkg/controller/inventory/types"
+	"github.com/docker/infrakit/pkg/fsm"
+	logutil "github.com/docker/infrakit/pkg/log"
+	"github.com/docker/infrakit/pkg/run/scope"
+	"github.com/docker/infrakit/pkg/spi/controller"
+	"github.com/docker/infrakit/pkg/spi/event"
+	"github.com/docker/infrakit/pkg/spi/metadata"
+	"github.com/docker/infrakit/pkg/template"
+	"github.com/docker/infrakit/pkg/types"
+)
+
+var (
+	log     = logutil.New("module", "controller/inventory")
+	debugV  = logutil.V(500)
+	debugV2 = logutil.V(1000)
+
+	// DefaultOptions return an Options with default values filled in.
+	DefaultOptions = inventory.Options{
+		PluginRetryInterval:  types.Duration(1 * time.Second),
+		MinChannelBufferSize: 10,
+		ModelProperties:      DefaultModelProperties,
+	}
+
+	// DefaultModelProperties is the default properties for the fsm model
+	DefaultModelProperties = inventory.ModelProperties{
+		TickUnit:                 types.FromDuration(1 * time.Second),
+		WaitBeforeRetryTerminate: fsm.Tick(10),
+		WaitBeforeCleanup:        fsm.Tick(10),
+		ChannelBufferSize:        10,
+	}
+
+	// DefaultProperties is the default properties for the controller, this is per collection / commit
+	DefaultProperties = inventory.Properties{}
+
+	// DefaultAccessProperties specifies some default parameters
+	DefaultAccessProperties = &internal.InstanceObserver{
+		ObserveInterval: types.Duration(1 * time.Second),
+		KeySelector: template.EscapeString(fmt.Sprintf(`{{.Tags.%s}}/{{.Tags.%s}}`,
+			internal.CollectionLabel, internal.InstanceLabel)),
+	}
+)
+
+// Components contains a set of components in this controller.
+type Components struct {
+	Controllers func() (map[string]controller.Controller, error)
+	Metadata    func() (map[string]metadata.Plugin, error)
+	Events      event.Plugin
+}
+
+// NewComponents returns a controller implementation
+func NewComponents(scope scope.Scope, options inventory.Options) *Components {
+
+	controller := internal.NewController(
+		// the constructor
+		func(spec types.Spec) (internal.Managed, error) {
+			return newCollection(scope, options)
+		},
+		// the key function
+		func(metadata types.Metadata) string {
+			return metadata.Name
+		},
+	)
+
+	return &Components{
+		Controllers: controller.Controllers,
+		Metadata:    controller.Metadata,
+		Events:      controller,
+	}
+}

--- a/pkg/controller/inventory/fsm.go
+++ b/pkg/controller/inventory/fsm.go
@@ -1,0 +1,215 @@
+package inventory
+
+import (
+	"sync"
+	"time"
+
+	inventory "github.com/docker/infrakit/pkg/controller/inventory/types"
+	"github.com/docker/infrakit/pkg/fsm"
+)
+
+// Model encapsulates the workflow / state machines for provisioning resources
+type Model struct {
+	spec     *fsm.Spec
+	set      *fsm.Set
+	clock    *fsm.Clock
+	tickSize time.Duration
+
+	inventory.Properties
+
+	instanceDestroyChan chan fsm.FSM
+	instanceFoundChan   chan fsm.FSM
+	instanceLostChan    chan fsm.FSM
+	cleanupChan         chan fsm.FSM
+
+	lock sync.RWMutex
+}
+
+// Cleanup is the channel to get signals to clean up
+func (m *Model) Cleanup() <-chan fsm.FSM {
+	return m.cleanupChan
+}
+
+// Destroy is the channel to get signals to destroy an instance
+func (m *Model) Destroy() <-chan fsm.FSM {
+	return m.instanceDestroyChan
+}
+
+// Found is the channel to get signals of instances that are found
+func (m *Model) Found() <-chan fsm.FSM {
+	return m.instanceFoundChan
+}
+
+// Lost is the channel to get signals of instances that are lost
+func (m *Model) Lost() <-chan fsm.FSM {
+	return m.instanceLostChan
+}
+
+// New adds a new fsm in the found (initial) state
+func (m *Model) New() fsm.FSM {
+	return m.set.Add(found)
+}
+
+// Spec returns the model description
+func (m *Model) Spec() *fsm.Spec {
+	m.lock.RLock()
+	defer m.lock.RUnlock()
+
+	return m.spec
+}
+
+// Start starts the model
+func (m *Model) Start() {
+	m.lock.Lock()
+	defer m.lock.Unlock()
+
+	if m.set == nil {
+		m.clock.Start()
+		m.set = fsm.NewSet(m.spec, m.clock, fsm.DefaultOptions("inventory"))
+	}
+}
+
+// Stop stops the model
+func (m *Model) Stop() {
+	m.lock.Lock()
+	defer m.lock.Unlock()
+
+	if m.set != nil {
+		m.set.Stop()
+		m.clock.Stop()
+
+		close(m.instanceDestroyChan)
+		close(m.instanceFoundChan)
+		close(m.instanceLostChan)
+		close(m.cleanupChan)
+		m.set = nil
+	}
+
+}
+
+const (
+
+	// States
+	found fsm.Index = iota
+	lost
+	terminating
+	terminated
+
+	// Signals
+	resourceFound fsm.Signal = iota
+	resourceLost
+	obeserveError
+	terminate
+	terminateError
+	cleanup
+)
+
+var (
+	stateNames = map[fsm.Index]string{
+		found:       "FOUND",
+		lost:        "LOST",
+		terminating: "TERMINATING",
+		terminated:  "TERMINATED",
+	}
+
+	signalNames = map[fsm.Signal]string{
+		resourceFound:  "resource_found",
+		resourceLost:   "resource_lost",
+		terminate:      "terminate",
+		cleanup:        "cleanup",
+		terminateError: "terminate_error",
+	}
+)
+
+// BuildModel constructs a workflow model given the configuration blob provided by user in the Properties
+func BuildModel(properties inventory.Properties, options inventory.Options) (*Model, error) {
+
+	log.Info("Build model", "properties", properties)
+	model := &Model{
+		Properties:          properties,
+		instanceDestroyChan: make(chan fsm.FSM, options.ChannelBufferSize),
+		instanceFoundChan:   make(chan fsm.FSM, options.ChannelBufferSize),
+		instanceLostChan:    make(chan fsm.FSM, options.ChannelBufferSize),
+		cleanupChan:         make(chan fsm.FSM, options.ChannelBufferSize),
+		tickSize:            1 * time.Second,
+	}
+
+	// find the max observation interval and set the model tick to be that
+	for _, accessList := range properties {
+		for _, accessor := range accessList {
+			if model.tickSize < accessor.ObserveInterval.Duration() {
+				model.tickSize = accessor.ObserveInterval.Duration()
+			}
+		}
+	}
+
+	model.clock = fsm.Wall(time.Tick(model.tickSize))
+	spec, err := fsm.With(stateNames, signalNames).Define(
+		fsm.State{
+			Index: found,
+			Transitions: map[fsm.Signal]fsm.Index{
+				resourceFound: found,
+				resourceLost:  lost,
+				terminate:     terminating,
+			},
+			Actions: map[fsm.Signal]fsm.Action{
+				resourceLost: func(n fsm.FSM) error {
+					model.instanceLostChan <- n
+					return nil
+				},
+				terminate: func(n fsm.FSM) error {
+					model.instanceDestroyChan <- n
+					return nil
+				},
+			},
+		},
+		fsm.State{
+			Index: lost,
+			Transitions: map[fsm.Signal]fsm.Index{
+				resourceFound: found,
+			},
+			Actions: map[fsm.Signal]fsm.Action{
+				resourceFound: func(n fsm.FSM) error {
+					model.instanceFoundChan <- n
+					return nil
+				},
+			},
+		},
+		fsm.State{
+			Index: terminating,
+			TTL:   fsm.Expiry{options.WaitBeforeRetryTerminate, terminate},
+			Transitions: map[fsm.Signal]fsm.Index{
+				terminate:      terminating,
+				terminateError: terminating,
+				resourceLost:   terminated,
+			},
+			Actions: map[fsm.Signal]fsm.Action{
+				terminate: func(n fsm.FSM) error {
+					model.instanceDestroyChan <- n
+					return nil
+				},
+			},
+		},
+		fsm.State{
+			Index: terminated,
+			TTL:   fsm.Expiry{options.WaitBeforeCleanup, cleanup},
+			Transitions: map[fsm.Signal]fsm.Index{
+				cleanup: terminated, // TODO - this is really unnecessary
+			},
+			Actions: map[fsm.Signal]fsm.Action{
+				cleanup: func(n fsm.FSM) error {
+					model.cleanupChan <- n
+					return nil
+				},
+			},
+		},
+	)
+
+	log.Info("model", "tickSize", model.tickSize, "err", err)
+	if err != nil {
+		panic(err) // Panic because there's a problem with the static / code definition of the model
+	}
+
+	model.spec = spec
+	return model, nil
+}

--- a/pkg/controller/inventory/types/types.go
+++ b/pkg/controller/inventory/types/types.go
@@ -1,0 +1,91 @@
+package types
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/docker/infrakit/pkg/controller/internal"
+	"github.com/docker/infrakit/pkg/fsm"
+	logutil "github.com/docker/infrakit/pkg/log"
+	"github.com/docker/infrakit/pkg/run/depends"
+	"github.com/docker/infrakit/pkg/spi/controller"
+	"github.com/docker/infrakit/pkg/types"
+)
+
+var (
+	log    = logutil.New("module", "controller/inventory/types")
+	debugV = logutil.V(200)
+)
+
+func init() {
+	depends.Register("inventory", types.InterfaceSpec(controller.InterfaceSpec), ResolveDependencies)
+}
+
+// ResolveDependencies returns a list of dependencies by parsing the opaque Properties blob.
+func ResolveDependencies(spec types.Spec) (depends.Runnables, error) {
+	if spec.Properties == nil {
+		return nil, nil
+	}
+
+	properties := Properties{}
+	err := spec.Properties.Decode(&properties)
+	if err != nil {
+		return nil, err
+	}
+
+	dep := depends.Runnables{}
+	for _, accessList := range properties {
+		for _, access := range accessList {
+			dep = append(dep,
+				depends.AsRunnable(
+					types.Spec{
+						Kind: access.InstanceObserver.Plugin.Lookup(),
+						Metadata: types.Metadata{
+							Name: access.InstanceObserver.Plugin.String(),
+						},
+					},
+				))
+		}
+	}
+	return dep, nil
+}
+
+// Properties is the schema of the configuration in the types.Spec.Properties
+type Properties map[string][]internal.InstanceAccess
+
+// ModelProperties contain fsm tuning parameters
+type ModelProperties struct {
+	TickUnit                 types.Duration
+	WaitBeforeRetryTerminate fsm.Tick
+	WaitBeforeCleanup        fsm.Tick
+	ChannelBufferSize        int
+}
+
+// Validate validates the input properties
+func (p Properties) Validate(ctx context.Context) error {
+	return nil
+}
+
+// Options is the controller options that is used at start up of the process.  It's one-time
+type Options struct {
+
+	// PluginRetryInterval is the interval for retrying to connect to the plugins
+	PluginRetryInterval types.Duration
+
+	// MinChannelBufferSize is the min size of the buffered chanels
+	MinChannelBufferSize int
+
+	// ModelProperties capture the config parameters of the workflow model
+	ModelProperties `json:",inline" yaml:",inline"`
+}
+
+// Validate validates the controller's options
+func (p Options) Validate(ctx context.Context) error {
+	if p.MinChannelBufferSize == 0 {
+		return fmt.Errorf("lost buffer size cannot be 0")
+	}
+	if p.ChannelBufferSize < p.MinChannelBufferSize {
+		return fmt.Errorf("channel buffer size can't be less than %v", p.MinChannelBufferSize)
+	}
+	return nil
+}

--- a/pkg/controller/inventory/types/types.go
+++ b/pkg/controller/inventory/types/types.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 
 	"github.com/docker/infrakit/pkg/controller/internal"
-	"github.com/docker/infrakit/pkg/fsm"
 	logutil "github.com/docker/infrakit/pkg/log"
 	"github.com/docker/infrakit/pkg/run/depends"
 	"github.com/docker/infrakit/pkg/spi/controller"
@@ -55,10 +54,8 @@ type Properties map[string][]internal.InstanceAccess
 
 // ModelProperties contain fsm tuning parameters
 type ModelProperties struct {
-	TickUnit                 types.Duration
-	WaitBeforeRetryTerminate fsm.Tick
-	WaitBeforeCleanup        fsm.Tick
-	ChannelBufferSize        int
+	TickUnit          types.Duration
+	ChannelBufferSize int
 }
 
 // Validate validates the input properties
@@ -68,6 +65,7 @@ func (p Properties) Validate(ctx context.Context) error {
 
 // Options is the controller options that is used at start up of the process.  It's one-time
 type Options struct {
+	*internal.InstanceObserver `json:",inline" yaml:",inline"`
 
 	// PluginRetryInterval is the interval for retrying to connect to the plugins
 	PluginRetryInterval types.Duration

--- a/pkg/fsm/errors.go
+++ b/pkg/fsm/errors.go
@@ -8,41 +8,43 @@ import (
 type ErrDuplicateState Index
 
 func (e ErrDuplicateState) Error() string {
-	return fmt.Sprintf("duplicated state index")
+	return fmt.Sprintf("duplicated state index: %v", e)
 }
 
 // ErrUnknownState indicates the state referenced does not match a known state index
 type ErrUnknownState Index
 
 func (e ErrUnknownState) Error() string {
-	return fmt.Sprintf("unknown state")
+	return fmt.Sprintf("unknown state: %v", e)
 }
 
 // ErrUnknownTransition indicates an unknown signal while in given state is raised
 type ErrUnknownTransition struct {
+	spec   *Spec
 	Signal Signal
 	State  Index
 }
 
 func (e ErrUnknownTransition) Error() string {
-	return fmt.Sprintf("unknown stransition")
+	return fmt.Sprintf("unknown stransition: signal=%v, state=%v", e.spec.SignalName(e.Signal), e.spec.StateName(e.State))
 }
 
 // ErrUnknownSignal is raised when a undefined signal is received in the given state
 type ErrUnknownSignal struct {
+	spec   *Spec
 	Signal Signal
 	State  Index
 }
 
 func (e ErrUnknownSignal) Error() string {
-	return fmt.Sprintf("unknown signal")
+	return fmt.Sprintf("unknown signal: signal=%v, state=%v", e.spec.SignalName(e.Signal), e.spec.StateName(e.State))
 }
 
 // ErrUnknownFSM is raised when the ID is does not match any thing in the set
 type ErrUnknownFSM ID
 
 func (e ErrUnknownFSM) Error() string {
-	return fmt.Sprintf("unknown instance")
+	return fmt.Sprintf("unknown instance: %v", e)
 }
 
 // ErrNilAction is raised when an action is nil

--- a/pkg/fsm/fsm.go
+++ b/pkg/fsm/fsm.go
@@ -143,6 +143,9 @@ func (s *Spec) SetSignalNames(v map[Signal]string) *Spec {
 // StateName returns the friendly name of the state, if defined
 func (s *Spec) StateName(i Index) (name string) {
 	name = fmt.Sprintf("%v", i)
+	if s == nil {
+		return
+	}
 	if s.stateNames == nil {
 		return
 	}
@@ -155,6 +158,10 @@ func (s *Spec) StateName(i Index) (name string) {
 // SignalName returns the friendly name of the signal, if defined
 func (s *Spec) SignalName(signal Signal) (name string) {
 	name = fmt.Sprintf("%v", signal)
+	if s == nil {
+		return
+	}
+
 	if s.signalNames == nil {
 		return
 	}

--- a/pkg/fsm/fsm_test.go
+++ b/pkg/fsm/fsm_test.go
@@ -26,7 +26,7 @@ func TestDefinition(t *testing.T) {
 		},
 	}
 
-	_, err := compile(m)
+	_, err := newSpec().compile(m)
 	require.Error(t, err)
 
 	// add missing
@@ -38,7 +38,7 @@ func TestDefinition(t *testing.T) {
 		Visit: Limit{5, turnOn},
 	}
 
-	_, err = compile(m)
+	_, err = newSpec().compile(m)
 	require.NoError(t, err)
 
 	states := []State{}

--- a/pkg/manager/controller_proxy.go
+++ b/pkg/manager/controller_proxy.go
@@ -124,7 +124,7 @@ func (m controllerAdapter) Commit(op controller.Operation, spec types.Spec) (obj
 		return
 	}
 
-	retry := true
+	retry := false
 	<-m.manager.queue("commit",
 		func() (bool, error) {
 			object, err = m.backend.Commit(op, spec)

--- a/pkg/manager/group_proxy.go
+++ b/pkg/manager/group_proxy.go
@@ -87,7 +87,7 @@ func (m *manager) CommitGroup(grp group.Spec, pretend bool) (resp string, err er
 		return
 	}
 
-	retry := true
+	retry := false
 	<-m.queue("commit",
 		func() (bool, error) {
 			log.Debug("Manager CommitGroup", "spec", grp, "V", debugV)

--- a/pkg/run/v0/inventory/inventory.go
+++ b/pkg/run/v0/inventory/inventory.go
@@ -1,0 +1,92 @@
+package inventory
+
+import (
+	"github.com/docker/infrakit/pkg/controller/inventory"
+	"github.com/docker/infrakit/pkg/discovery"
+	"github.com/docker/infrakit/pkg/launch/inproc"
+	logutil "github.com/docker/infrakit/pkg/log"
+	"github.com/docker/infrakit/pkg/plugin"
+	"github.com/docker/infrakit/pkg/rpc/client"
+	manager_rpc "github.com/docker/infrakit/pkg/rpc/manager"
+	"github.com/docker/infrakit/pkg/run"
+	"github.com/docker/infrakit/pkg/run/scope"
+	"github.com/docker/infrakit/pkg/spi/controller"
+	"github.com/docker/infrakit/pkg/spi/stack"
+	"github.com/docker/infrakit/pkg/types"
+)
+
+const (
+	// Kind is the canonical name of the plugin for starting up, etc.
+	Kind = "inventory"
+)
+
+var (
+	log = logutil.New("module", "run/v0/inventory")
+
+	defaultOptions = inventory.DefaultOptions
+)
+
+func init() {
+
+	inproc.Register(Kind, Run, defaultOptions)
+}
+
+func leadership(plugins func() discovery.Plugins) stack.Leadership {
+	// Scan for a manager
+	pm, err := plugins().List()
+	if err != nil {
+		log.Error("Cannot list plugins", "err", err)
+		return nil
+	}
+
+	for _, endpoint := range pm {
+		rpcClient, err := client.New(endpoint.Address, stack.InterfaceSpec)
+		if err == nil {
+			return manager_rpc.Adapt(rpcClient)
+		}
+
+		if !client.IsErrInterfaceNotSupported(err) {
+			log.Error("Got error getting manager", "endpoint", endpoint, "err", err)
+			return nil
+		}
+	}
+	return nil
+}
+
+// Run runs the plugin, blocking the current thread.  Error is returned immediately
+// if the plugin cannot be started.
+func Run(scope scope.Scope, name plugin.Name,
+	config *types.Any) (transport plugin.Transport, impls map[run.PluginCode]interface{}, onStop func(), err error) {
+
+	options := defaultOptions // decode into a copy of the updated defaults
+	err = config.Decode(&options)
+	if err != nil {
+		return
+	}
+
+	log.Info("Decoded input", "config", options)
+
+	transport.Name = name
+
+	inventory := inventory.NewComponents(scope, options)
+
+	leader := func() stack.Leadership {
+		return leadership(scope.Plugins)
+	}
+
+	impls = map[run.PluginCode]interface{}{
+		run.Controller: func() (map[string]controller.Controller, error) {
+			singletons := map[string]controller.Controller{}
+			if controllers, err := inventory.Controllers(); err == nil {
+				for k, c := range controllers {
+					singletons[k] = controller.Singleton(c, leader)
+				}
+			}
+			return singletons, nil
+		},
+		run.Metadata: inventory.Metadata,
+		run.Event:    inventory.Events,
+	}
+
+	return
+}


### PR DESCRIPTION
Inventory controller: a controller that monitors resources from different instance plugins.  
This controller exposes the event and metadata interfaces so that as resources are provisioned or destroyed, events can be seen via the `/found` and `/lost` topics.  It also exposes metadata
interface so that the properties of resources can be queried in a path-like manner.

Docs/playbooks available in `docs/controller/inventory/playbook.yml`

Signed-off-by: David Chung <david.chung@docker.com>