### PR TITLE
Use Infrakit Playbooks in Your Own Custom CLI

### DIFF
--- a/examples/go/cli/README.md
+++ b/examples/go/cli/README.md
@@ -1,0 +1,175 @@
+Using Infrakit Playbooks in Your Custom CLI
+===========================================
+
+The `main.go` in this directory shows how you can incorporate Infrakit
+playbooks in your own custom go program.
+
+Infrakit playbooks are template files that are rendered as input to some
+supported backend.   The tempates can be bound to command
+line flags and sub-commands via pre-defined template functions.  For example:
+
+```
+{{/* Render this document and then post to httpbin */}}
+{{/* Add this as a playbook command via infrakit playbook add test url-to-this-file */}}
+
+{{ $method := flag "http-method" "string" "POST" | prompt "http method?" "string" "POST" }}
+{{ $message := flag "message" "string" "" | prompt "message?" "string" "" }}
+
+{{ (cat `https://httpbin.org/` (lower $method) | nospace ) | var `url` }}
+{{ var `method` $method }}
+
+{{/* =% http (var `method`) (var `url`) `Content-Type=application/json`  %= */}}
+
+{
+  "message" : "{{ $message }}"
+}
+
+```
+
+This is a playbook that uses the `http` backend (via the `{{/* =% http %= */}}`)
+directive in the document.  Template variables are bound to command line flags
+via the `flag` and `prompt` functions.  When executed the CLI will capture
+user input via flag or prompt to render the template as input to the backend.
+So in this case, the CLI will render the JSON document and does a HTTP request
+to the backend service (`https://httpbin.org`).
+
+You can construct multiple commands like this in `playbook.yml`:
+
+```
+# This is an index file for a playbook module that contains
+# multiple commands
+
+httpbin : httpbin.json
+
+lines : lines.sh
+```
+
+There are two commands `httpbin` and `lines` in this playbook.
+
+## How to build your own CLI
+
+The `main.go` program shows the basics:
+
+1. Load the backends you want to support via anonymous imports.  For example:
+
+```
+import (
+	_ "github.com/docker/infrakit/pkg/callable/backend/http"
+	_ "github.com/docker/infrakit/pkg/callable/backend/print"
+	_ "github.com/docker/infrakit/pkg/callable/backend/sh"
+	_ "github.com/docker/infrakit/pkg/callable/backend/ssh"
+)
+```
+
+Will provide support in your program for backends like `{{/* =% http %= */}}`
+or `{{/* =% ssh %= */}}`.
+
+2. In this example, we want the first argument to be a URL for a playbook.
+Use this URL to load the playbook:
+
+```
+	playbooks, err := playbook.NewModules(
+		scope.Nil,
+		playbook.Modules{
+			playbook.Op(prog): playbook.SourceURL(makeURL(os.Args[1])),
+		},
+		os.Stdin, template.Options{})
+
+```
+
+3. The playbooks `List()` function will return a list of `cobra.Command`
+for adding to your CLI.  In this case we only have one URL, so we'd have
+only one command.
+
+4. Set the args for the command returned.  In this case, we used the first
+and second args (first is the program name and second is the URL itself),
+so we want to set the args to `os.Args[2:]` to the returned command so that
+it thinks it's executing like a program where it's `os.Args[0]`.
+
+5. Execute the command.
+
+
+## Build the program
+
+```
+go build -o mycli github.com/docker/infrakit/examples/go/cli
+```
+
+Now you should have a binary called `mycli`.
+
+If the URL points to a single playbook command file:
+
+```
+$ ./mycli ./examples/go/cli/httpbin.json --help
+mycli
+
+Usage:
+  mycli [flags]
+
+Flags:
+      --accept-defaults               True to accept defaults of prompts and flags
+      --http-method string            POST
+      --log int                       log level (default 4)
+      --log-caller                    include caller function (default true)
+      --log-debug-V int               log debug verbosity level. 0=logs all
+      --log-debug-match stringSlice   debug mode only -- select records with any of the k=v pairs
+      --log-debug-match-exclude       True to exclude; otherwise only include matches
+      --log-format string             log format: logfmt|term|json (default "term")
+      --log-stack                     include caller stack
+      --log-stdout                    log to stdout
+      --message string
+      --print-only                    True to print the rendered input
+      --test                          True to do a trial run
+
+```
+Running it:
+
+```
+$ ./mycli ./examples/go/cli/httpbin.json
+http method? [POST]:
+message? : hello
+{
+  "args": {},
+  "data": "\n\n\n\n\n\n\n\n\n\n\n{\n  \"message\" : \"hello\"\n}\n",
+  "files": {},
+  "form": {},
+  "headers": {
+    "Accept-Encoding": "gzip",
+    "Connection": "close",
+    "Content-Length": "37",
+    "Content-Type": "application/json",
+    "Host": "httpbin.org",
+    "User-Agent": "infrakit-cli/0.5"
+  },
+  "json": {
+    "message": "hello"
+  },
+  "origin": "76.184.96.167",
+  "url": "https://httpbin.org/post"
+}
+
+```
+
+If the URL points to an index yml:
+```
+$ ./mycli ./examples/go/cli/playbook.yml
+mycli
+
+Usage:
+  mycli [command]
+
+Available Commands:
+  httpbin     httpbin
+  lines       lines
+```
+
+Running the subcommands:
+
+```
+$ ./mycli ./examples/go/cli/playbook.yml lines --header hello --lines 5
+hello 1
+hello 2
+hello 3
+hello 4
+hello 5
+```

--- a/examples/go/cli/httpbin.json
+++ b/examples/go/cli/httpbin.json
@@ -1,0 +1,14 @@
+{{/* Render this document and then post to httpbin */}}
+{{/* Add this as a playbook command via infrakit playbook add test url-to-this-file */}}
+
+{{ $method := flag "http-method" "string" "POST" | prompt "http method?" "string" "POST" }}
+{{ $message := flag "message" "string" "" | prompt "message?" "string" "" }}
+
+{{ (cat `https://httpbin.org/` (lower $method) | nospace ) | var `url` }}
+{{ var `method` $method }}
+
+{{/* =% http (var `method`) (var `url`) `Content-Type=application/json`  %= */}}
+
+{
+  "message" : "{{ $message }}"
+}

--- a/examples/go/cli/lines.sh
+++ b/examples/go/cli/lines.sh
@@ -1,0 +1,7 @@
+#!/bin/sh
+{{/* =% sh "-s" "--"  %= */}}
+{{ $lines := flag "lines" "int" "the number of lines" 5 }}
+{{ $header := param "header" "string" "the header" "default" }}
+for i in $(seq {{$lines}}); do
+echo {{ $header }} $i
+done

--- a/examples/go/cli/main.go
+++ b/examples/go/cli/main.go
@@ -1,0 +1,102 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"path"
+	"strings"
+
+	"github.com/docker/infrakit/pkg/cli/playbook"
+	logutil "github.com/docker/infrakit/pkg/log"
+	"github.com/docker/infrakit/pkg/run/scope"
+	"github.com/docker/infrakit/pkg/template"
+	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
+
+	// backends that are supported
+	_ "github.com/docker/infrakit/pkg/callable/backend/http"
+	_ "github.com/docker/infrakit/pkg/callable/backend/print"
+	_ "github.com/docker/infrakit/pkg/callable/backend/sh"
+	_ "github.com/docker/infrakit/pkg/callable/backend/ssh"
+	_ "github.com/docker/infrakit/pkg/callable/backend/vmwscript"
+)
+
+func init() {
+	logutil.Configure(&logutil.ProdDefaults)
+}
+
+func makeURL(s string) string {
+	if strings.Index(s, "://") > 0 {
+		return s
+	}
+
+	wd, err := os.Getwd()
+	if err != nil {
+		panic(err)
+	}
+
+	return "file://" + path.Join(wd, s)
+}
+
+func main() {
+
+	prog := path.Base(os.Args[0])
+	if len(os.Args) < 2 {
+		fmt.Printf("Usage %v <url> [flags...]", prog)
+		os.Exit(-1)
+	}
+
+	// Commands from playbooks
+	playbooks, err := playbook.NewModules(
+		scope.Nil,
+		playbook.Modules{
+			playbook.Op(prog): playbook.SourceURL(makeURL(os.Args[1])),
+		},
+		os.Stdin, template.Options{})
+
+	if err != nil {
+		panic(err)
+	}
+
+	commands, err := playbooks.List()
+	if err != nil {
+		panic(err)
+	}
+
+	// we expect only one top level command because there's only one playbook url
+	if len(commands) == 0 {
+		panic("unable to make commands out of the playbook " + os.Args[1])
+	}
+
+	top := commands[0]
+
+	top.PersistentFlags().AddFlagSet(logFlags(&logutil.ProdDefaults))
+	top.PersistentPreRunE = func(c *cobra.Command, args []string) error {
+		logutil.Configure(&logutil.ProdDefaults)
+		return nil
+	}
+	// Don't print usage text for any error returned from a RunE function.
+	// Only print it when explicitly requested.
+	top.SilenceUsage = true
+	// Don't automatically print errors returned from a RunE function.
+	// They are returned from cmd.Execute() below and we print it ourselves.
+	top.SilenceErrors = true
+
+	// consume the first two args and let the command process the rest
+	top.SetArgs(os.Args[2:])
+	top.Execute()
+}
+
+func logFlags(o *logutil.Options) *pflag.FlagSet {
+	f := pflag.NewFlagSet("logging", pflag.ExitOnError)
+	f.IntVar(&o.Level, "log", o.Level, "log level")
+	f.IntVar(&o.DebugV, "log-debug-V", o.DebugV, "log debug verbosity level. 0=logs all")
+	f.BoolVar(&o.Stdout, "log-stdout", o.Stdout, "log to stdout")
+	f.BoolVar(&o.CallFunc, "log-caller", o.CallFunc, "include caller function")
+	f.BoolVar(&o.CallStack, "log-stack", o.CallStack, "include caller stack")
+	f.StringVar(&o.Format, "log-format", o.Format, "log format: logfmt|term|json")
+	f.BoolVar(&o.DebugMatchExclude, "log-debug-match-exclude", false, "True to exclude; otherwise only include matches")
+	f.StringSliceVar(&o.DebugMatchKeyValuePairs, "log-debug-match", []string{},
+		"debug mode only -- select records with any of the k=v pairs")
+	return f
+}

--- a/examples/go/cli/playbook.yml
+++ b/examples/go/cli/playbook.yml
@@ -1,0 +1,6 @@
+# This is an index file for a playbook module that contains
+# multiple commands
+
+httpbin : httpbin.json
+
+lines : lines.sh

--- a/pkg/run/scope/scope.go
+++ b/pkg/run/scope/scope.go
@@ -2,7 +2,6 @@ package scope
 
 import (
 	"github.com/docker/infrakit/pkg/discovery"
-	"github.com/docker/infrakit/pkg/discovery/local"
 	logutil "github.com/docker/infrakit/pkg/log"
 	"github.com/docker/infrakit/pkg/plugin"
 	"github.com/docker/infrakit/pkg/spi/controller"
@@ -18,14 +17,19 @@ import (
 
 var log = logutil.New("module", "run/scope")
 
-// Nil is no scope
-var Nil = DefaultScope(func() discovery.Plugins {
-	d, err := local.NewPluginDiscovery()
-	if err != nil {
-		panic(err)
-	}
-	return d
-})
+// Nil is no scope -- no infrakit services
+
+type emptyscope int
+
+func (s emptyscope) Find(name plugin.Name) (*plugin.Endpoint, error) {
+	return nil, nil
+}
+
+func (s emptyscope) List() (map[string]*plugin.Endpoint, error) {
+	return map[string]*plugin.Endpoint{}, nil
+}
+
+var Nil = DefaultScope(func() discovery.Plugins { return emptyscope(1) })
 
 // Scope provides an environment in which the necessary plugins are available
 // for doing a unit of work.  The scope can be local or remote, namespaced,

--- a/pkg/run/scope/scope.go
+++ b/pkg/run/scope/scope.go
@@ -29,6 +29,7 @@ func (s emptyscope) List() (map[string]*plugin.Endpoint, error) {
 	return map[string]*plugin.Endpoint{}, nil
 }
 
+// Nil is a scope that points to nothing, no plugins can be accessed.
 var Nil = DefaultScope(func() discovery.Plugins { return emptyscope(1) })
 
 // Scope provides an environment in which the necessary plugins are available


### PR DESCRIPTION
This PR contains a simple go program to show how you can use playbooks in infrakit
in your own go program so that your program can be customized and extended with
the same playbook template files.

@FrenchBen 


Signed-off-by: David Chung david.chung@docker.com