### PR TITLE
Resource controller and playbook bug fixes

### DIFF
--- a/cmd/infrakit/main.go
+++ b/cmd/infrakit/main.go
@@ -201,7 +201,13 @@ func useCommand(scope scope.Scope, use, description string, pb *playbook.Playboo
 
 			// Commands from playbooks
 			playbookCommands := []*cobra.Command{}
-			if playbooks, err := playbook.NewModules(scope, pb.Modules(), os.Stdin, template.Options{}); err != nil {
+			if playbooks, err := playbook.NewModules(scope, pb.Modules(),
+				os.Stdin,
+				playbook.Options{
+					// This value here is set by the environment variables
+					// because its evaluation is needed prior to flags generation.
+					ShowAllWarnings: local.Getenv("INFRAKIT_CALLABLE_WARNINGS", "false") == "true",
+				}); err != nil {
 				log.Warn("error loading playbooks", "err", err)
 			} else {
 				if more, err := playbooks.List(); err != nil {

--- a/cmd/infrakit/playbook/playbook.go
+++ b/cmd/infrakit/playbook/playbook.go
@@ -83,8 +83,10 @@ func Command(scope scope.Scope) *cobra.Command {
 					map[playbook.Op]playbook.SourceURL{
 						playbook.Op(name): playbook.SourceURL(source),
 					},
-					os.Stdin, template.Options{
-						CacheDir: cacheDir,
+					os.Stdin, playbook.Options{
+						Options: template.Options{
+							CacheDir: cacheDir,
+						},
 					})
 				if err != nil {
 					return err

--- a/docs/controller/inventory/az1.yml
+++ b/docs/controller/inventory/az1.yml
@@ -5,7 +5,7 @@ metadata:
 properties:
   az1-net1:
     plugin: az1/net
-    labels:
+    select:
       az: az1
       type: network
     ObserveInterval: 1s                               # optional - specified here to control polling interval
@@ -15,7 +15,7 @@ properties:
       gateway: 10.20.0.1
   az1-disk0:
     plugin: az1/disk
-    labels:
+    select:
       az: az1
       type: storage
     Properties:
@@ -26,7 +26,7 @@ properties:
       size: 1TB
   az1-disk1:
     plugin: az1/disk
-    labels:
+    select:
       az: az1
       type: storage
     Properties:
@@ -37,7 +37,7 @@ properties:
       size: 2TB
   az1-disk2:
     plugin: az1/disk
-    labels:
+    select:
       az: az1
       type: storage
     Properties:
@@ -48,7 +48,7 @@ properties:
       size: 3TB
   az1-disk3:
     plugin: az1/disk
-    labels:
+    select:
       az: az1
       type: storage
     Properties:
@@ -59,7 +59,7 @@ properties:
       size: 4TB
   az1-disk4:
     plugin: az1/disk
-    labels:
+    select:
       az: az1
       type: storage
     Properties:
@@ -70,7 +70,7 @@ properties:
       size: 5TB
   az1-disk5:
     plugin: az1/disk
-    labels:
+    select:
       az: az1
       type: storage
     Properties:
@@ -81,7 +81,7 @@ properties:
       size: 6TB
   az1-disk6:
     plugin: az1/disk
-    labels:
+    select:
       az: az1
       type: storage
     Properties:
@@ -92,7 +92,7 @@ properties:
       size: 7TB
   az1-disk7:
     plugin: az1/disk
-    labels:
+    select:
       az: az1
       type: storage
     Properties:
@@ -103,7 +103,7 @@ properties:
       size: 8TB
   az1-disk8:
     plugin: az1/disk
-    labels:
+    select:
       az: az1
       type: storage
     Properties:
@@ -114,7 +114,7 @@ properties:
       size: 9TB
   az1-disk9:
     plugin: az1/disk
-    labels:
+    select:
       az: az1
       type: storage
     Properties:

--- a/docs/controller/inventory/az2.yml
+++ b/docs/controller/inventory/az2.yml
@@ -8,7 +8,7 @@ options:
 properties:
   az2-net1:
     plugin: az2/net
-    labels:
+    select:
       az: az2
       type: network
     Properties:
@@ -16,7 +16,7 @@ properties:
       gateway: 10.20.0.1
   az2-disk0:
     plugin: az2/disk
-    labels:
+    select:
       az: az2
       type: storage
     Properties:
@@ -27,7 +27,7 @@ properties:
       size: 1TB
   az2-disk1:
     plugin: az2/disk
-    labels:
+    select:
       az: az2
       type: storage
     Properties:
@@ -38,7 +38,7 @@ properties:
       size: 2TB
   az2-disk2:
     plugin: az2/disk
-    labels:
+    select:
       az: az2
       type: storage
     Properties:
@@ -49,7 +49,7 @@ properties:
       size: 3TB
   az2-disk3:
     plugin: az2/disk
-    labels:
+    select:
       az: az2
       type: storage
     Properties:
@@ -60,7 +60,7 @@ properties:
       size: 4TB
   az2-disk4:
     plugin: az2/disk
-    labels:
+    select:
       az: az2
       type: storage
     Properties:

--- a/docs/controller/inventory/inventory.yml
+++ b/docs/controller/inventory/inventory.yml
@@ -7,15 +7,15 @@ options:
 properties:
   disks:
     - plugin: az1/disk
-      labels:
+      select:
         infrakit_collection: az1-resources
     - plugin: az2/disk
-      labels:
+      select:
         infrakit_collection: az2-resources
   network:
     - plugin: az1/net
-      labels:
+      select:
         infrakit_collection: az1-resources
     - plugin: az2/net
-      labels:
+      select:
         infrakit_collection: az2-resources

--- a/docs/controller/resource/chain.yml
+++ b/docs/controller/resource/chain.yml
@@ -8,7 +8,7 @@ options:
 properties:
   az1-net1:
     plugin: az1/net
-    labels:
+    select:
       az: az1
       type: network
     ObserveInterval: 1s                               # optional - specified here to control polling interval
@@ -18,7 +18,7 @@ properties:
       gateway: 10.20.0.1
   az1-disk0:
     plugin: az1/disk
-    labels:
+    select:
       az: az1
       type: storage
     Properties:
@@ -29,7 +29,7 @@ properties:
       size: 1TB
   az1-disk1:
     plugin: az1/disk
-    labels:
+    select:
       az: az1
       type: storage
     Properties:
@@ -40,7 +40,7 @@ properties:
       size: 2TB
   az1-disk2:
     plugin: az1/disk
-    labels:
+    select:
       az: az1
       type: storage
     Properties:
@@ -51,7 +51,7 @@ properties:
       size: 3TB
   az1-disk3:
     plugin: az1/disk
-    labels:
+    select:
       az: az1
       type: storage
     Properties:
@@ -62,7 +62,7 @@ properties:
       size: 4TB
   az1-disk4:
     plugin: az1/disk
-    labels:
+    select:
       az: az1
       type: storage
     Properties:
@@ -73,7 +73,7 @@ properties:
       size: 5TB
   az1-disk5:
     plugin: az1/disk
-    labels:
+    select:
       az: az1
       type: storage
     Properties:
@@ -84,7 +84,7 @@ properties:
       size: 6TB
   az1-disk6:
     plugin: az1/disk
-    labels:
+    select:
       az: az1
       type: storage
     Properties:
@@ -95,7 +95,7 @@ properties:
       size: 7TB
   az1-disk7:
     plugin: az1/disk
-    labels:
+    select:
       az: az1
       type: storage
     Properties:
@@ -106,7 +106,7 @@ properties:
       size: 8TB
   az1-disk8:
     plugin: az1/disk
-    labels:
+    select:
       az: az1
       type: storage
     Properties:
@@ -117,7 +117,7 @@ properties:
       size: 9TB
   az1-disk9:
     plugin: az1/disk
-    labels:
+    select:
       az: az1
       type: storage
     Properties:

--- a/examples/playbooks/aws/README.md
+++ b/examples/playbooks/aws/README.md
@@ -88,7 +88,7 @@ properties:
     Properties:
       AttachInternetGatewayInput:
         VpcId: '@depend(''vpc/Properties/VpcId'')@'
-    labels:
+    select:
       Name: myproject-igw
       infrakit_created: 2018-03-18
       infrakit_scope: myproject
@@ -101,7 +101,7 @@ properties:
         GatewayId: '@depend(''igw/Properties/InternetGatewayId'')@'
       CreateRouteTableInput:
         VpcId: '@depend(''vpc/Properties/VpcId'')@'
-    labels:
+    select:
       Name: myproject-rtb
       infrakit_created: 2018-03-18
       infrakit_scope: myproject
@@ -122,7 +122,7 @@ properties:
         Description: basic-sg
         GroupName: myproject-sg1
         VpcId: '@depend(''vpc/Properties/VpcId'')@'
-    labels:
+    select:
       Name: myproject-sg1
       infrakit_created: 2018-03-18
       infrakit_scope: myproject
@@ -136,7 +136,7 @@ properties:
         VpcId: '@depend(''vpc/Properties/VpcId'')@'
       RouteTableAssociation:
         RouteTableId: '@depend(''rtb/Properties/RouteTableId'')@'
-    labels:
+    select:
       Name: myproject-subnet1
       infrakit_created: 2018-03-18
       infrakit_scope: myproject
@@ -150,7 +150,7 @@ properties:
         VpcId: '@depend(''vpc/Properties/VpcId'')@'
       RouteTableAssociation:
         RouteTableId: '@depend(''rtb/Properties/RouteTableId'')@'
-    labels:
+    select:
       Name: myproject-subnet2
       infrakit_created: 2018-03-18
       infrakit_scope: myproject
@@ -165,7 +165,7 @@ properties:
           Value: true
       - EnableDnsHostnames:
           Value: true
-    labels:
+    select:
       Name: myproject-vpc
       infrakit_created: 2018-03-18
       infrakit_scope: myproject

--- a/examples/playbooks/aws/index.yml
+++ b/examples/playbooks/aws/index.yml
@@ -2,29 +2,23 @@
 # Start infrakit
 start : start.sh
 
-# The resource config for entire mystack
-mystack : mystack.yml
-
-# Creates a vpc
-vpc : provision-vpc.yml
-
-# Creates a subnet
-subnet : provision-subnet.yml
-
-# Creates a security group
-sg : provision-securitygroup.yml
-
-# Creates and attaches an internet gateway to VPC
-gateway : provision-gateway.yml
-
-# Creates a routetable and associate to VPC and subnet
-routetable : provision-routetable.yml
-
-# Create a single instance
-ondemand : provision-instance.yml
-
-# Create a spot instance
-spot : provision-spot-instance.yml
+# vars - sets the variables
+vars : vars.sh
 
 # Configuration for inventory controller
-inventory.yml : inventory.yml
+inventory : inventory.yml
+
+# The resource config for entire mystack
+phase1 : mystack.yml
+
+# The resource config for nodes after phase1
+phase2 : nodes.yml
+
+# The specific resources we can provision
+resources : resources/index.yml
+
+# Create a single instance
+ondemand : resources/provision-instance.yml
+
+# Create a spot instance
+spot : resources/provision-spot-instance.yml

--- a/examples/playbooks/aws/inventory.yml
+++ b/examples/playbooks/aws/inventory.yml
@@ -6,29 +6,29 @@ kind: inventory
 metadata:
   name: {{ $project }}
 options:
-  ObserveInterval: 5s
+  ObserveInterval: 60s
   KeySelector: "\\{\\{.Tags.Name\\}\\}"
 properties:
   networking:
     - plugin: aws/ec2-vpc
-      labels:
+      select:
         infrakit_scope : {{ $project }}
     - plugin: aws/ec2-internetgateway
-      labels:
+      select:
         infrakit_scope : {{ $project }}
     - plugin: aws/ec2-routetable
-      labels:
+      select:
         infrakit_scope : {{ $project }}
     - plugin: aws/ec2-subnet
-      labels:
+      select:
         infrakit_scope : {{ $project }}
     - plugin: aws/ec2-securitygroup
-      labels:
+      select:
         infrakit_scope : {{ $project }}
   compute:
     - plugin: aws/ec2-instance
-      labels:
+      select:
         infrakit_scope : {{ $project }}
     - plugin: aws/ec2-spot-instance
-      labels:
+      select:
         infrakit_scope : {{ $project }}

--- a/examples/playbooks/aws/mystack.yml
+++ b/examples/playbooks/aws/mystack.yml
@@ -1,30 +1,25 @@
 {{/* =% text %= */}}
 
-{{ $user := param "user" "string" "username" | prompt "Please enter your user name:" "string" (env "USER")}}
-{{ $project := param "project" "string" "project" | prompt "Project?" "string" "myproject" }}
-
-{{ $cidr := param "cidr" "string" "CIDR Block" | prompt "CIDR block?" "string" "10.0.0.0/16" }}
-{{ $cidrSubnet1 := param "cidrSubnet1" "string" "CIDR Block for subnet1" | prompt "CIDR block?" "string" "10.0.100.0/24" }}
-{{ $cidrSubnet2 := param "cidrSubnet2" "string" "CIDR Block for subnet2" | prompt "CIDR block?" "string" "10.0.200.0/24" }}
-
-{{ $azSubnet1 := param "azSubnet1" "string" "AZ Subnet1" | prompt "Availability Zone?" "string" "eu-central-1a" }}
-{{ $azSubnet2 := param "azSubnet2" "string" "AZ Subnet2" | prompt "Availability Zone?" "string" "eu-central-1b" }}
+{{ $project := metadata `mystack/vars/project` }}
+{{ $cidr := metadata `mystack/vars/cidr` }}
+{{ $cidrSubnet1 := metadata `mystack/vars/subnet1/cidr` }}
+{{ $cidrSubnet2 := metadata `mystack/vars/subnet2/cidr` }}
+{{ $azSubnet1 := metadata `mystack/vars/subnet1/az` }}
+{{ $azSubnet2 := metadata `mystack/vars/subnet2/az` }}
 
 kind: resource
 metadata:
   name: {{ $project }}
 options:
-  ObserveInterval: 30s
+  ObserveInterval: 10s
 properties:
 
   # The VPC
   vpc:
     plugin: aws/ec2-vpc
-    labels:
+    select:
       Name: {{ $project }}-vpc
       infrakit_scope: {{ $project }}
-      infrakit_created: {{ now | htmlDate }}
-      infrakit_user: {{ $user }}
     Properties:
       CreateVpcInput:
         CidrBlock: {{ $cidr }}
@@ -37,11 +32,9 @@ properties:
   # Internet Gateway
   igw:
     plugin: aws/ec2-internetgateway
-    labels:
+    select:
       Name: {{ $project }}-igw
       infrakit_scope: {{ $project }}
-      infrakit_created: {{ now | htmlDate }}
-      infrakit_user: {{ $user }}
     Properties:
       AttachInternetGatewayInput:
         VpcId : {{ depend `vpc/Properties/VpcId` }}
@@ -49,11 +42,9 @@ properties:
   # The main routetable
   rtb:
     plugin: aws/ec2-routetable
-    labels:
+    select:
       Name: {{ $project }}-rtb
       infrakit_scope: {{ $project }}
-      infrakit_created: {{ now | htmlDate }}
-      infrakit_user: {{ $user }}
     Properties:
       CreateRouteTableInput:
         VpcId : {{ depend `vpc/Properties/VpcId` }}
@@ -64,11 +55,9 @@ properties:
   # Subnet 1 in az1
   subnet1:
     plugin: aws/ec2-subnet
-    labels:
+    select:
       Name: {{ $project }}-subnet1
       infrakit_scope: {{ $project }}
-      infrakit_created: {{ now | htmlDate }}
-      infrakit_user: {{ $user }}
     Properties:
       CreateSubnetInput:
         VpcId : {{ depend `vpc/Properties/VpcId` }}
@@ -80,11 +69,9 @@ properties:
   # Subnet 2 in az2
   subnet2:
     plugin: aws/ec2-subnet
-    labels:
+    select:
       Name: {{ $project }}-subnet2
       infrakit_scope: {{ $project }}
-      infrakit_created: {{ now | htmlDate }}
-      infrakit_user: {{ $user }}
     Properties:
       CreateSubnetInput:
         VpcId : {{ depend `vpc/Properties/VpcId` }}
@@ -96,11 +83,9 @@ properties:
   # Security Groups
   sg1:
     plugin: aws/ec2-securitygroup
-    labels:
+    select:
       Name: {{ $project }}-sg1
       infrakit_scope: {{ $project }}
-      infrakit_created: {{ now | htmlDate }}
-      infrakit_user: {{ $user }}
     Properties:
       CreateSecurityGroupInput:
         VpcId : {{ depend `vpc/Properties/VpcId` }}

--- a/examples/playbooks/aws/nodes.yml
+++ b/examples/playbooks/aws/nodes.yml
@@ -1,0 +1,65 @@
+{{/* =% text %= */}}
+
+{{ $subnet := param "subnet" "string" "subnet" | prompt "Subnet?" "string" "subnet2" }}
+
+{{ $instanceType := param "instance-type" "string" "instance type" | prompt "Instance type?" "string" "t2.micro" }}
+
+{{ $imageId := param "image-id" "string" "Image ID" | prompt "AMI?" "string" "ami-df8406b0" }}
+
+{{ $keyName := param "key" "string" "ssh key name" | prompt "SSH key?" "string" "infrakit"}}
+
+{{ $spotPrice := param "spot-price" "string" "Spot price" | prompt "Spot price?" "string" "0.03" }}
+
+{{/* subnet id from subnet name */}}
+{{ $project := metadata `mystack/vars/project` }}
+
+{{ $subnetKey := list `resource` $project $subnet `Properties` | join `/` }}
+
+{{ $subnetId := list $subnetKey `SubnetId` | join `/` | metadata }}
+{{ $az := list $subnetKey `AvailabilityZone` | join `/` | metadata }}
+{{ $cidr := list $subnetKey `CidrBlock` | join `/` | metadata }}
+
+{{ $securityGroupKey := list `resource` $project `sg1` `Properties` | join `/` }}
+{{ $securityGroupID := list $securityGroupKey `GroupId` | join `/` | metadata }}
+
+{{ $privateIp := param "private-ip" "string" "IP" | prompt "Private IP address?" "string" $cidr }}
+
+kind: resource
+metadata:
+  name: {{ $project }}-nodes
+options:
+  ObserveInterval: 10s
+properties:
+
+
+  host1:
+    plugin: aws/ec2-spot-instance
+    select:
+      Name: {{ $project }}-host1
+      infrakit_scope: {{ $project }}
+    init: |
+      #!/bin/bash
+      sudo add-apt-repository ppa:gophers/archive
+      sudo apt-get update -y
+      sudo apt-get install -y wget curl git golang-1.9-go
+      wget -qO- https://get.docker.com | sh
+      ln -s /usr/lib/go-1.9/bin/go /usr/local/bin/go
+    properties:
+      RequestSpotInstancesInput:
+        SpotPrice: "{{ $spotPrice }}"
+        Type: one-time
+        LaunchSpecification:
+          ImageId: {{ $imageId }}
+          InstanceType: {{ $instanceType }}
+          KeyName: {{ $keyName }}
+          NetworkInterfaces:
+            - AssociatePublicIpAddress: true
+              DeleteOnTermination: true
+              DeviceIndex: 0
+              Groups:
+                - {{ $securityGroupID }}
+              NetworkInterfaceId: null
+              PrivateIpAddress: {{ $privateIp  }}
+              SubnetId: {{ $subnetId }}
+          Placement:
+            AvailabilityZone: {{ $az }}

--- a/examples/playbooks/aws/resources/index.yml
+++ b/examples/playbooks/aws/resources/index.yml
@@ -1,0 +1,20 @@
+# Creates a vpc
+vpc : provision-vpc.yml
+
+# Creates a subnet
+subnet : provision-subnet.yml
+
+# Creates a security group
+sg : provision-securitygroup.yml
+
+# Creates and attaches an internet gateway to VPC
+gateway : provision-gateway.yml
+
+# Creates a routetable and associate to VPC and subnet
+routetable : provision-routetable.yml
+
+# Create a single instance
+ondemand : provision-instance.yml
+
+# Create a spot instance
+spot : provision-spot-instance.yml

--- a/examples/playbooks/aws/resources/provision-gateway.yml
+++ b/examples/playbooks/aws/resources/provision-gateway.yml
@@ -1,19 +1,15 @@
 {{/* Input to create instance using the AWS instance plugin */}}
 {{/* =% instanceProvision `aws/ec2-internetgateway` %= */}}
 
-{{ $user := param "user" "string" "username" | prompt "Please enter your user name:" "string" (env "USER")}}
 {{ $project := param "project" "string" "project" | prompt "Project?" "string" "myproject" }}
 
 {{ $vpcID := param "vpcID" "string" "VPC ID" | prompt "VPC ID?" "string" }}
 
 Tags:
   infrakit_scope: {{ $project }}
-  infrakit_created: {{ now | htmlDate }}
-  infrakit_user: {{ $user }}
 
 Properties:
   Tags:
     Name: {{ $project }}-igw
-    infrakit_user: {{ $user }}
   AttachInternetGatewayInput:
     VpcId : {{ $vpcID }}

--- a/examples/playbooks/aws/resources/provision-instance.yml
+++ b/examples/playbooks/aws/resources/provision-instance.yml
@@ -1,35 +1,18 @@
 {{/* Input to create instance using the AWS instance plugin */}}
 {{/* =% instanceProvision `aws/ec2-instance` %= */}}
 
-{{ $user := param "user" "string" "username" | prompt "Please enter your user name:" "string" (env "USER")}}
 {{ $project := param "project" "string" "project" | prompt "Project?" "string" "myproject" }}
 {{ $imageId := param "image-id" "string" "Image ID" | prompt "AMI?" "string" "ami-df8406b0" }}
 {{ $instanceType := param "instance-type" "string" "instance type" | prompt "Instance type?" "string" "t2.micro" }}
-
 {{ $name := param "name" "string" "Host name" | prompt "Host name?" "string" (cat $project `-` (randAlphaNum 8) | nospace ) }}
-
 {{ $keyName := param "key" "string" "ssh key name" | prompt "SSH key?" "string" "infrakit"}}
-
-{{ $subnet := param "subnet" "string" "subnet" | prompt "Subnet?" "string" "subnet1" }}
-{{ $subnetKey := list `inventory` $project `networking/aws/ec2-subnet` (list $project $subnet | join `-`) `Properties` | join `/` }}
-
-{{ $azKey := list $subnetKey `AvailabilityZone` | join `/` }}
-{{ $az := metadata $azKey }}
-
-{{ $subnetIdKey := list $subnetKey `SubnetId` | join `/` }}
-{{ $subnetId := metadata $subnetIdKey }}
-
-{{ $cidrBlockKey := list $subnetKey `CidrBlock` | join `/` }}
-{{ $privateIp := param "private-ip" "string" "IP" | prompt "Private IP address?" "string" (metadata $cidrBlockKey) }}
-
-{{ $securityGroupIdKey := list `inventory` $project `networking/aws/ec2-securitygroup` (list $project `sg1` | join `-`) `Properties/GroupId` | join `/` }}
-
-{{ $securityGroupID := param "security-group-id" "string" "security group id" | prompt "Security group ID?" "string" (metadata $securityGroupIdKey) }}
+{{ $subnetId := param "subnet-id" "string" "subnet ID" | prompt "Subnet?" "string" "" }}
+{{ $az := param "az" "string" "availability zone" | prompt "AZ?" "string" "" }}
+{{ $privateIp := param "private-ip" "string" "IP" | prompt "Private IP address?" "string" "" }}
+{{ $securityGroupID := param "security-group-id" "string" "security group" | prompt "Security group ID?" "string" "" }}
 
 Tags:
   infrakit_scope: {{ $project }}
-  infrakit_created: {{ now | htmlDate }}
-  infrakit_user: {{ $user }}
 
 Init: |
   #!/bin/bash
@@ -42,7 +25,6 @@ Init: |
 Properties:
   Tags:
     Name: {{ $name }}
-    infrakit_user: {{ $user }}
   RunInstancesInput:
     BlockDeviceMappings: null
     DisableApiTermination: null

--- a/examples/playbooks/aws/resources/provision-routetable.yml
+++ b/examples/playbooks/aws/resources/provision-routetable.yml
@@ -1,7 +1,6 @@
 {{/* Input to create instance using the AWS instance plugin */}}
 {{/* =% instanceProvision `aws/ec2-routetable` %= */}}
 
-{{ $user := param "user" "string" "username" | prompt "Please enter your user name:" "string" (env "USER")}}
 {{ $project := param "project" "string" "project" | prompt "Project?" "string" "myproject" }}
 
 {{ $vpcID := param "vpcID" "string" "VPC ID" | prompt "VPC ID?" "string" }}
@@ -9,13 +8,10 @@
 
 Tags:
   infrakit_scope: {{ $project }}
-  infrakit_created: {{ now | htmlDate }}
-  infrakit_user: {{ $user }}
 
 Properties:
   Tags:
     Name: {{ $project }}-public-route-via-gateway
-    infrakit_user: {{ $user }}
   CreateRouteTableInput:
     VpcId : {{ $vpcID }}
   CreateRouteInputs:

--- a/examples/playbooks/aws/resources/provision-securitygroup.yml
+++ b/examples/playbooks/aws/resources/provision-securitygroup.yml
@@ -1,7 +1,6 @@
 {{/* Input to create instance using the AWS instance plugin */}}
 {{/* =% instanceProvision `aws/ec2-securitygroup` %= */}}
 
-{{ $user := param "user" "string" "username" | prompt "Please enter your user name:" "string" (env "USER")}}
 {{ $project := param "project" "string" "project" | prompt "Project?" "string" "myproject" }}
 
 {{ $vpcID := param "vpcID" "string" "VPC ID" | prompt "VPC ID?" "string" }}
@@ -9,13 +8,10 @@
 
 Tags:
   infrakit_scope: {{ $project }}
-  infrakit_created: {{ now | htmlDate }}
-  infrakit_user: {{ $user }}
 
 Properties:
   Tags:
     Name: {{ $project }}-{{ $name }}
-    infrakit_user: {{ $user }}
   CreateSecurityGroupInput:
     VpcId : {{ $vpcID }}
     GroupName: {{ $name }}

--- a/examples/playbooks/aws/resources/provision-spot-instance.yml
+++ b/examples/playbooks/aws/resources/provision-spot-instance.yml
@@ -1,37 +1,20 @@
 {{/* Input to create a spot instance using the AWS instance plugin */}}
 {{/* =% instanceProvision `aws/ec2-spot-instance` %= */}}
 
-{{ $user := param "user" "string" "username" | prompt "Please enter your user name:" "string" (env "USER")}}
 {{ $project := param "project" "string" "project" | prompt "Project?" "string" "myproject" }}
 {{ $imageId := param "image-id" "string" "Image ID" | prompt "AMI?" "string" "ami-df8406b0" }}
 {{ $instanceType := param "instance-type" "string" "instance type" | prompt "Instance type?" "string" "t2.micro" }}
-
 {{ $name := param "name" "string" "Host name" | prompt "Host name?" "string" (cat $project `-` (randAlphaNum 8) | nospace ) }}
-
 {{ $spotPrice := param "spot-price" "string" "Spot price" | prompt "Spot price?" "string" "0.03" }}
-
 {{ $keyName := param "key" "string" "ssh key name" | prompt "SSH key?" "string" "infrakit"}}
+{{ $subnetId := param "subnet-id" "string" "subnet ID" | prompt "Subnet?" "string" "" }}
+{{ $az := param "az" "string" "availability zone" | prompt "AZ?" "string" "" }}
+{{ $privateIp := param "private-ip" "string" "IP" | prompt "Private IP address?" "string" "" }}
+{{ $securityGroupID := param "security-group-id" "string" "security group" | prompt "Security group ID?" "string" "" }}
 
-{{ $subnet := param "subnet" "string" "subnet" | prompt "Subnet?" "string" "subnet2" }}
-{{ $subnetKey := list `inventory` $project `networking/aws/ec2-subnet` (list $project $subnet | join `-`) `Properties` | join `/` }}
-
-{{ $azKey := list $subnetKey `AvailabilityZone` | join `/` }}
-{{ $az := metadata $azKey }}
-
-{{ $subnetIdKey := list $subnetKey `SubnetId` | join `/` }}
-{{ $subnetId := metadata $subnetIdKey }}
-
-{{ $cidrBlockKey := list $subnetKey `CidrBlock` | join `/` }}
-{{ $privateIp := param "private-ip" "string" "IP" | prompt "Private IP address?" "string" (metadata $cidrBlockKey) }}
-
-{{ $securityGroupIdKey := list `inventory` $project `networking/aws/ec2-securitygroup` (list $project `sg1` | join `-`) `Properties/GroupId` | join `/` }}
-
-{{ $securityGroupID := param "security-group-id" "string" "security group id" | prompt "Security group ID?" "string" (metadata $securityGroupIdKey) }}
 
 Tags:
   infrakit_scope: {{ $project }}
-  infrakit_created: {{ now | htmlDate }}
-  infrakit_user: {{ $user }}
 
 Init: |
   #!/bin/bash
@@ -44,12 +27,11 @@ Init: |
 Properties:
   Tags:
     Name: {{ $name }}
-    infrakit_user: {{ $user }}
   RequestSpotInstancesInput:
     LaunchSpecification:
       ImageId: {{ $imageId }}
       InstanceType: {{ $instanceType }}
-      KeyName: infrakit
+      KeyName: {{ $keyName }}
       NetworkInterfaces:
       - AssociatePublicIpAddress: true
         DeleteOnTermination: true

--- a/examples/playbooks/aws/resources/provision-subnet.yml
+++ b/examples/playbooks/aws/resources/provision-subnet.yml
@@ -1,7 +1,6 @@
 {{/* Input to create instance using the AWS instance plugin */}}
 {{/* =% instanceProvision `aws/ec2-subnet` %= */}}
 
-{{ $user := param "user" "string" "username" | prompt "Please enter your user name:" "string" (env "USER")}}
 {{ $project := param "project" "string" "project" | prompt "Project?" "string" "myproject" }}
 
 {{ $vpcID := param "vpcID" "string" "VPC ID" | prompt "VPC ID?" "string" }}
@@ -13,16 +12,13 @@
 
 Tags:
   infrakit_scope: {{ $project }}
-  infrakit_created: {{ now | htmlDate }}
-  infrakit_user: {{ $user }}
 
 Properties:
+  Tags:
+    Name: {{ $project }}-{{ $name }}
   CreateSubnetInput:
     VpcId : {{ $vpcID }}
     AvailabilityZone: {{ $az }}
     CidrBlock: {{ $cidr }}
   RouteTableAssociation:
     RouteTableId: {{ $routeTableID }}
-  Tags:
-    Name: {{ $project }}-{{ $name }}
-    infrakit_user: {{ $user }}

--- a/examples/playbooks/aws/resources/provision-vpc.yml
+++ b/examples/playbooks/aws/resources/provision-vpc.yml
@@ -1,20 +1,16 @@
 {{/* Input to create instance using the AWS instance plugin */}}
 {{/* =% instanceProvision `aws/ec2-vpc` %= */}}
 
-{{ $user := param "user" "string" "username" | prompt "Please enter your user name:" "string" (env "USER")}}
 {{ $project := param "project" "string" "project" | prompt "Project?" "string" "myproject" }}
 
 {{ $cidr := param "cidr" "string" "CIDR Block" | prompt "CIDR block?" "string" "10.0.0.0/16" }}
 
 Tags:
   infrakit_scope: {{ $project }}
-  infrakit_created: {{ now | htmlDate }}
-  infrakit_user: {{ $user }}
 
 Properties:
   Tags:
     Name: {{ $project }}-vpc
-    infrakit_user: {{ $user }}
   CreateVpcInput:
     CidrBlock: {{ $cidr }}
   ModifyVpcAttributeInputs:

--- a/examples/playbooks/aws/start.sh
+++ b/examples/playbooks/aws/start.sh
@@ -8,7 +8,7 @@
 {{ if $clearState }}
 echo "Clear local state from previous runs"
 rm -rf ~/.infrakit/plugins/* # remove sockets, pid files, etc.
-rm -rf ~/.infrakit/configs/global.config # for file based manager
+rm -rf ~/.infrakit/configs/* # for file based manager
 # Since we are using file based leader detection, write the default name (manager1) to the leader file.
 echo manager1 > ~/.infrakit/leader
 {{ end }}

--- a/examples/playbooks/aws/vars.sh
+++ b/examples/playbooks/aws/vars.sh
@@ -1,0 +1,26 @@
+{{/* =% sh %= */}}
+
+{{ $project := param "project" "string" "project" | prompt "Project?" "string" "myproject" }}
+
+{{ $cidr := param "cidr" "string" "CIDR Block" | prompt "CIDR block?" "string" "10.0.0.0/16" }}
+{{ $cidrSubnet1 := param "cidrSubnet1" "string" "CIDR Block for subnet1" | prompt "CIDR block?" "string" "10.0.100.0/24" }}
+{{ $cidrSubnet2 := param "cidrSubnet2" "string" "CIDR Block for subnet2" | prompt "CIDR block?" "string" "10.0.200.0/24" }}
+
+{{ $azSubnet1 := param "azSubnet1" "string" "AZ Subnet1" | prompt "Availability Zone?" "string" "eu-central-1a" }}
+{{ $azSubnet2 := param "azSubnet2" "string" "AZ Subnet2" | prompt "Availability Zone?" "string" "eu-central-1b" }}
+
+# write to the metadata vars
+{{ metadata `mystack/vars/project` $project }}
+{{ metadata `mystack/vars/cidr` $cidr }}
+{{ metadata `mystack/vars/subnet1/cidr` $cidrSubnet1 }}
+{{ metadata `mystack/vars/subnet2/cidr` $cidrSubnet2 }}
+{{ metadata `mystack/vars/subnet1/az` $azSubnet1 }}
+{{ metadata `mystack/vars/subnet2/az` $azSubnet2 }}
+
+infrakit local mystack/vars change
+
+{{ $project := metadata `mystack/vars/project` }}
+
+echo "Project is {{ $project }}"
+
+infrakit local mystack/vars change

--- a/pkg/callable/callable.go
+++ b/pkg/callable/callable.go
@@ -28,6 +28,10 @@ const (
 // Options has optional settings for a call.  It can be in a CLI (where Parameters are implemented by flags) or
 // programmatic, where Parameters are implemented as maps that can be set in a golang program.
 type Options struct {
+
+	// ShowAllWarnings will print all warnings to the console.
+	ShowAllWarnings bool
+
 	// Output is the writer used by the backend to write the result.  Typically it's stdout
 	OutputFunc func() io.Writer
 
@@ -78,7 +82,6 @@ type TemplateFunc func(url string, opts template.Options) (*template.Template, e
 
 // NewCallable creates a callable
 func NewCallable(scope scope.Scope, src string, parameters backend.Parameters, options Options) *Callable {
-
 	// Note that because Callable embeds Parameters and implements the methods in Parameters, a Callable
 	// can be nested inside another callable..
 	return &Callable{
@@ -596,6 +599,9 @@ func (c *Callable) DefineParameters() (err error) {
 
 	t.SetOptions(c.Options.TemplateOptions)
 	_, err = t.Render(c)
+	if err != nil && c.Options.ShowAllWarnings {
+		log.Warn("Error rendering playbook while defining params", "err", err)
+	}
 
 	// add the backend-defined flags. These are flags that are
 	// applied as the backend is chosen.  The delimiter here is =% %=

--- a/pkg/cli/playbook/modules_test.go
+++ b/pkg/cli/playbook/modules_test.go
@@ -8,7 +8,6 @@ import (
 	"testing"
 
 	"github.com/docker/infrakit/pkg/run/scope"
-	"github.com/docker/infrakit/pkg/template"
 	"github.com/spf13/cobra"
 	"github.com/stretchr/testify/require"
 
@@ -24,7 +23,7 @@ command2 : file2
 group    : file3
 `
 
-	m, err := dir(SourceURL("str://"+buff), template.Options{})
+	m, err := dir(SourceURL("str://"+buff), Options{})
 	require.NoError(t, err)
 	require.Equal(t, Modules{
 		Op("command1"): SourceURL("file1"),
@@ -40,7 +39,7 @@ func TestLoadModules(t *testing.T) {
 
 	top := filepath.Join(pwd, "testdata/index.ikm")
 
-	options := template.Options{}
+	options := Options{}
 
 	root := SourceURL("file://" + top)
 	m, err := dir(root, options)
@@ -62,7 +61,7 @@ func TestLoadAll(t *testing.T) {
 		Op("testdata"): root,
 	}
 
-	modules, err := NewModules(scope.Nil, top, os.Stdin, template.Options{})
+	modules, err := NewModules(scope.Nil, top, os.Stdin, Options{})
 	require.NoError(t, err)
 
 	commands, err := modules.List()

--- a/pkg/controller/internal/access_test.go
+++ b/pkg/controller/internal/access_test.go
@@ -19,7 +19,7 @@ func TestInstanceAccessMarshal(t *testing.T) {
 	access1 := new(InstanceAccess)
 	err := types.Decode([]byte(`
 plugin: simulator/compute
-labels:
+select:
   group: workers
   type: large
 observeinterval: 2s
@@ -52,7 +52,7 @@ func TestInstanceAccess(t *testing.T) {
 	access := new(InstanceAccess)
 	err := types.Decode([]byte(`
 plugin: simulator/compute
-labels:
+select:
   group: workers
   type: large
 observeinterval: 2s
@@ -85,7 +85,7 @@ properties:
 	require.Equal(t, map[string]string{
 		"group": "workers",
 		"type":  "large",
-	}, access.Labels)
+	}, access.Select)
 
 	lookup := make(chan string, 10)
 
@@ -130,7 +130,7 @@ properties:
 	access.Pause(false)
 
 	require.Equal(t, "simulator/compute", <-lookup)
-	require.Equal(t, []interface{}{access.Labels, true}, <-described)
+	require.Equal(t, []interface{}{access.Select, true}, <-described)
 
 	var seen []instance.Description
 

--- a/pkg/controller/internal/observer.go
+++ b/pkg/controller/internal/observer.go
@@ -22,8 +22,8 @@ type InstanceObserver struct {
 	// Plugin is the name of the instance plugin
 	Plugin plugin.Name
 
-	// Labels are the labels to use when querying for instances. This is the namespace.
-	Labels map[string]string
+	// Select are the labels to use when querying for instances. This is the namespace.
+	Select map[string]string
 
 	// ObserveInterval is the polling interval for making an observation
 	ObserveInterval types.Duration
@@ -99,7 +99,7 @@ func (o *InstanceObserver) Init(scope scope.Scope, retry time.Duration) error {
 		retry)
 
 	o.observe = func() ([]instance.Description, error) {
-		return instancePlugin.DescribeInstances(o.Labels, true)
+		return instancePlugin.DescribeInstances(o.Select, true)
 	}
 
 	o.observations = make(chan []instance.Description, 10)
@@ -127,7 +127,7 @@ func (o *InstanceObserver) Init(scope scope.Scope, retry time.Duration) error {
 			log.Debug("polling", "V", debugV2,
 				"freed", o.paused,
 				"plugin", o.Plugin,
-				"labels", o.Labels,
+				"select", o.Select,
 				"observed", len(instances))
 
 			// send the current observations

--- a/pkg/controller/internal/observer_test.go
+++ b/pkg/controller/internal/observer_test.go
@@ -16,7 +16,7 @@ func TestInstanceObserver(t *testing.T) {
 	observer := new(InstanceObserver)
 	err := types.Decode([]byte(`
 plugin: simulator/compute
-labels:
+select:
   group: workers
   type: large
 observeinterval: 2s
@@ -29,7 +29,7 @@ KeySelector: \{\{.link\}\}
 	require.Equal(t, map[string]string{
 		"group": "workers",
 		"type":  "large",
-	}, observer.Labels)
+	}, observer.Select)
 
 	lookup := make(chan string, 10)
 
@@ -64,7 +64,7 @@ KeySelector: \{\{.link\}\}
 	observer.Pause(false)
 
 	require.Equal(t, "simulator/compute", <-lookup)
-	require.Equal(t, []interface{}{observer.Labels, true}, <-called)
+	require.Equal(t, []interface{}{observer.Select, true}, <-called)
 
 	var seen []instance.Description
 
@@ -88,7 +88,7 @@ func TestInstanceObserverMultipleSamples(t *testing.T) {
 	observer := new(InstanceObserver)
 	err := types.Decode([]byte(`
 plugin: simulator/compute
-labels:
+select:
   group: workers
   type: large
 observeinterval: 2s
@@ -101,7 +101,7 @@ KeySelector: \{\{.link\}\}
 	require.Equal(t, map[string]string{
 		"group": "workers",
 		"type":  "large",
-	}, observer.Labels)
+	}, observer.Select)
 
 	// 2 samples with different values... link2 and link4 disappears
 	expected := [][]instance.Description{

--- a/pkg/controller/inventory/collection.go
+++ b/pkg/controller/inventory/collection.go
@@ -403,8 +403,8 @@ func (c *collection) stop() error {
 }
 
 func (c *collection) configureAccessor(spec types.Spec, name string, access *internal.InstanceAccess) error {
-	if access.Labels == nil {
-		access.Labels = map[string]string{}
+	if access.Select == nil {
+		access.Select = map[string]string{}
 	}
 
 	err := access.InstanceObserver.Validate(c.options.InstanceObserver)

--- a/pkg/controller/resource/collection.go
+++ b/pkg/controller/resource/collection.go
@@ -578,13 +578,13 @@ func (c *collection) stop() error {
 }
 
 func (c *collection) configureAccessor(spec types.Spec, name string, access *internal.InstanceAccess) error {
-	if access.Labels == nil {
-		access.Labels = map[string]string{}
+	if access.Select == nil {
+		access.Select = map[string]string{}
 	}
 
 	// inject a filter specifically for *this* resource
-	access.Labels[internal.CollectionLabel] = spec.Metadata.Name
-	access.Labels[internal.InstanceLabel] = name
+	access.Select[internal.CollectionLabel] = spec.Metadata.Name
+	access.Select[internal.InstanceLabel] = name
 
 	err := access.InstanceObserver.Validate(c.options.InstanceObserver)
 	if err != nil {
@@ -668,7 +668,7 @@ func (c *collection) populateDependencies(resourceName string, spec instance.Spe
 	// Additional labels in the InstanceAccess spec
 	access := c.accessors[resourceName]
 	if access != nil {
-		for k, v := range access.Labels {
+		for k, v := range access.Select {
 			processed.Tags[k] = v
 		}
 	}

--- a/pkg/controller/resource/fsm_test.go
+++ b/pkg/controller/resource/fsm_test.go
@@ -39,7 +39,7 @@ options:
 properties:
   az1-net1:
     plugin: az1/net
-    labels:
+    select:
       az: az1
       type: network
     ObserveInterval: 1s
@@ -49,7 +49,7 @@ properties:
       gateway: 10.20.0.1
   az1-net2:
     plugin: az1/net
-    labels:
+    select:
       az: az1
       type: network
     ObserveInterval: 1s
@@ -60,7 +60,7 @@ properties:
       gateway: 10.20.0.1
   az2-net1:
     plugin: az2/net
-    labels:
+    select:
       az: az2
       type: network
     ObserveInterval: 1s
@@ -71,7 +71,7 @@ properties:
       gateway: 192.178.0.1
   az2-net2:
     plugin: az2/net
-    labels:
+    select:
       az: az2
       type: network
     ObserveInterval: 1s
@@ -82,7 +82,7 @@ properties:
       gateway: 192.178.0.1
   az1-disk1:
     plugin: az1/disk
-    labels:
+    select:
       az: az1
       type: storage
     ObserveInterval: 0.5s
@@ -94,7 +94,7 @@ properties:
       size: 1TB
   az1-disk2:
     plugin: az1/disk
-    labels:
+    select:
       az: az1
       type: storage
     ObserveInterval: 0.5s
@@ -106,7 +106,7 @@ properties:
       size: 1TB
   az2-disk1:
     plugin: az2/disk
-    labels:
+    select:
       az: az2
       type: storage
     ObserveInterval: 0.5s
@@ -118,7 +118,7 @@ properties:
       size: 1TB
   az2-disk1:
     plugin: az2/disk
-    labels:
+    select:
       az: az2
       type: storage
     ObserveInterval: 0.5s


### PR DESCRIPTION
This PR
  + Fixes a problem with `""` empty string in playbook's `{{ metadata }}` calls which cause the vars backend to be updated with empty strings.
  + Renames the `InstanceObserver.Labels` to `InstanceObserver.Select` to better describe its purpose of providing a set of labels for query / resource object filtering.
  + Improves the aws playbooks to use the vars plugin to store user-defined variables such as project name, CIDR ranges for subnets and subnet locations (azs).

Signed-off-by: David Chung david.chung@docker.com