### PR TITLE
Destroy / terminate resources based on dependency

### DIFF
--- a/pkg/cli/v0/controller/describe.go
+++ b/pkg/cli/v0/controller/describe.go
@@ -71,7 +71,7 @@ func Describe(name string, services *cli.Services) *cobra.Command {
 				}
 
 				// show collections only from spec.State
-				format := "%-20s  %-15s  %-15s  %-15s\n"
+				format := "%-20s  %-20s  %-20s  %-20s\n"
 				rows := map[string]string{}
 				keys := types.Paths{}
 

--- a/pkg/controller/internal/collection.go
+++ b/pkg/controller/internal/collection.go
@@ -556,15 +556,16 @@ func (c *Collection) Free() (*types.Object, error) {
 
 // Terminate destroys the resources associated with this collection.
 func (c *Collection) Terminate() (object *types.Object, err error) {
+	object, err = c.Inspect()
+	if err != nil {
+		return
+	}
 	err = c.writeTxn(func() error {
 		if c.TerminateFunc != nil {
 			return c.TerminateFunc()
 		}
 		return fmt.Errorf("not supported")
 	})
-	if err == nil {
-		object, err = c.Inspect()
-	}
 	return
 }
 

--- a/pkg/controller/resource/watch.go
+++ b/pkg/controller/resource/watch.go
@@ -43,9 +43,11 @@ func (w *Watch) notify(name string) {
 	defer w.lock.RUnlock()
 
 	watchers, has := w.watchers[name]
-	if !has {
+
+	if !has || len(watchers) == 0 {
 		return
 	}
+	log.Debug("Notify", "name", name, "watchers", watchers, "V", debugV)
 	watchers.Notify()
 }
 

--- a/pkg/spi/controller/spi.go
+++ b/pkg/spi/controller/spi.go
@@ -16,7 +16,7 @@ type Operation int
 
 const (
 	// Enforce represents create, update, reconcile operations
-	Enforce = iota
+	Enforce Operation = iota
 
 	// Destroy is the destroy operation. Destroy also implies Free.
 	Destroy


### PR DESCRIPTION
This PR
  + Adds the feature to terminate resources based on the dependencies among the resources. 
  + Adds a flag `--destroy-all` for the `controller commit`

Here's a demo using the example `docs/controller/chain.yml`
 
[![asciicast](https://asciinema.org/a/eBlm5RI2hMFq7nh8agf4hGZJ2.png)](https://asciinema.org/a/eBlm5RI2hMFq7nh8agf4hGZJ2)


Signed-off-by: David Chung <david.chung@docker.com>