### PR TITLE
Support for dependencies in instanceSpec.Init and modifiers in keys

### DIFF
--- a/docs/controller/resource/chain.yml
+++ b/docs/controller/resource/chain.yml
@@ -13,7 +13,8 @@ properties:
       type: network
     ObserveInterval: 1s                               # optional - specified here to control polling interval
     KeySelector: \{\{.Tags.infrakit_instance\}\}      # optional specified here to control key extraction
-    Properties:
+    properties:
+      name: network:az1-net1
       cidr: 10.20.100.0/24
       gateway: 10.20.0.1
   az1-disk0:
@@ -21,7 +22,9 @@ properties:
     select:
       az: az1
       type: storage
-    Properties:
+    init: |
+      echo "The network is {{ depend `az1-net1/Properties/name` }}"
+    properties:
       dep: {{ depend `az1-net1/ID` }}
       depname: {{ depend `az1-net1/Tags/infrakit_instance` }}
       gw: {{ depend `az1-net1/Properties/gateway` }}
@@ -32,7 +35,7 @@ properties:
     select:
       az: az1
       type: storage
-    Properties:
+    properties:
       dep: {{ depend `az1-disk0/ID` }}
       depname: {{ depend `az1-disk0/Tags/infrakit_instance` }}
       gw: {{ depend `az1-net1/Properties/gateway` }}
@@ -43,7 +46,7 @@ properties:
     select:
       az: az1
       type: storage
-    Properties:
+    properties:
       dep: {{ depend `az1-disk1/ID` }}
       depname: {{ depend `az1-disk1/Tags/infrakit_instance` }}
       gw: {{ depend `az1-net1/Properties/gateway` }}
@@ -54,7 +57,7 @@ properties:
     select:
       az: az1
       type: storage
-    Properties:
+    properties:
       dep: {{ depend `az1-disk2/ID` }}
       depname: {{ depend `az1-disk2/Tags/infrakit_instance` }}
       gw: {{ depend `az1-net1/Properties/gateway` }}
@@ -65,7 +68,7 @@ properties:
     select:
       az: az1
       type: storage
-    Properties:
+    properties:
       dep: {{ depend `az1-disk3/ID` }}
       depname: {{ depend `az1-disk3/Tags/infrakit_instance` }}
       gw: {{ depend `az1-net1/Properties/gateway` }}
@@ -76,7 +79,7 @@ properties:
     select:
       az: az1
       type: storage
-    Properties:
+    properties:
       dep: {{ depend `az1-disk4/ID` }}
       depname: {{ depend `az1-disk4/Tags/infrakit_instance` }}
       gw: {{ depend `az1-net1/Properties/gateway` }}
@@ -87,7 +90,7 @@ properties:
     select:
       az: az1
       type: storage
-    Properties:
+    properties:
       dep: {{ depend `az1-disk5/ID` }}
       depname: {{ depend `az1-disk5/Tags/infrakit_instance` }}
       gw: {{ depend `az1-net1/Properties/gateway` }}
@@ -98,7 +101,7 @@ properties:
     select:
       az: az1
       type: storage
-    Properties:
+    properties:
       dep: {{ depend `az1-disk6/ID` }}
       depname: {{ depend `az1-disk6/Tags/infrakit_instance` }}
       gw: {{ depend `az1-net1/Properties/gateway` }}
@@ -109,7 +112,7 @@ properties:
     select:
       az: az1
       type: storage
-    Properties:
+    properties:
       dep: {{ depend `az1-disk7/ID` }}
       depname: {{ depend `az1-disk7/Tags/infrakit_instance` }}
       gw: {{ depend `az1-net1/Properties/gateway` }}
@@ -120,7 +123,7 @@ properties:
     select:
       az: az1
       type: storage
-    Properties:
+    properties:
       dep: {{ depend `az1-disk8/ID` }}
       depname: {{ depend `az1-disk8/Tags/infrakit_instance` }}
       gw: {{ depend `az1-net1/Properties/gateway` }}

--- a/pkg/controller/internal/collection.go
+++ b/pkg/controller/internal/collection.go
@@ -18,6 +18,8 @@ import (
 )
 
 const (
+	// SpecHash is the label name used to include a hash of the instance.Spec used to provision
+	SpecHash = "infrakit_spec_hash"
 	// InstanceLabel is the label name used for labeling the resource with the name in the collection
 	InstanceLabel = "infrakit_instance"
 	// CollectionLabel is the the label used to label the name of the collection

--- a/pkg/types/depend.go
+++ b/pkg/types/depend.go
@@ -5,29 +5,34 @@ import (
 	"fmt"
 	"reflect"
 	"regexp"
+	"strings"
 
 	"github.com/twmb/algoimpl/go/graph"
 )
 
-// DependRegex is the regex for the special format of a string value to denote a dependency
+const dependRegexStr = "\\@depend\\('(([[:alnum:]]|-|_|:|\\.|/|\\[|\\])+)'\\)\\@"
+
+// dependRegex is the regex for the special format of a string value to denote a dependency
 // on another resource's property field.  Eg. "@depends('net1/cidr')@"
-var DependRegex = regexp.MustCompile("\\@depend\\('(([[:alnum:]]|-|_|\\.|/|\\[|\\])+)'\\)\\@")
+var dependRegex = regexp.MustCompile(dependRegexStr)
 
 // Depend is a specification of a dependency
 type Depend string
 
-// NewDepend returns a Depend
-func NewDepend(p string) (Depend, error) {
-	return Depend(fmt.Sprintf("\"@depend('%s')@\"", p)), nil
+// NewDepend returns a Depend for a single expression
+func NewDepend(p string) Depend {
+	return Depend(fmt.Sprintf("\"@depend('%s')@\"", p))
 }
 
 // Parse parses the expression into a path.  If it's not a valid expression, false is returned.
-func (d Depend) Parse() (Path, bool) {
-	matches := DependRegex.FindStringSubmatch(string(d))
-	if len(matches) > 1 {
-		return PathFromString(matches[1]), true
+// TODO - this assumes there's only 1 expression and it's the entire string. This won't work
+// for cases like an Init script where a script like `cluster join --token @depend('a')@ --flag @depend('b')@ 10.1.1.1`
+func (d Depend) Parse() (found []Path, hasMatches bool) {
+	for _, m := range dependRegex.FindAllStringSubmatch(string(d), -1) {
+		found = append(found, PathFromString(m[1]))
 	}
-	return Path{}, false
+	hasMatches = len(found) > 0
+	return
 }
 
 // EvalDepends takes a value that possibly have a number of depend expressions and evaluate
@@ -43,15 +48,47 @@ func EvalDepends(v interface{}, fetcher func(Path) (interface{}, error)) interfa
 			v[i] = EvalDepends(vv, fetcher)
 		}
 	case string:
-		if p, ok := Depend(v).Parse(); ok {
-			// found a depend, now get the real value and swap
-			newV, err := fetcher(p)
-			if err != nil {
-				return err.Error()
+		if found, ok := Depend(v).Parse(); ok {
+
+			// If there are more than one '@depend@' expression, then we'd assume the field
+			// value is a string, because it doesn't make any sense to "concatenate" two ints or floats.
+			if len(found) == 1 {
+				// found a depend, now get the real value and swap
+				substituted, err := fetcher(found[0])
+				if err != nil {
+					substituted = err.Error()
+				}
+				if substituted == nil {
+					// no value found, just return original expression
+					return fmt.Sprintf("@depend('%s')@", found[0].String())
+				}
+				if _, is := substituted.(string); !is {
+					return substituted // for a string expression that evals to a non-string type
+				}
 			}
-			if newV != nil {
-				return newV
+
+			// Otherwise we assume this is going to be text with 0 or more expressions
+			text := v
+			for _, p := range found {
+
+				// Pretty hacky: since all the paths are tokenized in order as they appear
+				// we simply reconstruct the original expressions and use them as separators to split the text
+				// and perform substitutions from left to right until the end.
+				separator := fmt.Sprintf("@depend('%s')@", p.String())
+
+				// found a depend, now get the real value and swap
+				substituted, err := fetcher(p)
+				if err != nil {
+					substituted = err.Error()
+				}
+				if substituted == nil {
+					substituted = separator // if we don't have value, then use the original expression
+				}
+
+				parts := strings.Split(text, separator)
+				text = strings.Join(append([]string{parts[0], fmt.Sprintf("%v", substituted)}, parts[1:]...), "")
 			}
+			return text
 		}
 	default:
 	}
@@ -82,8 +119,10 @@ func parse(v interface{}, found []Path) (out []Path) {
 			out = append(out, parse(vv, nil)...)
 		}
 	case string:
-		if p, ok := Depend(v).Parse(); ok {
-			out = append(out, p)
+		if found, ok := Depend(v).Parse(); ok {
+			for _, p := range found {
+				out = append(out, p)
+			}
 		}
 	default:
 	}

--- a/pkg/types/depend.go
+++ b/pkg/types/depend.go
@@ -39,6 +39,11 @@ func (d Depend) Parse() (found []Path, hasMatches bool) {
 // all expression within and substitute values from the fetcher.
 func EvalDepends(v interface{}, fetcher func(Path) (interface{}, error)) interface{} {
 	switch v := v.(type) {
+	case *Any:
+		var f interface{}
+		if err := v.Decode(&f); err == nil {
+			return EvalDepends(f, fetcher)
+		}
 	case map[string]interface{}:
 		for k, vv := range v {
 			v[k] = EvalDepends(vv, fetcher)

--- a/pkg/types/link.go
+++ b/pkg/types/link.go
@@ -119,6 +119,9 @@ func (l *Link) WriteMap(target map[string]string) (merged map[string]string) {
 		merged[k] = v
 	}
 	for k, v := range l.Map() {
+		if v == "" {
+			continue
+		}
 		merged[k] = v
 	}
 	return

--- a/pkg/types/path.go
+++ b/pkg/types/path.go
@@ -231,6 +231,11 @@ func (p Paths) Sort() {
 	sort.Sort(p)
 }
 
+// Slice returns the slice
+func (p Paths) Slice() []Path {
+	return []Path(p)
+}
+
 // SortPaths sorts the paths
 func SortPaths(p []Path) {
 	sort.Sort(Paths(p))


### PR DESCRIPTION
This PR adds support for processing config like this:

```
kind: resource
metadata:
  name: resources
options:
  WaitBeforeProvision: 100
properties:
  A:
    plugin: az1/net
    Properties:
      prop1: A-1
      prop2: A-2
  B:
    plugin: az1/net
    Properties:
      wait: "@depend('A/ID')@"
      prop1: B-1
      prop2: B-2
  C:
    plugin: az1/net
    Properties:
      wait1: "@depend('A/ID')@"
      wait2: "@depend('B/ID')@"
      wait3: "@depend('post-provision:A/data/joinToken')@"
      prop1: C-1
      prop2: C-2
  D:
    plugin: az1/net
    init: |
      cluster join --token @depend('post-provision:A/data/joinToken')@ @depend('A/Properties/address')@
    Properties:
      wait1: "@depend('A/ID')@"
      wait2: "@depend('B/ID')@"
      wait3: "@depend('C/ID')@"
      prop1: D-1
      prop2: D-2
```
In this example, as soon as A is provisioned (in band or out of band), B will begin to be provisioned.  
Once B completes, C starts, then D.  The Init of D will have values from A's properties as well as a post-provision step of A (to be implemented).

Signed-off-by: David Chung <david.chung@docker.com>