### PR TITLE
Pool controller

### DIFF
--- a/cmd/infrakit/builtin.go
+++ b/cmd/infrakit/builtin.go
@@ -12,6 +12,7 @@ import (
 	_ "github.com/docker/infrakit/pkg/run/v0/ingress"
 	_ "github.com/docker/infrakit/pkg/run/v0/inventory"
 	_ "github.com/docker/infrakit/pkg/run/v0/manager"
+	_ "github.com/docker/infrakit/pkg/run/v0/pool"
 	_ "github.com/docker/infrakit/pkg/run/v0/resource"
 	_ "github.com/docker/infrakit/pkg/run/v0/selector"
 	_ "github.com/docker/infrakit/pkg/run/v0/simulator"

--- a/cmd/infrakit/playbook/playbook.go
+++ b/cmd/infrakit/playbook/playbook.go
@@ -50,6 +50,14 @@ func Command(scope scope.Scope) *cobra.Command {
 			name := args[0]
 			source := args[1]
 
+			if strings.Index(source, "://") == -1 {
+				wd, err := os.Getwd()
+				if err != nil {
+					return err
+				}
+				source = "file://" + filepath.Join(wd, source)
+			}
+
 			playbooks, err := playbook.Load()
 			if err != nil {
 				return err

--- a/docs/controller/pool/playbook.yml
+++ b/docs/controller/pool/playbook.yml
@@ -1,0 +1,5 @@
+
+# Start infrakit
+start : start.sh
+
+workers.yml : workers.yml

--- a/docs/controller/pool/start.sh
+++ b/docs/controller/pool/start.sh
@@ -1,0 +1,17 @@
+{{/* =% sh %= */}}
+
+{{ $clearState := flag "clear-state" "bool" "Clear stored states" | prompt "Clear state?" "bool" true }}
+
+{{ if $clearState }}
+rm -rf ~/.infrakit/plugins/* # remove sockets, pid files, etc.
+rm -rf ~/.infrakit/configs/global.config # for file based manager
+# Since we are using file based leader detection, write the default name (manager1) to the leader file.
+echo manager1 > ~/.infrakit/leader
+{{ end }}
+
+# The simulators are started up with different names to mimic different resources
+INFRAKIT_MANAGER_CONTROLLERS=pool \
+infrakit plugin start manager:mystack vars group pool simulator:az1 \
+	 --log 5 --log-stack --log-debug-V 500 \
+	 --log-debug-match module=controller/pool \
+	 --log-debug-match module=controller/internal \

--- a/docs/controller/pool/workers.yml
+++ b/docs/controller/pool/workers.yml
@@ -9,7 +9,6 @@ metadata:
 options:
   WaitBeforeProvision: 3
   WaitBeforeDestroy: 3
-  ObserveInterval: 0.5s
 properties:
   plugin: az1/compute
   count: {{ $count }}   # how many in the pool

--- a/docs/controller/pool/workers.yml
+++ b/docs/controller/pool/workers.yml
@@ -1,0 +1,24 @@
+{{/* =% text %= */}}
+
+{{ $count := param "count" "int" "Count" | prompt "How many?" "int" 5 }}
+{{ $parallelism := param "parallelism" "int" "Parallelism" | prompt "How many at a time?" "int" 1 }}
+
+kind: pool
+metadata:
+  name: workers
+options:
+  WaitBeforeProvision: 5
+  WaitBeforeDestroy: 5
+properties:
+  plugin: az1/compute
+  count: {{ $count }}   # how many in the pool
+  parallelism: {{ $parallelism }}  # how many to provision / destroy at a time
+  select:
+    az: az1
+    type: compute
+  init: |
+    sudo apt-get install -y docker
+  properties:
+    instanceType: xlarge
+    vcpu: 8
+    mem: 512G

--- a/docs/controller/pool/workers.yml
+++ b/docs/controller/pool/workers.yml
@@ -7,8 +7,9 @@ kind: pool
 metadata:
   name: workers
 options:
-  WaitBeforeProvision: 5
-  WaitBeforeDestroy: 5
+  WaitBeforeProvision: 3
+  WaitBeforeDestroy: 3
+  ObserveInterval: 0.5s
 properties:
   plugin: az1/compute
   count: {{ $count }}   # how many in the pool

--- a/pkg/controller/internal/collection.go
+++ b/pkg/controller/internal/collection.go
@@ -42,9 +42,10 @@ func (f stateMachine) MarshalJSON() ([]byte, error) {
 
 // Item is an item in the collection.
 type Item struct {
-	Key   string
-	State stateMachine
-	Data  map[string]interface{} `json:",omitempty"`
+	Key     string
+	Ordinal int
+	State   stateMachine
+	Data    map[string]interface{} `json:",omitempty"`
 }
 
 // Collection is a Managed that tracks a set of finite state machines.

--- a/pkg/controller/internal/collection.go
+++ b/pkg/controller/internal/collection.go
@@ -350,6 +350,17 @@ func (c *Collection) Get(k string) *Item {
 	return c.items[k]
 }
 
+// GetCountByState returns the number of instances in the given state
+func (c *Collection) GetCountByState(state fsm.Index) (count int) {
+	c.Visit(func(i Item) bool {
+		if i.State.State() == state {
+			count++
+		}
+		return true
+	})
+	return
+}
+
 // GetByFSM returns an item by the state machine
 func (c *Collection) GetByFSM(f fsm.FSM) (item *Item) {
 	c.Visit(func(i Item) bool {

--- a/pkg/controller/pool/collection.go
+++ b/pkg/controller/pool/collection.go
@@ -1,0 +1,554 @@
+package pool
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/docker/infrakit/pkg/controller/internal"
+	pool "github.com/docker/infrakit/pkg/controller/pool/types"
+	"github.com/docker/infrakit/pkg/run/scope"
+	"github.com/docker/infrakit/pkg/spi/event"
+	"github.com/docker/infrakit/pkg/spi/instance"
+	"github.com/docker/infrakit/pkg/types"
+	"github.com/imdario/mergo"
+)
+
+type resources map[string]instance.Description
+
+type collection struct {
+	*internal.Collection
+
+	accessor *internal.InstanceAccess // current version
+	last     *internal.InstanceAccess // last version
+
+	spec       types.Spec
+	properties pool.Properties
+	options    pool.Options
+	model      *Model
+
+	resources resources
+
+	cancel func()
+}
+
+var (
+	// TopicProvision is the topic for provision
+	TopicProvision = types.PathFromString("provision")
+
+	// TopicProvisionErr is the topic for provision error
+	TopicProvisionErr = types.PathFromString("error/provision")
+
+	// TopicDestroy is the topic for destroy
+	TopicDestroy = types.PathFromString("destroy")
+
+	// TopicDestroyErr is the topic for destroy error
+	TopicDestroyErr = types.PathFromString("error/destroy")
+
+	// TopicPending is the topic for waiting for data
+	TopicPending = types.PathFromString("pending")
+
+	// TopicReady is the topic for resource ready
+	TopicReady = types.PathFromString("ready")
+)
+
+func newCollection(scope scope.Scope, options pool.Options) (internal.Managed, error) {
+
+	if err := mergo.Merge(&options, DefaultOptions); err != nil {
+		return nil, err
+	}
+
+	if err := options.Validate(context.Background()); err != nil {
+		return nil, err
+	}
+
+	base, err := internal.NewCollection(scope,
+		TopicProvision,
+		TopicProvisionErr,
+		TopicDestroy,
+		TopicDestroyErr,
+		TopicPending,
+		TopicReady,
+	)
+	if err != nil {
+		return nil, err
+	}
+	c := &collection{
+		Collection: base,
+		options:    options,
+		resources:  resources{},
+	}
+	// set the behaviors
+	base.StartFunc = c.run
+	base.StopFunc = c.stop
+	base.UpdateSpecFunc = c.updateSpec
+	base.TerminateFunc = c.terminate
+
+	return c, nil
+}
+
+func (c *collection) updateSpec(spec types.Spec, previous *types.Spec) (err error) {
+
+	prev := spec
+	if previous != nil {
+		prev = *previous
+	}
+
+	log.Debug("updateSpec", "spec", spec, "prev", prev)
+
+	// parse input, then select the model to use
+	properties := pool.Properties{}
+	err = spec.Properties.Decode(&properties)
+	if err != nil {
+		return
+	}
+
+	prevProperties := pool.Properties{}
+	err = prev.Properties.Decode(&prevProperties)
+	if err != nil {
+		return
+	}
+
+	options := c.options // the plugin options at initialization are the defaults
+	err = spec.Options.Decode(&options)
+	if err != nil {
+		return
+	}
+
+	ctx := context.Background()
+	if err = properties.Validate(ctx); err != nil {
+		return
+	}
+
+	if err = options.Validate(ctx); err != nil {
+		return
+	}
+
+	log.Debug("Begin processing", "properties", properties, "previous", prevProperties, "options", options, "V", debugV2)
+
+	err = c.configureAccessor(spec, &properties.InstanceAccess)
+	if err != nil {
+		return err
+	}
+
+	c.accessor = &properties.InstanceAccess
+
+	log.Debug("Initialized current accessor", "spec", spec, "access", c.accessor, "V", debugV)
+
+	err = c.configureAccessor(spec, &prevProperties.InstanceAccess)
+	if err != nil {
+		return err
+	}
+	c.last = &prevProperties.InstanceAccess
+
+	log.Debug("Initialize last accessor", "previous", previous, "access", c.last, "V", debugV)
+
+	// build the fsm model
+	var model *Model
+	model, err = BuildModel(properties, options)
+	if err != nil {
+		return
+	}
+
+	c.model = model
+	c.spec = spec
+	c.properties = properties
+	c.options = options
+
+	log.Debug("Starting with state", "properties", c.properties, "V", debugV)
+	return
+}
+
+func (c *collection) run(ctx context.Context) {
+
+	// Start the model
+	c.model.Start()
+
+	// channels that aggregate from all the instance accessors
+	type observation struct {
+		instances []instance.Description
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	c.cancel = cancel
+
+	// Start all the instance accessors and wire up the observations.
+
+	lostInstances := make(chan *observation, c.options.ChannelBufferSize)  // ch to aggregate all lost observations
+	foundInstances := make(chan *observation, c.options.ChannelBufferSize) // ch to aggregate all found observations
+
+	log.Debug("Set up events from instance accessor", "V", debugV)
+	go func(accessor *internal.InstanceAccess) {
+		for {
+			select {
+			case list, ok := <-accessor.Observations():
+				if !ok {
+					log.Debug("found observations done", "V", debugV2)
+					return
+				}
+				if len(list) > 0 {
+					foundInstances <- &observation{instances: list}
+					log.Debug("accessor found instances", "count", len(list), "V", debugV2)
+				}
+			case list, ok := <-accessor.Lost():
+				if !ok {
+					log.Debug("lost events done", "V", debugV2)
+					return
+				}
+				if len(list) > 0 {
+					lostInstances <- &observation{instances: list}
+					log.Debug("accessor lost instances", "count", len(list), "V", debugV2)
+				}
+			}
+		}
+	}(c.accessor)
+
+	c.accessor.Start()
+	log.Debug("accessor started")
+
+	go func() {
+
+	loop:
+		for {
+
+			select {
+
+			case f, ok := <-c.model.Cleanup():
+				if !ok {
+					return
+				}
+				item := c.Collection.GetByFSM(f)
+				if item != nil {
+					c.Collection.Delete(item.Key)
+				}
+			case f, ok := <-c.model.Ready():
+				if !ok {
+					return
+				}
+				item := c.Collection.GetByFSM(f)
+				if item != nil {
+					c.EventCh() <- event.Event{
+						Topic:   c.Topic(TopicReady),
+						Type:    event.Type("Ready"),
+						ID:      c.EventID(item.Key),
+						Message: "resource ready",
+					}.Init()
+				}
+
+			case f, ok := <-c.model.Pending():
+				if !ok {
+					return
+				}
+				item := c.Collection.GetByFSM(f)
+				if item != nil {
+
+					msg := fmt.Sprintf("%v : resource blocked waiting on dependencies", item.State)
+					c.EventCh() <- event.Event{
+						Topic:   c.Topic(TopicPending),
+						Type:    event.Type("Pending"),
+						ID:      c.EventID(item.Key),
+						Message: msg,
+					}.Init()
+				}
+
+			case f, ok := <-c.model.Destroy():
+				if !ok {
+					return
+				}
+
+				item := c.Collection.GetByFSM(f)
+				if item != nil {
+
+					accessor := c.accessor
+					log.Info("Destroy", "fsm", f.ID(), "item", item, "accessor", accessor)
+
+					if accessor == nil {
+						accessor = c.last
+					}
+
+					if accessor == nil {
+						log.Error("cannot find accessor for seq", "seq", item.Key)
+						continue loop
+					}
+
+					d := item.Data["instance"]
+					if d == nil {
+						log.Error("cannot find instance", "item", item.Key)
+						continue loop
+					}
+
+					if dd, is := d.(instance.Description); is {
+
+						log.Info("Destroy", "instanceID", dd.ID, "key", item.Key)
+						err := accessor.Destroy(dd.ID, instance.Termination)
+						log.Debug("destroy", "instanceID", dd.ID, "key", item.Key, "err", err)
+
+						if err != nil {
+
+							log.Error("Cannot destroy", "err", err)
+							item.State.Signal(terminateError)
+
+							c.EventCh() <- event.Event{
+								Topic:   c.Topic(TopicDestroyErr),
+								Type:    event.Type("DestroyErr"),
+								ID:      c.EventID(item.Key),
+								Message: "destroying resource error",
+							}.Init().WithError(err)
+
+						} else {
+
+							c.EventCh() <- event.Event{
+								Topic:   c.Topic(TopicDestroy),
+								Type:    event.Type("Destroy"),
+								ID:      c.EventID(item.Key),
+								Message: "destroying resource",
+							}.Init()
+
+						}
+					}
+				}
+
+			case f, ok := <-c.model.Provision():
+				if !ok {
+					return
+				}
+
+				item := c.Collection.GetByFSM(f)
+				if item != nil {
+					accessor := c.accessor
+					spec, err := c.buildSpec(item, accessor.Spec)
+					if err != nil {
+
+						log.Error("Error building spec",
+							"fsm", f.ID(), "item", item,
+							"accessor", accessor, "spec", spec,
+							"err", err)
+
+						item.State.Signal(dependencyMissing)
+						continue
+					}
+
+					func() {
+
+						defer func() {
+							e := recover()
+							if e != nil {
+								log.Error("Recovered from error while provisioning", "err", e,
+									"accessor", accessor,
+									"spec", spec, "item", item)
+							}
+						}()
+						instanceID, err := accessor.Provision(spec)
+						if err != nil {
+
+							log.Error("Cannot provision", "err", err)
+							item.State.Signal(provisionError)
+
+							c.EventCh() <- event.Event{
+								Topic:   c.Topic(TopicProvisionErr),
+								Type:    event.Type("ProvisionErr"),
+								ID:      c.EventID(item.Key),
+								Message: "error when provision",
+							}.Init().WithError(err)
+
+						} else {
+
+							id := ""
+							if instanceID != nil {
+								id = string(*instanceID)
+							}
+
+							log.Info("Provisioned", "id", id, "spec", spec)
+
+							/// don't do anything. next sample will make sure it moves to ready
+
+							c.EventCh() <- event.Event{
+								Topic:   c.Topic(TopicProvision),
+								Type:    event.Type("Provision"),
+								ID:      c.EventID(item.Key),
+								Message: "provisioning resource",
+							}.Init().WithDataMust(spec)
+						}
+
+					}()
+				}
+
+			case lost, ok := <-lostInstances:
+				if !ok {
+					log.Info("Lost aggregator done")
+					return
+				}
+
+				// Update the view in the metadata plugin
+				c.MetadataGone(c.accessor.KeyOf, lost.instances)
+
+				for _, n := range lost.instances {
+					k, err := c.accessor.KeyOf(n)
+					if err != nil {
+						log.Error("error getting key", "err", err, "instance", n)
+						break
+					}
+
+					if item := c.Collection.Get(k); item != nil {
+						item.State.Signal(resourceLost)
+						log.Error("lost", "instance", n, "key", k)
+					}
+					delete(c.resources, k)
+				}
+
+			case found, ok := <-foundInstances:
+				if !ok {
+					log.Info("Found aggregator done")
+					return
+				}
+
+				// Update the view in the metadata plugin
+				export := []instance.Description{}
+
+				for _, n := range found.instances {
+					k, err := c.accessor.KeyOf(n)
+					if err != nil {
+						log.Error("error getting key", "err", err, "instance", n)
+						break
+					}
+					item := c.Collection.Get(k)
+					if item == nil {
+
+						// In this case, the fsm isn't requested.. it's something we get out of band
+						// that somehow shows up (or from previous runs but now the user has
+						// removed it from the spec and performed a commit.
+						f := c.model.Unmatched()
+						item = c.Put(k, f, c.model.Spec(), map[string]interface{}{
+							"instance": n,
+						})
+
+						export = append(export, n) // export to metadata
+
+					} else {
+
+						// if we already have entries stored, then see if the data changed
+						prev := item.Data["instance"]
+						if prev == nil {
+							export = append(export, n)
+						} else if dd, is := prev.(instance.Description); is {
+							if dd.Fingerprint() != n.Fingerprint() {
+								export = append(export, n)
+							}
+						}
+					}
+
+					c.resources[k] = n
+
+					log.Debug("found", "instance", n, "key", k, "V", debugV2)
+					item.State.Signal(resourceFound)
+					item.Data["instance"] = n
+				}
+
+				c.MetadataExport(c.accessor.KeyOf, export)
+			}
+		}
+	}()
+
+	log.Debug("Seeding instances", "count", c.properties.Count, "V", debugV)
+
+	// Seed the initial fsm instances for the size of the collection
+	for i := 0; i < c.properties.Count; i++ {
+
+		f := c.model.Requested()
+		k := fmt.Sprintf("%s_%d", c.spec.Metadata.Name, i)
+
+		item := c.Put(k, f, c.model.Spec(), nil)
+		item.Ordinal = i
+
+		log.Debug("requested", "id", f.ID(), "key", item.Key, "ordinal", item.Ordinal)
+	}
+
+	log.Debug("Seeded instances. Running.")
+}
+
+func (c *collection) terminate() error {
+	c.Visit(func(item internal.Item) bool {
+		item.State.Signal(terminate)
+		return true
+	})
+
+	return nil
+}
+
+func (c *collection) stop() error {
+	log.Info("stop")
+
+	if c.model != nil {
+
+		c.cancel()
+
+		log.Debug("Stopping", "V", debugV)
+		c.accessor.Stop()
+		if c.last != nil {
+			c.last.Stop()
+		}
+		c.model.Stop()
+		c.model = nil
+	}
+	return nil
+}
+
+func (c *collection) configureAccessor(spec types.Spec, access *internal.InstanceAccess) error {
+	if access.Select == nil {
+		access.Select = map[string]string{}
+	}
+	access.Select[internal.CollectionLabel] = spec.Metadata.Name
+	err := access.InstanceObserver.Validate(c.options.InstanceObserver)
+	if err != nil {
+		return err
+	}
+
+	return access.Init(c.Scope(), c.options.PluginRetryInterval.AtLeast(1*time.Second))
+}
+
+func (c *collection) buildSpec(item *internal.Item, spec instance.Spec) (instance.Spec, error) {
+
+	// Turn the spec into a blob and use that to parse the dependencies
+	specAny, err := types.AnyValue(spec)
+	if err != nil {
+		return spec, err
+	}
+
+	evaled := types.EvalDepends(specAny,
+		func(p types.Path) (interface{}, error) {
+			v := types.Get(p, c.resources)
+			return v, nil
+		}) // should have all values populated
+
+	specAny, err = types.AnyValue(evaled)
+	if err != nil {
+		return spec, err
+	}
+	if depends := types.ParseDepends(specAny); len(depends) > 0 {
+		return spec, fmt.Errorf("missing data %v", specAny.String())
+	}
+
+	// Now take the whole thing and decode into a Spec
+	processed := spec
+
+	err = specAny.Decode(&processed)
+	if err != nil {
+		return spec, err
+	}
+
+	if processed.Tags == nil {
+		processed.Tags = map[string]string{}
+	}
+
+	processed.Tags[internal.InstanceLabel] = item.Key
+	processed.Tags[internal.CollectionLabel] = c.Collection.Spec.Metadata.Name
+	processed.Tags[internal.SpecHash] = types.Fingerprint(specAny)
+	types.NewLink().WriteMap(processed.Tags)
+
+	// Additional labels in the InstanceAccess spec
+	for k, v := range c.accessor.Select {
+		processed.Tags[k] = v
+	}
+
+	return processed, nil
+}

--- a/pkg/controller/pool/controller.go
+++ b/pkg/controller/pool/controller.go
@@ -31,15 +31,15 @@ var (
 		},
 		PluginRetryInterval:    types.Duration(1 * time.Second),
 		MinChannelBufferSize:   10,
-		MinWaitBeforeProvision: 5,
+		MinWaitBeforeProvision: 3,
 		ModelProperties:        DefaultModelProperties,
 	}
 
 	// DefaultModelProperties is the default properties for the fsm model
 	DefaultModelProperties = pool.ModelProperties{
 		TickUnit:            types.FromDuration(1 * time.Second),
-		WaitBeforeProvision: fsm.Tick(5),
-		WaitBeforeDestroy:   fsm.Tick(5),
+		WaitBeforeProvision: fsm.Tick(3),
+		WaitBeforeDestroy:   fsm.Tick(3),
 		ChannelBufferSize:   10,
 	}
 

--- a/pkg/controller/pool/controller.go
+++ b/pkg/controller/pool/controller.go
@@ -1,0 +1,78 @@
+package pool
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/docker/infrakit/pkg/controller/internal"
+	pool "github.com/docker/infrakit/pkg/controller/pool/types"
+	"github.com/docker/infrakit/pkg/fsm"
+	logutil "github.com/docker/infrakit/pkg/log"
+	"github.com/docker/infrakit/pkg/run/scope"
+	"github.com/docker/infrakit/pkg/spi/controller"
+	"github.com/docker/infrakit/pkg/spi/event"
+	"github.com/docker/infrakit/pkg/spi/metadata"
+	"github.com/docker/infrakit/pkg/template"
+	"github.com/docker/infrakit/pkg/types"
+)
+
+var (
+	log     = logutil.New("module", "controller/pool")
+	debugV  = logutil.V(500)
+	debugV2 = logutil.V(1000)
+
+	// DefaultOptions is the default options of the controller. This can be controlled at starup
+	// and is set once.
+	DefaultOptions = pool.Options{
+		InstanceObserver: &internal.InstanceObserver{
+			ObserveInterval: types.Duration(5 * time.Second),
+			KeySelector: template.EscapeString(fmt.Sprintf(`{{.Tags.%s}}`,
+				internal.InstanceLabel)),
+		},
+		PluginRetryInterval:    types.Duration(1 * time.Second),
+		MinChannelBufferSize:   10,
+		MinWaitBeforeProvision: 5,
+		ModelProperties:        DefaultModelProperties,
+	}
+
+	// DefaultModelProperties is the default properties for the fsm model
+	DefaultModelProperties = pool.ModelProperties{
+		TickUnit:            types.FromDuration(1 * time.Second),
+		WaitBeforeProvision: fsm.Tick(5),
+		WaitBeforeDestroy:   fsm.Tick(5),
+		ChannelBufferSize:   10,
+	}
+
+	// DefaultProperties is the default properties for the controller, this is per collection / commit
+	DefaultProperties = pool.Properties{
+		Parallelism: 1,
+	}
+)
+
+// Components contains a set of components in this controller.
+type Components struct {
+	Controllers func() (map[string]controller.Controller, error)
+	Metadata    func() (map[string]metadata.Plugin, error)
+	Events      event.Plugin
+}
+
+// NewComponents returns a controller implementation
+func NewComponents(scope scope.Scope, options pool.Options) *Components {
+
+	controller := internal.NewController(
+		// the constructor
+		func(spec types.Spec) (internal.Managed, error) {
+			return newCollection(scope, options)
+		},
+		// the key function
+		func(metadata types.Metadata) string {
+			return metadata.Name
+		},
+	)
+
+	return &Components{
+		Controllers: controller.Controllers,
+		Metadata:    controller.Metadata,
+		Events:      controller,
+	}
+}

--- a/pkg/controller/pool/fsm.go
+++ b/pkg/controller/pool/fsm.go
@@ -112,7 +112,7 @@ const (
 	terminating
 	terminated
 	throttled
-	terminate_throttled
+	terminateThrottled
 
 	// Signals
 	resourceFound fsm.Signal = iota
@@ -209,7 +209,7 @@ func BuildModel(properties pool.Properties, options pool.Options) (*Model, error
 			},
 		},
 		fsm.State{
-			Index: terminate_throttled,
+			Index: terminateThrottled,
 			TTL:   fsm.Expiry{fsm.Tick(1), terminate},
 			Transitions: map[fsm.Signal]fsm.Index{
 				resourceLost: terminated,
@@ -228,7 +228,7 @@ func BuildModel(properties pool.Properties, options pool.Options) (*Model, error
 				dependencyMissing: waitingTerminate,
 				resourceLost:      terminated,
 				terminateError:    cannotTerminate,
-				throttle:          terminate_throttled,
+				throttle:          terminateThrottled,
 			},
 			Actions: map[fsm.Signal]fsm.Action{
 				dependencyMissing: func(n fsm.FSM) error {
@@ -321,18 +321,18 @@ func BuildModel(properties pool.Properties, options pool.Options) (*Model, error
 	}
 
 	spec.SetStateNames(map[fsm.Index]string{
-		requested:           "REQUESTED",
-		throttled:           "THROTTLED",
-		terminate_throttled: "THROTTLED",
-		ready:               "READY",
-		provisioning:        "PROVISIONING",
-		waiting:             "WAITING_PROVISION",
-		waitingTerminate:    "WAITING_TERMINATE",
-		cannotProvision:     "CANNOT_PROVISION",
-		cannotTerminate:     "CANNOT_TERMINATE",
-		unmatched:           "UNMATCHED",
-		terminating:         "TERMINATING",
-		terminated:          "TERMINATED",
+		requested:          "REQUESTED",
+		throttled:          "THROTTLED",
+		terminateThrottled: "THROTTLED",
+		ready:              "READY",
+		provisioning:       "PROVISIONING",
+		waiting:            "WAITING_PROVISION",
+		waitingTerminate:   "WAITING_TERMINATE",
+		cannotProvision:    "CANNOT_PROVISION",
+		cannotTerminate:    "CANNOT_TERMINATE",
+		unmatched:          "UNMATCHED",
+		terminating:        "TERMINATING",
+		terminated:         "TERMINATED",
 	}).SetSignalNames(map[fsm.Signal]string{
 		resourceFound:     "resource_found",
 		resourceLost:      "resource_lost",

--- a/pkg/controller/pool/fsm.go
+++ b/pkg/controller/pool/fsm.go
@@ -1,0 +1,313 @@
+package pool
+
+import (
+	"sync"
+	"time"
+
+	pool "github.com/docker/infrakit/pkg/controller/pool/types"
+	"github.com/docker/infrakit/pkg/fsm"
+)
+
+// Model encapsulates the workflow / state machines for provisioning resources
+type Model struct {
+	spec     *fsm.Spec
+	set      *fsm.Set
+	clock    *fsm.Clock
+	tickSize time.Duration
+
+	pool.Properties
+
+	instanceDestroyChan   chan fsm.FSM
+	instanceProvisionChan chan fsm.FSM
+	instancePendingChan   chan fsm.FSM
+	instanceReadyChan     chan fsm.FSM
+	cleanupChan           chan fsm.FSM
+
+	lock sync.RWMutex
+}
+
+// Cleanup is the channel to get signals to clean up
+func (m *Model) Cleanup() <-chan fsm.FSM {
+	return m.cleanupChan
+}
+
+// Destroy is the channel to get signals to destroy an instance
+func (m *Model) Destroy() <-chan fsm.FSM {
+	return m.instanceDestroyChan
+}
+
+// Pending is the channel to get signals that instances are in pending state
+func (m *Model) Pending() <-chan fsm.FSM {
+	return m.instancePendingChan
+}
+
+// Ready is the channel to get signals of instances that are ready
+func (m *Model) Ready() <-chan fsm.FSM {
+	return m.instanceReadyChan
+}
+
+// Provision is the channel to get signals to provision new instance
+func (m *Model) Provision() <-chan fsm.FSM {
+	return m.instanceProvisionChan
+}
+
+// Requested adds a new fsm in the requested state
+func (m *Model) Requested() fsm.FSM {
+	return m.set.Add(requested)
+}
+
+// Unmatched adds a new fsm in unmatched state
+func (m *Model) Unmatched() fsm.FSM {
+	return m.set.Add(unmatched)
+}
+
+// Spec returns the model description
+func (m *Model) Spec() *fsm.Spec {
+	m.lock.RLock()
+	defer m.lock.RUnlock()
+
+	return m.spec
+}
+
+// Start starts the model
+func (m *Model) Start() {
+	m.lock.Lock()
+	defer m.lock.Unlock()
+
+	if m.set == nil {
+		m.clock.Start()
+		m.set = fsm.NewSet(m.spec, m.clock, fsm.DefaultOptions("resource"))
+	}
+}
+
+// Stop stops the model
+func (m *Model) Stop() {
+	m.lock.Lock()
+	defer m.lock.Unlock()
+
+	if m.set != nil {
+		m.set.Stop()
+		m.clock.Stop()
+
+		close(m.instanceDestroyChan)
+		close(m.instanceProvisionChan)
+		close(m.instancePendingChan)
+		close(m.instanceReadyChan)
+		close(m.cleanupChan)
+		m.set = nil
+	}
+}
+
+const (
+
+	// States
+	requested fsm.Index = iota
+	provisioning
+	waiting
+	waitingTerminate
+	ready
+	cannotProvision
+	cannotTerminate
+	unmatched
+	terminating
+	terminated
+
+	// Signals
+	resourceFound fsm.Signal = iota
+	resourceLost
+	provision
+	provisionError
+	dependencyMissing
+	dependencyReady
+	terminate
+	terminateError
+	cleanup
+)
+
+// BuildModel constructs a workflow model given the configuration blob provided by user in the Properties
+func BuildModel(properties pool.Properties, options pool.Options) (*Model, error) {
+
+	log.Info("Build model", "properties", properties, "options", options)
+	model := &Model{
+		Properties:            properties,
+		instanceDestroyChan:   make(chan fsm.FSM, options.ChannelBufferSize),
+		instanceProvisionChan: make(chan fsm.FSM, options.ChannelBufferSize),
+		instancePendingChan:   make(chan fsm.FSM, options.ChannelBufferSize),
+		instanceReadyChan:     make(chan fsm.FSM, options.ChannelBufferSize),
+		cleanupChan:           make(chan fsm.FSM, options.ChannelBufferSize),
+		tickSize:              1 * time.Second,
+	}
+
+	// find the max observation interval and set the model tick to be that
+	if model.tickSize < properties.ObserveInterval.Duration() {
+		model.tickSize = properties.ObserveInterval.Duration()
+	}
+
+	// We must guarantee that the tick size is at least as large as the global
+	// setting.  This is so that we don't miss samples and instead advances state
+	// too quickly.
+	if options.InstanceObserver.ObserveInterval.Duration() > model.tickSize {
+		model.tickSize = options.InstanceObserver.ObserveInterval.Duration()
+	}
+
+	log.Info("model", "tickSize", model.tickSize,
+		"waitBeforeProvision", options.WaitBeforeProvision)
+
+	model.clock = fsm.Wall(time.Tick(model.tickSize))
+
+	spec, err := fsm.Define(
+		fsm.State{
+			Index: requested,
+			TTL:   fsm.Expiry{options.WaitBeforeProvision, provision},
+			Transitions: map[fsm.Signal]fsm.Index{
+				resourceFound: ready,
+				resourceLost:  provisioning,
+				provision:     provisioning,
+			},
+			Actions: map[fsm.Signal]fsm.Action{
+				provision: func(n fsm.FSM) error {
+					model.instanceProvisionChan <- n
+					return nil
+				},
+			},
+		},
+		fsm.State{
+			Index: provisioning,
+			Transitions: map[fsm.Signal]fsm.Index{
+				dependencyMissing: waiting,
+				resourceFound:     ready,
+				provisionError:    cannotProvision,
+			},
+			Actions: map[fsm.Signal]fsm.Action{
+				dependencyMissing: func(n fsm.FSM) error {
+					model.instancePendingChan <- n
+					return nil
+				},
+				resourceFound: func(n fsm.FSM) error {
+					model.instanceReadyChan <- n
+					return nil
+				},
+			},
+		},
+		fsm.State{
+			Index: terminating,
+			Transitions: map[fsm.Signal]fsm.Index{
+				dependencyMissing: waitingTerminate,
+				resourceLost:      terminated,
+				terminateError:    cannotTerminate,
+			},
+			Actions: map[fsm.Signal]fsm.Action{
+				dependencyMissing: func(n fsm.FSM) error {
+					model.instancePendingChan <- n
+					return nil
+				},
+			},
+		},
+		fsm.State{
+			Index: waiting,
+			Transitions: map[fsm.Signal]fsm.Index{
+				dependencyMissing: waiting,
+				dependencyReady:   provisioning,
+			},
+			Actions: map[fsm.Signal]fsm.Action{
+				dependencyReady: func(n fsm.FSM) error {
+					model.instanceProvisionChan <- n
+					return nil
+				},
+			},
+		},
+		fsm.State{
+			Index: waitingTerminate,
+			Transitions: map[fsm.Signal]fsm.Index{
+				dependencyMissing: waitingTerminate,
+				dependencyReady:   terminating,
+				resourceLost:      terminated,
+			},
+			Actions: map[fsm.Signal]fsm.Action{
+				dependencyReady: func(n fsm.FSM) error {
+					model.instanceDestroyChan <- n
+					return nil
+				},
+			},
+		},
+		fsm.State{
+			Index: ready,
+			Transitions: map[fsm.Signal]fsm.Index{
+				resourceLost:  provisioning,
+				resourceFound: ready, // just loops back to self in the ready state
+				terminate:     terminating,
+			},
+			Actions: map[fsm.Signal]fsm.Action{
+				resourceLost: func(n fsm.FSM) error {
+					model.instanceProvisionChan <- n
+					return nil
+				},
+				terminate: func(n fsm.FSM) error {
+					model.instanceDestroyChan <- n
+					return nil
+				},
+			},
+		},
+		fsm.State{
+			Index: cannotProvision,
+		},
+		fsm.State{
+			Index: cannotTerminate,
+		},
+		fsm.State{
+			Index: unmatched,
+			TTL:   fsm.Expiry{options.WaitBeforeDestroy, terminate},
+			Transitions: map[fsm.Signal]fsm.Index{
+				terminate: terminating,
+			},
+			Actions: map[fsm.Signal]fsm.Action{
+				terminate: func(n fsm.FSM) error {
+					model.instanceDestroyChan <- n
+					return nil
+				},
+			},
+		},
+		fsm.State{
+			Index: terminated,
+			TTL:   fsm.Expiry{options.WaitBeforeDestroy, cleanup},
+			Transitions: map[fsm.Signal]fsm.Index{
+				cleanup: terminated, // This is really unnecessary, just here to trigger the cleanup action
+			},
+			Actions: map[fsm.Signal]fsm.Action{
+				cleanup: func(n fsm.FSM) error {
+					model.cleanupChan <- n
+					return nil
+				},
+			},
+		},
+	)
+
+	if err != nil {
+		return nil, err
+	}
+
+	spec.SetStateNames(map[fsm.Index]string{
+		requested:        "REQUESTED",
+		ready:            "READY",
+		provisioning:     "PROVISIONING",
+		waiting:          "WAITING_PROVISION",
+		waitingTerminate: "WAITING_TERMINATE",
+		cannotProvision:  "CANNOT_PROVISION",
+		cannotTerminate:  "CANNOT_TERMINATE",
+		unmatched:        "UNMATCHED",
+		terminating:      "TERMINATING",
+		terminated:       "TERMINATED",
+	}).SetSignalNames(map[fsm.Signal]string{
+		resourceFound:     "resource_found",
+		resourceLost:      "resource_lost",
+		provision:         "provision",
+		terminate:         "terminate",
+		cleanup:           "cleanup",
+		provisionError:    "provision_error",
+		terminateError:    "terminate_error",
+		dependencyMissing: "dependency_missing",
+		dependencyReady:   "dependency_ready",
+	})
+	model.spec = spec
+	return model, nil
+}

--- a/pkg/controller/pool/types/types.go
+++ b/pkg/controller/pool/types/types.go
@@ -1,0 +1,107 @@
+package types
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/docker/infrakit/pkg/controller/internal"
+	"github.com/docker/infrakit/pkg/fsm"
+	logutil "github.com/docker/infrakit/pkg/log"
+	"github.com/docker/infrakit/pkg/run/depends"
+	"github.com/docker/infrakit/pkg/spi/controller"
+	"github.com/docker/infrakit/pkg/types"
+)
+
+var (
+	log     = logutil.New("module", "controller/pool/types")
+	debugV  = logutil.V(500)
+	debugV2 = logutil.V(1000)
+)
+
+func init() {
+	depends.Register("pool", types.InterfaceSpec(controller.InterfaceSpec), ResolveDependencies)
+}
+
+// ResolveDependencies returns a list of dependencies by parsing the opaque Properties blob.
+func ResolveDependencies(spec types.Spec) (depends.Runnables, error) {
+	if spec.Properties == nil {
+		return nil, nil
+	}
+
+	properties := Properties{}
+	err := spec.Properties.Decode(&properties)
+	if err != nil {
+		return nil, err
+	}
+
+	dep := depends.Runnables{}
+	dep = append(dep, depends.AsRunnable(
+		types.Spec{
+			Kind: properties.InstanceObserver.Plugin.Lookup(),
+			Metadata: types.Metadata{
+				Name: properties.InstanceObserver.Plugin.String(),
+			},
+		},
+	))
+
+	return dep, nil
+}
+
+// Properties is the schema of the configuration in the types.Spec.Properties
+type Properties struct {
+	internal.InstanceAccess `json:",inline" yaml:",inline"`
+
+	// Parallelism specifies how many instances are created in parallel
+	Parallelism int
+
+	// Count is how many instances of the resource to provision
+	Count int
+}
+
+// ModelProperties contain fsm tuning parameters
+type ModelProperties struct {
+	TickUnit            types.Duration
+	WaitBeforeProvision fsm.Tick
+	WaitBeforeDestroy   fsm.Tick
+	ChannelBufferSize   int
+}
+
+// Validate validates the input properties
+func (p Properties) Validate(ctx context.Context) error {
+	return nil
+}
+
+// Options is the controller options that is used at start up of the process.  It's one-time
+type Options struct {
+	// for overriding globally
+	*internal.InstanceObserver `json:",inline" yaml:",inline"`
+
+	// PluginRetryInterval is the interval for retrying to connect to the plugins
+	PluginRetryInterval types.Duration
+
+	// MinChannelBufferSize is the min size of the buffered chanels
+	MinChannelBufferSize int
+
+	// MinWaitBeforeProvision is the number of ticks before provision of missing resources begins
+	MinWaitBeforeProvision fsm.Tick
+
+	// ModelProperties are the config parameters for the workflow model
+	ModelProperties `json:",inline" yaml:",inline"`
+}
+
+// Validate validates the controller's options
+func (p Options) Validate(ctx context.Context) error {
+	if p.MinChannelBufferSize == 0 {
+		return fmt.Errorf("min channel buffer size cannot be 0")
+	}
+	if p.MinWaitBeforeProvision == 0 {
+		return fmt.Errorf("min wait before provision cannot be 0")
+	}
+	if p.ChannelBufferSize < p.MinChannelBufferSize {
+		return fmt.Errorf("channel buffer size can't be less than %v", p.MinChannelBufferSize)
+	}
+	if p.WaitBeforeProvision < p.MinWaitBeforeProvision {
+		return fmt.Errorf("wait before provision can't be less than %v", p.MinWaitBeforeProvision)
+	}
+	return nil
+}

--- a/pkg/manager/manager.go
+++ b/pkg/manager/manager.go
@@ -513,7 +513,7 @@ func (m *manager) execPlugins(config globalSpec,
 
 		// TODO(chungers) ==> temporary
 		switch k.Kind {
-		case "ingress", "enrollment", "gc", "resource", "inventory":
+		case "ingress", "enrollment", "gc", "resource", "inventory", "pool":
 
 			cp, err := m.scope.Controller(r.Handler.String())
 			if err != nil {

--- a/pkg/run/v0/pool/pool.go
+++ b/pkg/run/v0/pool/pool.go
@@ -1,0 +1,92 @@
+package pool
+
+import (
+	"github.com/docker/infrakit/pkg/controller/pool"
+	"github.com/docker/infrakit/pkg/discovery"
+	"github.com/docker/infrakit/pkg/launch/inproc"
+	logutil "github.com/docker/infrakit/pkg/log"
+	"github.com/docker/infrakit/pkg/plugin"
+	"github.com/docker/infrakit/pkg/rpc/client"
+	manager_rpc "github.com/docker/infrakit/pkg/rpc/manager"
+	"github.com/docker/infrakit/pkg/run"
+	"github.com/docker/infrakit/pkg/run/scope"
+	"github.com/docker/infrakit/pkg/spi/controller"
+	"github.com/docker/infrakit/pkg/spi/stack"
+	"github.com/docker/infrakit/pkg/types"
+)
+
+const (
+	// Kind is the canonical name of the plugin for starting up, etc.
+	Kind = "pool"
+)
+
+var (
+	log = logutil.New("module", "run/v0/pool")
+
+	defaultOptions = pool.DefaultOptions
+)
+
+func init() {
+
+	inproc.Register(Kind, Run, defaultOptions)
+}
+
+func leadership(plugins func() discovery.Plugins) stack.Leadership {
+	// Scan for a manager
+	pm, err := plugins().List()
+	if err != nil {
+		log.Error("Cannot list plugins", "err", err)
+		return nil
+	}
+
+	for _, endpoint := range pm {
+		rpcClient, err := client.New(endpoint.Address, stack.InterfaceSpec)
+		if err == nil {
+			return manager_rpc.Adapt(rpcClient)
+		}
+
+		if !client.IsErrInterfaceNotSupported(err) {
+			log.Error("Got error getting manager", "endpoint", endpoint, "err", err)
+			return nil
+		}
+	}
+	return nil
+}
+
+// Run runs the plugin, blocking the current thread.  Error is returned immediately
+// if the plugin cannot be started.
+func Run(scope scope.Scope, name plugin.Name,
+	config *types.Any) (transport plugin.Transport, impls map[run.PluginCode]interface{}, onStop func(), err error) {
+
+	options := defaultOptions // decode into a copy of the updated defaults
+	err = config.Decode(&options)
+	if err != nil {
+		return
+	}
+
+	log.Info("Decoded input", "config", options)
+
+	transport.Name = name
+
+	pool := pool.NewComponents(scope, options)
+
+	leader := func() stack.Leadership {
+		return leadership(scope.Plugins)
+	}
+
+	impls = map[run.PluginCode]interface{}{
+		run.Controller: func() (map[string]controller.Controller, error) {
+			singletons := map[string]controller.Controller{}
+			if controllers, err := pool.Controllers(); err == nil {
+				for k, c := range controllers {
+					singletons[k] = controller.Singleton(c, leader)
+				}
+			}
+			return singletons, nil
+		},
+		run.Metadata: pool.Metadata,
+		run.Event:    pool.Events,
+	}
+
+	return
+}


### PR DESCRIPTION
The PR is the pool controller 
  + equivalent to the "Group" controller in managing a 'pool' of instances.  
  + uses FSM to implement throttle/ parallelism
  + does not "overshoot" when provisioning when backends are too slow
  + can easily scale down to 0 (#717)

Once the pool controller is stable and examples put together, the Group controller will be deprecated in favor of a consistent schema and controller implementation using finite state machines than using instance counts and polling.

[![asciicast](https://asciinema.org/a/kKtlsMECvBlK7zYT9xE1LDZkY.png)](https://asciinema.org/a/kKtlsMECvBlK7zYT9xE1LDZkY)

Signed-off-by: David Chung david.chung@docker.com