### PR TITLE
Stability and scalability fixes; expose tuning parameters

### DIFF
--- a/docs/controller/pool/start.sh
+++ b/docs/controller/pool/start.sh
@@ -15,3 +15,4 @@ infrakit plugin start manager:mystack vars group pool simulator:az1 \
 	 --log 5 --log-stack --log-debug-V 500 \
 	 --log-debug-match module=controller/pool \
 	 --log-debug-match module=controller/internal \
+	 --log-debug-match module=simulator/instance \

--- a/docs/controller/pool/workers.yml
+++ b/docs/controller/pool/workers.yml
@@ -1,13 +1,26 @@
 {{/* =% text %= */}}
 
-{{ $count := param "count" "int" "Count" | prompt "How many?" "int" 5 }}
-{{ $parallelism := param "parallelism" "int" "Parallelism" | prompt "How many at a time?" "int" 1 }}
+{{ $count := param "count" "int" "Count" | prompt "How many?" "int" 50 }}
+{{ $parallelism := param "parallelism" "int" "Parallelism" | prompt "How many at a time?" "int" 5 }}
 
 kind: pool
 metadata:
   name: workers
 options:
+
+  # This is how often we sample the infrastructure.  The ticks are all units of this duration.
+  ObserveInterval: 0.5s
+
+  # This is the size of the buffered channel for the finite state machine work queue -- needs to be at least the count.
+  BufferSize: {{ mul $count 10 | add 1024 }} # controls the fsm engine's queue capacity
+
+  # observation's inbound channel capacity -- needs to be at least the same as the number of resource objects.
+  ChannelBufferSize: {{ mul $count 10 | add 1024 }}
+
+  # How long to wait before we start the provision process, in unit of time (ticks)
   WaitBeforeProvision: 3
+
+  # How long to wait before we start the termination / destroy, in unit of time (ticks)
   WaitBeforeDestroy: 3
 properties:
   plugin: az1/compute
@@ -22,3 +35,5 @@ properties:
     instanceType: xlarge
     vcpu: 8
     mem: 512G
+    simulator_cap: 900    # simulator max capacity
+    #simulator_delay: .5s # simulator provision latency

--- a/pkg/controller/internal/collection.go
+++ b/pkg/controller/internal/collection.go
@@ -76,7 +76,7 @@ type Collection struct {
 
 	previous *types.Spec
 
-	items     map[string]*Item // read/writes of this will not be synchronized by the lock.
+	items     map[string]*Item
 	itemsLock sync.RWMutex
 
 	stop chan struct{}

--- a/pkg/controller/pool/controller.go
+++ b/pkg/controller/pool/controller.go
@@ -21,6 +21,21 @@ var (
 	debugV  = logutil.V(500)
 	debugV2 = logutil.V(1000)
 
+	// DefaultModelProperties is the default properties for the fsm model
+	DefaultModelProperties = pool.ModelProperties{
+		TickUnit:            types.FromDuration(1 * time.Second),
+		WaitBeforeProvision: fsm.Tick(3),
+		WaitBeforeDestroy:   fsm.Tick(3),
+		ChannelBufferSize:   4096,
+		Options: fsm.Options{
+			Name:                       "pool",
+			BufferSize:                 4096,
+			IgnoreUndefinedTransitions: true,
+			IgnoreUndefinedSignals:     true,
+			IgnoreUndefinedStates:      true,
+		},
+	}
+
 	// DefaultOptions is the default options of the controller. This can be controlled at starup
 	// and is set once.
 	DefaultOptions = pool.Options{
@@ -30,17 +45,11 @@ var (
 				internal.InstanceLabel)),
 		},
 		PluginRetryInterval:    types.Duration(1 * time.Second),
-		MinChannelBufferSize:   10,
+		MinChannelBufferSize:   1024,
 		MinWaitBeforeProvision: 3,
 		ModelProperties:        DefaultModelProperties,
-	}
-
-	// DefaultModelProperties is the default properties for the fsm model
-	DefaultModelProperties = pool.ModelProperties{
-		TickUnit:            types.FromDuration(1 * time.Second),
-		WaitBeforeProvision: fsm.Tick(3),
-		WaitBeforeDestroy:   fsm.Tick(3),
-		ChannelBufferSize:   10,
+		ProvisionDeadline:      types.Duration(1 * time.Second),
+		DestroyDeadline:        types.Duration(1 * time.Second),
 	}
 
 	// DefaultProperties is the default properties for the controller, this is per collection / commit

--- a/pkg/controller/pool/types/types.go
+++ b/pkg/controller/pool/types/types.go
@@ -64,6 +64,9 @@ type ModelProperties struct {
 	WaitBeforeProvision fsm.Tick
 	WaitBeforeDestroy   fsm.Tick
 	ChannelBufferSize   int
+
+	// FSM tuning options
+	fsm.Options `json:",inline" yaml:",inline"`
 }
 
 // Validate validates the input properties
@@ -87,6 +90,12 @@ type Options struct {
 
 	// ModelProperties are the config parameters for the workflow model
 	ModelProperties `json:",inline" yaml:",inline"`
+
+	// ProvisionDeadline is the deadline for synchronously calling the plugin to provision
+	ProvisionDeadline types.Duration
+
+	// DestroyDeadline is the deadline for synchronously calling the plugin to destroy
+	DestroyDeadline types.Duration
 }
 
 // Validate validates the controller's options
@@ -102,6 +111,12 @@ func (p Options) Validate(ctx context.Context) error {
 	}
 	if p.WaitBeforeProvision < p.MinWaitBeforeProvision {
 		return fmt.Errorf("wait before provision can't be less than %v", p.MinWaitBeforeProvision)
+	}
+	if p.ProvisionDeadline.Duration() == 0 {
+		return fmt.Errorf("bad provision deadline: %v", p.ProvisionDeadline)
+	}
+	if p.DestroyDeadline.Duration() == 0 {
+		return fmt.Errorf("bad destroy deadline: %v", p.DestroyDeadline)
 	}
 	return nil
 }

--- a/pkg/controller/resource/controller.go
+++ b/pkg/controller/resource/controller.go
@@ -21,6 +21,21 @@ var (
 	debugV  = logutil.V(500)
 	debugV2 = logutil.V(1000)
 
+	// DefaultModelProperties is the default properties for the fsm model
+	DefaultModelProperties = resource.ModelProperties{
+		TickUnit:            types.FromDuration(1 * time.Second),
+		WaitBeforeProvision: fsm.Tick(5),
+		WaitBeforeDestroy:   fsm.Tick(5),
+		ChannelBufferSize:   4096,
+		Options: fsm.Options{
+			Name:                       "resource",
+			BufferSize:                 4096,
+			IgnoreUndefinedTransitions: true,
+			IgnoreUndefinedSignals:     true,
+			IgnoreUndefinedStates:      true,
+		},
+	}
+
 	// DefaultOptions is the default options of the controller. This can be controlled at starup
 	// and is set once.
 	DefaultOptions = resource.Options{
@@ -33,14 +48,8 @@ var (
 		MinChannelBufferSize:   10,
 		MinWaitBeforeProvision: 5,
 		ModelProperties:        DefaultModelProperties,
-	}
-
-	// DefaultModelProperties is the default properties for the fsm model
-	DefaultModelProperties = resource.ModelProperties{
-		TickUnit:            types.FromDuration(1 * time.Second),
-		WaitBeforeProvision: fsm.Tick(5),
-		WaitBeforeDestroy:   fsm.Tick(5),
-		ChannelBufferSize:   10,
+		ProvisionDeadline:      types.Duration(1 * time.Second),
+		DestroyDeadline:        types.Duration(1 * time.Second),
 	}
 
 	// DefaultProperties is the default properties for the controller, this is per collection / commit

--- a/pkg/controller/resource/types/types.go
+++ b/pkg/controller/resource/types/types.go
@@ -57,6 +57,9 @@ type ModelProperties struct {
 	WaitBeforeProvision fsm.Tick
 	WaitBeforeDestroy   fsm.Tick
 	ChannelBufferSize   int
+
+	// FSM tuning options
+	fsm.Options `json:",inline" yaml:",inline"`
 }
 
 // Validate validates the input properties
@@ -80,6 +83,12 @@ type Options struct {
 
 	// ModelProperties are the config parameters for the workflow model
 	ModelProperties `json:",inline" yaml:",inline"`
+
+	// ProvisionDeadline is the deadline for synchronously calling the plugin to provision
+	ProvisionDeadline types.Duration
+
+	// DestroyDeadline is the deadline for synchronously calling the plugin to destroy
+	DestroyDeadline types.Duration
 }
 
 // Validate validates the controller's options
@@ -95,6 +104,12 @@ func (p Options) Validate(ctx context.Context) error {
 	}
 	if p.WaitBeforeProvision < p.MinWaitBeforeProvision {
 		return fmt.Errorf("wait before provision can't be less than %v", p.MinWaitBeforeProvision)
+	}
+	if p.ProvisionDeadline.Duration() == 0 {
+		return fmt.Errorf("bad provision deadline: %v", p.ProvisionDeadline)
+	}
+	if p.DestroyDeadline.Duration() == 0 {
+		return fmt.Errorf("bad destroy deadline: %v", p.DestroyDeadline)
 	}
 	return nil
 }


### PR DESCRIPTION
This PR

  + Fixed deadlocks in simulator code that prevented simulated caps from working
  + Added simulator control parameters for adding provision delays to simulate long-running or slow instance plugin Provision calls.
  + Exposes tuning parameters and updated example / docs (`workers.yml`) to show tuning parameters when provisioning large set of resource (> 500 simulated instances).
  + Make provision and destroy asynchronous with deadlines.
  + Using example `docs/controller/pool/workers.yml` and simulator, it is now possible to provision > 500 instances and very quick scale up and scale down (before settling into steady state between commits).  More examples, docs to come.

Signed-off-by: David Chung <david.chung@docker.com>