### PR TITLE
New playbook backend + flag fixes

### DIFF
--- a/cmd/infrakit/main.go
+++ b/cmd/infrakit/main.go
@@ -35,6 +35,7 @@ import (
 	_ "github.com/docker/infrakit/pkg/cli/v0"
 
 	// Callable backends via playbook or via lib
+	_ "github.com/docker/infrakit/pkg/callable/backend/controller"
 	_ "github.com/docker/infrakit/pkg/callable/backend/http"
 	_ "github.com/docker/infrakit/pkg/callable/backend/instance"
 	_ "github.com/docker/infrakit/pkg/callable/backend/print"

--- a/docs/controller/pool/workers.yml
+++ b/docs/controller/pool/workers.yml
@@ -29,11 +29,15 @@ properties:
   select:
     az: az1
     type: compute
+  tags:
+    node_label: join(`-`, `node`,index())
   init: |
     sudo apt-get install -y docker
   properties:
     instanceType: xlarge
     vcpu: 8
     mem: 512G
+    private_ip: allocate_ip()
     simulator_cap: 1000    # simulator max capacity
-    simulator_delay: 1s # simulator provision latency
+    simulator_delay: 5s # simulator provision latency
+    node: join(`-`, `node`, index())

--- a/examples/playbooks/aws/index.yml
+++ b/examples/playbooks/aws/index.yml
@@ -9,10 +9,10 @@ vars : vars.sh
 inventory : inventory.yml
 
 # The resource config for entire mystack
-phase1 : mystack.yml
+vpc : mystack.yml
 
 # The resource config for nodes after phase1
-phase2 : nodes.yml
+nodes : nodes.yml
 
 # The specific resources we can provision
 resources : resources/index.yml

--- a/examples/playbooks/aws/inventory.yml
+++ b/examples/playbooks/aws/inventory.yml
@@ -1,4 +1,4 @@
-{{/* =% text %= */}}
+{{/* =% controllerCommit %= */}}
 
 {{ $project := param "project" "string" "project" | prompt "Project?" "string" "myproject" }}
 

--- a/examples/playbooks/aws/mystack.yml
+++ b/examples/playbooks/aws/mystack.yml
@@ -1,4 +1,4 @@
-{{/* =% text %= */}}
+{{/* =% controllerCommit %= */}}
 
 {{ $project := metadata `mystack/vars/project` }}
 {{ $cidr := metadata `mystack/vars/cidr` }}

--- a/examples/playbooks/aws/nodes.yml
+++ b/examples/playbooks/aws/nodes.yml
@@ -1,65 +1,67 @@
-{{/* =% text %= */}}
+{{/* =% controllerCommit %= */}}
 
-{{ $subnet := param "subnet" "string" "subnet" | prompt "Subnet?" "string" "subnet2" }}
-
-{{ $instanceType := param "instance-type" "string" "instance type" | prompt "Instance type?" "string" "t2.micro" }}
-
-{{ $imageId := param "image-id" "string" "Image ID" | prompt "AMI?" "string" "ami-df8406b0" }}
-
-{{ $keyName := param "key" "string" "ssh key name" | prompt "SSH key?" "string" "infrakit"}}
-
-{{ $spotPrice := param "spot-price" "string" "Spot price" | prompt "Spot price?" "string" "0.03" }}
-
-{{/* subnet id from subnet name */}}
 {{ $project := metadata `mystack/vars/project` }}
 
-{{ $subnetKey := list `resource` $project $subnet `Properties` | join `/` }}
+{{ $instanceType := param "instance-type" "string" "instance type" | prompt "Instance type?" "string" "t2.micro" }}
+{{ $imageId := param "image-id" "string" "Image ID" | prompt "AMI?" "string" "ami-7c412f13" }}
+{{ $keyName := param "key" "string" "ssh key name" | prompt "SSH key?" "string" "infrakit"}}
+{{ $spotPrice := param "spot-price" "string" "Spot price" | prompt "Spot price?" "string" "0.03" }}
 
-{{ $subnetId := list $subnetKey `SubnetId` | join `/` | metadata }}
-{{ $az := list $subnetKey `AvailabilityZone` | join `/` | metadata }}
-{{ $cidr := list $subnetKey `CidrBlock` | join `/` | metadata }}
+{{ $subnetId := param "subnet-id" "string" "subnet ID" | prompt "Subnet?" "string" "" }}
+{{ $az := param "az" "string" "availability zone" | prompt "AZ?" "string" "" }}
+{{ $securityGroupID := param "security-group-id" "string" "security group" | prompt "Security group ID?" "string" "" }}
 
-{{ $securityGroupKey := list `resource` $project `sg1` `Properties` | join `/` }}
-{{ $securityGroupID := list $securityGroupKey `GroupId` | join `/` | metadata }}
+{{ $count := param "count" "int" "Count" | prompt "How many?" "int" 6 }}
+{{ $parallelism := param "parallelism" "int" "Parallelism" | prompt "How many at a time?" "int" 2 }}
 
-{{ $privateIp := param "private-ip" "string" "IP" | prompt "Private IP address?" "string" $cidr }}
-
-kind: resource
+kind: pool
 metadata:
   name: {{ $project }}-nodes
 options:
   ObserveInterval: 10s
+  # This is the size of the buffered channel for the finite state machine work queue -- needs to be at least the count.
+  BufferSize: {{ mul $count 10 | add 1024 }} # controls the fsm engine's queue capacity
+  # observation's inbound channel capacity -- needs to be at least the same as the number of resource objects.
+  ChannelBufferSize: {{ mul $count 10 | add 1024 }}
+  # How long to wait before we start the provision process, in unit of time (ticks)
+  WaitBeforeProvision: 3
+  # How long to wait before we start the termination / destroy, in unit of time (ticks)
+  WaitBeforeDestroy: 3
+
 properties:
-
-
-  host1:
-    plugin: aws/ec2-spot-instance
-    select:
-      Name: {{ $project }}-host1
-      infrakit_scope: {{ $project }}
-    init: |
+  plugin: aws/ec2-spot-instance
+  count: {{ $count }}   # how many in the pool
+  parallelism: {{ $parallelism }}  # how many to provision / destroy at a time
+  select:
+    az: az1
+    type: compute
+  tags:
+    node_label: test
+  init: |
       #!/bin/bash
       sudo add-apt-repository ppa:gophers/archive
       sudo apt-get update -y
-      sudo apt-get install -y wget curl git golang-1.9-go
-      wget -qO- https://get.docker.com | sh
-      ln -s /usr/lib/go-1.9/bin/go /usr/local/bin/go
-    properties:
-      RequestSpotInstancesInput:
-        SpotPrice: "{{ $spotPrice }}"
-        Type: one-time
-        LaunchSpecification:
-          ImageId: {{ $imageId }}
-          InstanceType: {{ $instanceType }}
-          KeyName: {{ $keyName }}
-          NetworkInterfaces:
-            - AssociatePublicIpAddress: true
-              DeleteOnTermination: true
-              DeviceIndex: 0
-              Groups:
-                - {{ $securityGroupID }}
-              NetworkInterfaceId: null
-              PrivateIpAddress: {{ $privateIp  }}
-              SubnetId: {{ $subnetId }}
-          Placement:
-            AvailabilityZone: {{ $az }}
+      # install golang
+      sudo apt-get install -y wget curl git golang-1.10-go
+      ln -s /usr/lib/go-1.10/bin/go /usr/local/bin/go
+      # install docker CE
+      curl -sSL https://get.docker.com | sh
+      # install infrakit
+      curl -sSL https://docker.github.io/infrakit/install | sh
+  properties:
+    RequestSpotInstancesInput:
+      SpotPrice: "{{ $spotPrice }}"
+      Type: one-time
+      LaunchSpecification:
+        ImageId: {{ $imageId }}
+        InstanceType: {{ $instanceType }}
+        KeyName: {{ $keyName }}
+        NetworkInterfaces:
+          - AssociatePublicIpAddress: true
+            DeleteOnTermination: true
+            DeviceIndex: 0
+            Groups:
+              - {{ $securityGroupID }}
+            SubnetId: {{ $subnetId }}
+        Placement:
+          AvailabilityZone: {{ $az }}

--- a/examples/playbooks/aws/resources/provision-spot-instance.yml
+++ b/examples/playbooks/aws/resources/provision-spot-instance.yml
@@ -2,14 +2,13 @@
 {{/* =% instanceProvision `aws/ec2-spot-instance` %= */}}
 
 {{ $project := param "project" "string" "project" | prompt "Project?" "string" "myproject" }}
-{{ $imageId := param "image-id" "string" "Image ID" | prompt "AMI?" "string" "ami-df8406b0" }}
+{{ $imageId := param "image-id" "string" "Image ID" | prompt "AMI?" "string" "ami-7c412f13" }}
 {{ $instanceType := param "instance-type" "string" "instance type" | prompt "Instance type?" "string" "t2.micro" }}
 {{ $name := param "name" "string" "Host name" | prompt "Host name?" "string" (cat $project `-` (randAlphaNum 8) | nospace ) }}
 {{ $spotPrice := param "spot-price" "string" "Spot price" | prompt "Spot price?" "string" "0.03" }}
 {{ $keyName := param "key" "string" "ssh key name" | prompt "SSH key?" "string" "infrakit"}}
 {{ $subnetId := param "subnet-id" "string" "subnet ID" | prompt "Subnet?" "string" "" }}
 {{ $az := param "az" "string" "availability zone" | prompt "AZ?" "string" "" }}
-{{ $privateIp := param "private-ip" "string" "IP" | prompt "Private IP address?" "string" "" }}
 {{ $securityGroupID := param "security-group-id" "string" "security group" | prompt "Security group ID?" "string" "" }}
 
 
@@ -39,7 +38,7 @@ Properties:
         Groups:
         - {{ $securityGroupID }}
         NetworkInterfaceId: null
-        PrivateIpAddress: {{ $privateIp  }}
+        PrivateIpAddress: null  # let their IPAM pick an ip address
         PrivateIpAddresses: null
         SecondaryPrivateIpAddressCount: null
         SubnetId: {{ $subnetId }}

--- a/examples/playbooks/aws/start.sh
+++ b/examples/playbooks/aws/start.sh
@@ -1,13 +1,15 @@
 {{/* =% sh %= */}}
 
-{{ $clearState := flag "clear-state" "bool" "Clear stored states" | prompt "Clear state?" "bool" true }}
+{{ $clearState := flag "clear-state" "bool" "Clear stored states" | prompt "Clear state?" "bool" false }}
 
 {{ $profile := flag "aws-cred-profile" "string" "Profile name" | prompt "Profile for your .aws/credentials?" "string" "default" }}
 {{ $region := flag "region" "string" "aws region" | prompt "Region?" "string" "eu-central-1"}}
 
+echo "Clear stale pids"
+rm -rf $HOME/.infrakit/plugins/* # remove sockets, pid files, etc.
+
 {{ if $clearState }}
 echo "Clear local state from previous runs"
-rm -rf $HOME/.infrakit/plugins/* # remove sockets, pid files, etc.
 rm -rf $HOME/.infrakit/configs/* # for file based manager
 # Since we are using file based leader detection, write the default name (manager1) to the leader file.
 echo manager1 > $HOME/.infrakit/leader
@@ -32,8 +34,8 @@ AWS_ACCESS_KEY_ID={{ $creds.aws_access_key_id }} \
 AWS_SECRET_ACCESS_KEY={{ $creds.aws_secret_access_key }} \
 INFRAKIT_AWS_REGION={{ $region }} \
 INFRAKIT_AWS_NAMESPACE_TAGS="infrakit_namespace={{ $namespace }}" \
-INFRAKIT_MANAGER_CONTROLLERS=resource,inventory \
-infrakit plugin start manager:mystack vars group resource inventory aws \
+INFRAKIT_MANAGER_CONTROLLERS=resource,inventory,pool \
+infrakit plugin start manager:mystack vars group resource inventory pool aws \
 	 --log 5 --log-stack --log-debug-V 1000 \
 	 --log-debug-match module=controller/resource \
 	 --log-debug-match module=provider/aws \

--- a/pkg/callable/backend/controller/commit.go
+++ b/pkg/callable/backend/controller/commit.go
@@ -1,0 +1,63 @@
+package controller
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/docker/infrakit/pkg/callable/backend"
+	"github.com/docker/infrakit/pkg/run/scope"
+	"github.com/docker/infrakit/pkg/spi/controller"
+	"github.com/docker/infrakit/pkg/types"
+)
+
+func init() {
+	backend.Register("controllerCommit", Commit,
+		func(params backend.Parameters) {
+			params.String("plugin", "", "plugin")
+		})
+}
+
+// Commit returns an executable function based on that specification to call the named controller plugin's
+// Commit method.
+// The optional parameter in the playbook script can be overridden by the value of the `--plugin` flag
+// in the command line.
+func Commit(scope scope.Scope, test bool, opt ...interface{}) (backend.ExecFunc, error) {
+
+	return func(ctx context.Context, script string, parameters backend.Parameters, args []string) error {
+
+		var name string
+
+		// Optional parameter for plugin name can be overridden by the value of the flag (--plugin):
+		if len(opt) > 0 {
+			s, is := opt[0].(string)
+			if !is {
+				return fmt.Errorf("first param (pluginName) must be string")
+			}
+			name = s
+		}
+		if n, err := parameters.GetString("plugin"); err != nil {
+			return err
+		} else if n != "" {
+			name = n
+		}
+
+		c, err := scope.Controller(name)
+		if err != nil {
+			return err
+		}
+
+		spec := types.Spec{}
+		if err := types.Decode([]byte(script), &spec); err != nil {
+			return err
+		}
+
+		object, err := c.Commit(controller.Enforce, spec)
+		if err != nil {
+			return err
+		}
+
+		out := backend.GetWriter(ctx)
+		fmt.Fprintln(out, object)
+		return nil
+	}, nil
+}

--- a/pkg/callable/callable_test.go
+++ b/pkg/callable/callable_test.go
@@ -21,9 +21,9 @@ import (
 
 func TestMissing(t *testing.T) {
 	require.True(t, Missing("string", ""))
-	require.True(t, Missing("int", 0))
-	require.True(t, Missing("float", 0.))
-	require.True(t, Missing("bool", none))
+	require.True(t, Missing("int", missingInt))
+	require.True(t, Missing("float", missingFloat))
+	require.True(t, Missing("bool", missingBool))
 	require.False(t, Missing("bool", false))
 	require.False(t, Missing("bool", true))
 }

--- a/pkg/controller/internal/collection.go
+++ b/pkg/controller/internal/collection.go
@@ -51,10 +51,17 @@ type Item struct {
 
 // Error associates an error
 func (i *Item) Error(err error) {
+
+	const errorKey = "error"
+
 	if i.Data == nil {
 		i.Data = map[string]interface{}{}
 	}
-	i.Data["error"] = err.Error()
+	if err != nil {
+		i.Data[errorKey] = err.Error()
+	} else {
+		delete(i.Data, errorKey)
+	}
 }
 
 // Collection is a Managed that tracks a set of finite state machines.

--- a/pkg/controller/internal/collection.go
+++ b/pkg/controller/internal/collection.go
@@ -14,6 +14,7 @@ import (
 	"github.com/docker/infrakit/pkg/spi/event"
 	"github.com/docker/infrakit/pkg/spi/instance"
 	"github.com/docker/infrakit/pkg/spi/metadata"
+	"github.com/docker/infrakit/pkg/template"
 	"github.com/docker/infrakit/pkg/types"
 )
 
@@ -155,6 +156,22 @@ func NewCollection(scope scope.Scope, topics ...types.Path) (*Collection, error)
 	}
 	c.metadata = metadata_plugin.NewPluginFromChannel(c.metadataUpdates)
 	return c, nil
+}
+
+// Render renders the template in any using the receiver as context
+func (c *Collection) Render(any *types.Any, item Item) (*types.Any, error) {
+	// Run the spec as a template and evaluate it.  So for any escaped {{}} sequences
+	// we can process things
+	unescaped := string(template.Unescape(any.Bytes()))
+	templateEngine, err := c.scope.TemplateEngine("str://"+unescaped, template.Options{})
+	if err != nil {
+		return nil, err
+	}
+	rendered, err := templateEngine.Render(item)
+	if err != nil {
+		return nil, err
+	}
+	return types.AnyString(rendered), nil
 }
 
 // Metadata returns a metadata plugin implementation. Optional; ok to be nil

--- a/pkg/controller/pool/collection.go
+++ b/pkg/controller/pool/collection.go
@@ -385,8 +385,6 @@ func (c *collection) run(ctx context.Context) {
 					timer := time.NewTimer(c.options.ProvisionDeadline.Duration())
 					done := make(chan struct{})
 
-					item.State.Signal(provisionStart)
-
 					go func() {
 						defer func() {
 							e := recover()
@@ -510,6 +508,7 @@ func (c *collection) run(ctx context.Context) {
 					log.Debug("found", "instance", n, "key", k, "V", debugV2)
 					item.State.Signal(resourceFound)
 					item.Data["instance"] = n
+					item.Error(nil) // clear any previous error if this is from a retry
 				}
 
 				c.MetadataExport(c.accessor.KeyOf, export)

--- a/pkg/controller/pool/fsm.go
+++ b/pkg/controller/pool/fsm.go
@@ -288,6 +288,9 @@ func BuildModel(properties pool.Properties, options pool.Options) (*Model, error
 		},
 		fsm.State{
 			Index: cannotProvision,
+			Transitions: map[fsm.Signal]fsm.Index{
+				resourceFound: ready, // in case a client timeout puts us in fail state...
+			},
 		},
 		fsm.State{
 			Index: cannotTerminate,

--- a/pkg/controller/resource/collection.go
+++ b/pkg/controller/resource/collection.go
@@ -474,7 +474,7 @@ func (c *collection) run(ctx context.Context) {
 				if item != nil {
 					accessor := c.accessors[item.Key]
 
-					spec, err := c.populateDependencies(item.Key, accessor.Spec)
+					spec, err := c.populateDependencies(item, accessor.Spec)
 					if err != nil {
 
 						log.Error("Dependency missing",
@@ -824,10 +824,17 @@ func processDestroyWatches(properties resource.Properties) (watch *Watch, watchi
 // Assumption: the spec.Properties is fully rendered.  We can take the spec.Properties and
 // generate a list of dependencies via depends().  Now we are rendering this spec.Properties
 // into the final form with all the dependencies substituted.
-func (c *collection) populateDependencies(resourceName string, spec instance.Spec) (instance.Spec, error) {
+func (c *collection) populateDependencies(item *internal.Item, spec instance.Spec) (instance.Spec, error) {
+
+	resourceName := item.Key
 
 	// Turn the spec into a blob and use that to parse the dependencies
-	specAny, err := types.AnyValue(spec)
+	any, err := types.AnyValue(spec)
+	if err != nil {
+		return spec, err
+	}
+
+	specAny, err := c.Render(any, *item)
 	if err != nil {
 		return spec, err
 	}

--- a/pkg/controller/resource/fsm.go
+++ b/pkg/controller/resource/fsm.go
@@ -255,6 +255,11 @@ func BuildModel(properties resource.Properties, options resource.Options) (*Mode
 		},
 		fsm.State{
 			Index: cannotProvision,
+			Transitions: map[fsm.Signal]fsm.Index{
+				// we may have timeout on the synchronous call to provision,
+				// but later on we observe the instance actually being created.
+				resourceFound: ready,
+			},
 		},
 		fsm.State{
 			Index: cannotTerminate,


### PR DESCRIPTION
This PR 
 + adds a new `controllerCommit` backend for controller specs as playbooks
 + fixes logic for handling missing float/int/bool param/flag values
 + fixes a problem with pool controller's fsm stuck in "provisionFail" state when it's only the client api timed out during provision (e.g. when provisioning a spot instance which takes a while and can cause ec2 api client to timeout).

Signed-off-by: David Chung david.chung@docker.com