### PR TITLE
Calling playbooks from code: modules and callables

### DIFF
--- a/pkg/callable/backends.go
+++ b/pkg/callable/backends.go
@@ -15,7 +15,7 @@ func (c *Callable) loadBackends(t *template.Template) error {
 		func(funcName string, backend backend.ExecFuncBuilder) {
 			t.AddFunc(funcName,
 				func(opt ...interface{}) error {
-					executor, err := backend(c.scope, *c.test, opt...)
+					executor, err := backend(c.scope, *c.Options.TestMode, opt...)
 					if err != nil {
 						return err
 					}

--- a/pkg/callable/callable.go
+++ b/pkg/callable/callable.go
@@ -39,6 +39,15 @@ type Options struct {
 
 	// TemplateOptions has options for processing template
 	TemplateOptions template.Options
+
+	// TestMode indicates the callable is for test only. It's up to the backend to interpret this.
+	TestMode *bool
+
+	// PrintOnly will not actually invoke the backend but will instead renders the input to the backend.
+	PrintOnly *bool
+
+	// AcceptDefaults allows any unspecified parameter / flag values to use default values if set.
+	AcceptDefaults *bool
 }
 
 // Clone returns another copy, having defined the parameters
@@ -55,15 +64,15 @@ func (c *Callable) Clone(parameters backend.Parameters) (*Callable, error) {
 type Callable struct {
 	backend.Parameters // has methods of Parameters
 
-	Options Options
+	Options
 
 	*template.Template // has methods of Template
 
-	test           *bool
-	printOnly      *bool
-	acceptDefaults *bool
-	src            string
-	exec           bool
+	// test           *bool
+	// printOnly      *bool
+	// acceptDefaults *bool
+	src  string
+	exec bool
 
 	run    func(context.Context, string, backend.Parameters, []string) error
 	script string
@@ -519,7 +528,7 @@ func (c *Callable) Funcs() []template.Function {
 
 				}
 
-				return c.Options.Prompter(prompt, ftype, *c.acceptDefaults, optional...)
+				return c.Options.Prompter(prompt, ftype, *c.AcceptDefaults, optional...)
 			},
 		},
 		{
@@ -558,7 +567,7 @@ func (c *Callable) Funcs() []template.Function {
 					}
 
 				}
-				p, err := c.Options.Prompter(prompt, ftype, *c.acceptDefaults, optional...)
+				p, err := c.Options.Prompter(prompt, ftype, *c.AcceptDefaults, optional...)
 				pl = strings.Split(p.(string), ",")
 				return pl, err
 			},
@@ -586,24 +595,32 @@ func (c *Callable) DefineParameters() (err error) {
 		return fmt.Errorf("not initialized")
 	}
 
-	c.test = c.Bool("test", false, "True to do a trial run")
-	c.printOnly = c.Bool("print-only", false, "True to print the rendered input")
-	c.acceptDefaults = c.Bool("accept-defaults", false, "True to accept defaults of prompts and flags")
+	if c.TestMode == nil {
+		c.TestMode = c.Bool("test", false, "True to do a trial run")
+	}
+
+	if c.PrintOnly == nil {
+		c.PrintOnly = c.Bool("print-only", false, "True to print the rendered input")
+	}
+
+	if c.AcceptDefaults == nil {
+		c.AcceptDefaults = c.Bool("accept-defaults", false, "True to accept defaults of prompts and flags")
+	}
 
 	t, err := c.getTemplate()
 	if err != nil {
 		return
 	}
 
-	t.SetOptions(c.Options.TemplateOptions)
+	t.SetOptions(c.TemplateOptions)
 	_, err = t.Render(c)
-	if err != nil && c.Options.ShowAllWarnings {
+	if err != nil && c.ShowAllWarnings {
 		log.Warn("Error rendering playbook while defining params", "err", err)
 	}
 
 	// add the backend-defined flags. These are flags that are
 	// applied as the backend is chosen.  The delimiter here is =% %=
-	opt := c.Options.TemplateOptions
+	opt := c.TemplateOptions
 	opt.DelimLeft = "=%"
 	opt.DelimRight = "%="
 	// Determine the backends
@@ -632,6 +649,7 @@ func (c *Callable) DefineParameters() (err error) {
 
 // Execute runs the command
 func (c *Callable) Execute(ctx context.Context, args []string, out io.Writer) (err error) {
+
 	c.lock.Lock()
 	defer c.lock.Unlock()
 
@@ -648,10 +666,10 @@ func (c *Callable) Execute(ctx context.Context, args []string, out io.Writer) (e
 		return
 	}
 
-	opt := c.Options.TemplateOptions
+	opt := c.TemplateOptions
 
-	if c.Options.ErrOutputFunc != nil {
-		opt.Stderr = c.Options.ErrOutputFunc
+	if c.ErrOutputFunc != nil {
+		opt.Stderr = c.ErrOutputFunc
 	} else {
 		opt.Stderr = func() io.Writer { return os.Stderr }
 	}
@@ -664,14 +682,14 @@ func (c *Callable) Execute(ctx context.Context, args []string, out io.Writer) (e
 		return err
 	}
 	c.script = script
-	if *c.printOnly {
-		fmt.Print(c.script)
-		return nil
+	if *c.PrintOnly {
+		_, err := fmt.Fprint(c.OutputFunc(), c.script)
+		return err
 	}
 
 	log.Debug("running", "script", script)
 
-	opt = c.Options.TemplateOptions
+	opt = c.TemplateOptions
 	opt.DelimLeft = "=%"
 	opt.DelimRight = "%="
 	// Determine the backends
@@ -686,8 +704,8 @@ func (c *Callable) Execute(ctx context.Context, args []string, out io.Writer) (e
 		switch {
 		case out != nil:
 			ctx = backend.SetWriter(ctx, out)
-		case c.Options.OutputFunc != nil:
-			ctx = backend.SetWriter(ctx, c.Options.OutputFunc())
+		case c.OutputFunc != nil:
+			ctx = backend.SetWriter(ctx, c.OutputFunc())
 		}
 		return c.run(ctx, script, c, args)
 	}

--- a/pkg/callable/callable.go
+++ b/pkg/callable/callable.go
@@ -68,9 +68,6 @@ type Callable struct {
 
 	*template.Template // has methods of Template
 
-	// test           *bool
-	// printOnly      *bool
-	// acceptDefaults *bool
 	src  string
 	exec bool
 

--- a/pkg/callable/module.go
+++ b/pkg/callable/module.go
@@ -20,11 +20,12 @@ type Module struct {
 	Options        Options
 	ParametersFunc func() backend.Parameters
 	Callables      map[string]*Callable
+	Modules        map[string]*Module
 
 	lock sync.RWMutex
 }
 
-func (m *Module) loadIndex(model interface{}) error {
+func (m Module) loadIndex(model interface{}) error {
 	// an index at the path specified is rendered and parsed into the provided
 	// model.
 	t, err := template.NewTemplate(m.IndexURL, m.Options.TemplateOptions)
@@ -56,6 +57,33 @@ func (m *Module) GetCallable(name string) (*Callable, error) {
 	return c.Clone(parameters)
 }
 
+// GetModule gets the loaded sub module by name
+func (m *Module) GetModule(name string) (Module, error) {
+	m.lock.RLock()
+	defer m.lock.RUnlock()
+	c, has := m.Modules[name]
+	if !has {
+		return Module{}, fmt.Errorf("not found %v", name)
+	}
+	return *c, nil
+}
+
+// Find takes a path and returns a nested callable, if found, or error.
+func (m *Module) Find(path []string) (*Callable, error) {
+	switch len(path) {
+	case 0:
+		return nil, fmt.Errorf("no path")
+	case 1:
+		return m.GetCallable(path[0])
+	default:
+		mm, err := m.GetModule(path[0])
+		if err != nil {
+			return nil, err
+		}
+		return mm.Find(path[1:])
+	}
+}
+
 // List returns a list of callable names
 func (m *Module) List() []string {
 	m.lock.RLock()
@@ -76,16 +104,13 @@ func (m *Module) List() []string {
 // Load loads and initializes the module from the source
 func (m *Module) Load() error {
 
-	m.lock.Lock()
-	defer m.lock.Unlock()
-
 	index := map[string]string{}
-
 	if err := m.loadIndex(&index); err != nil {
 		return err
 	}
 
 	callables := map[string]*Callable{}
+	modules := map[string]*Module{}
 	for name, sub := range index {
 
 		fullURL := path.Join(path.Dir(m.IndexURL), sub)
@@ -103,9 +128,27 @@ func (m *Module) Load() error {
 			params = &Parameters{} // default in-memory map
 		}
 
-		callables[name] = NewCallable(m.Scope, source.String(), params, m.Options)
+		// Because a URL like https://pb.com/p/foo can point to just a directory
+		// there is no easy way to tell if a callable is in fact module (directory)
+		// So here we do the expensive operation of defining all the params and check for any errors.
+		// If an error is seen, then it's not included as a searchable callable.
+		callable := NewCallable(m.Scope, source.String(), params, m.Options)
+		if err := callable.DefineParameters(); err == nil {
+			callables[name] = callable
+		} else {
+			// check for moudule.  A module has `index.yml` inside a directory
+			sub := *m // shallow copy
+			sub.IndexURL = path.Join(source.String(), "index.yml")
+			if err := sub.Load(); err == nil {
+				modules[name] = &sub
+			}
+		}
 	}
 
+	m.lock.Lock()
+	defer m.lock.Unlock()
+
 	m.Callables = callables
+	m.Modules = modules
 	return nil
 }

--- a/pkg/callable/test/index.yml
+++ b/pkg/callable/test/index.yml
@@ -10,3 +10,7 @@ spot : provision-spot-instance.yml
 
 # print some lines
 lines: lines.sh
+
+vpc: sub/provision-vpc.yml
+
+sub: sub

--- a/pkg/callable/test/sub/index.yml
+++ b/pkg/callable/test/sub/index.yml
@@ -1,0 +1,4 @@
+# Creates a vpc
+provision_vpc : provision-vpc.yml
+
+sub2 : sub2

--- a/pkg/callable/test/sub/provision-vpc.yml
+++ b/pkg/callable/test/sub/provision-vpc.yml
@@ -1,0 +1,20 @@
+{{/* Input to create instance using the AWS instance plugin */}}
+{{/* =% instanceProvision `aws/vpc` %= */}}
+
+{{ $project := param "project" "string" "project" | prompt "Project?" "string" "myproject" }}
+
+{{ $cidr := param "cidr" "string" "CIDR Block" | prompt "CIDR block?" "string" "10.0.0.0/16" }}
+
+Tags:
+  infrakit_scope: {{ $project }}
+
+Properties:
+  Tags:
+    Name: {{ $project }}-vpc
+  CreateVpcInput:
+    CidrBlock: {{ $cidr }}
+  ModifyVpcAttributeInputs:
+    - EnableDnsSupport :
+        Value: true
+    - EnableDnsHostnames :
+        Value: true

--- a/pkg/callable/test/sub/sub2/index.yml
+++ b/pkg/callable/test/sub/sub2/index.yml
@@ -1,0 +1,5 @@
+# Creates a gateway
+provision_gateway : provision-gateway.yml
+
+# Creates a subnet
+provision_subnet : provision-subnet.yml

--- a/pkg/callable/test/sub/sub2/provision-gateway.yml
+++ b/pkg/callable/test/sub/sub2/provision-gateway.yml
@@ -1,0 +1,15 @@
+{{/* Input to create instance using the AWS instance plugin */}}
+{{/* =% instanceProvision `aws/ec2-internetgateway` %= */}}
+
+{{ $project := param "project" "string" "project" | prompt "Project?" "string" "myproject" }}
+
+{{ $vpcID := param "vpcID" "string" "VPC ID" | prompt "VPC ID?" "string" }}
+
+Tags:
+  infrakit_scope: {{ $project }}
+
+Properties:
+  Tags:
+    Name: {{ $project }}-igw
+  AttachInternetGatewayInput:
+    VpcId : {{ $vpcID }}

--- a/pkg/callable/test/sub/sub2/provision-subnet.yml
+++ b/pkg/callable/test/sub/sub2/provision-subnet.yml
@@ -1,0 +1,26 @@
+{{/* Input to create instance using the AWS instance plugin */}}
+{{/* =% instanceProvision `aws/ec2-subnet` %= */}}
+
+{{ $project := param "project" "string" "project" | prompt "Project?" "string" "myproject" }}
+
+{{ $vpcID := param "vpcID" "string" "VPC ID" | prompt "VPC ID?" "string" }}
+{{ $az := param "az" "string" "AZ" | prompt "Availability Zone?" "string" "eu-central-1b" }}
+{{ $cidr := param "cidr" "string" "CIDR Block" | prompt "CIDR block?" "string" "10.0.0.0/24" }}
+{{ $name := param "name" "string" "Subnet name" | prompt "Subnet name?" "string" "subnet-1" }}
+{{ $routeTableID := param "routeTableID" "string" "RouteTable ID" | prompt "RouteTable ID?" "string" "" }}
+{{ $code := param "code" "int" "Integer code" | prompt "Integer code?" "int" 100 }}
+
+
+Tags:
+  infrakit_scope: {{ $project }}
+  special_code : {{ $code }}
+
+Properties:
+  Tags:
+    Name: {{ $project }}-{{ $name }}
+  CreateSubnetInput:
+    VpcId : {{ $vpcID }}
+    AvailabilityZone: {{ $az }}
+    CidrBlock: {{ $cidr }}
+  RouteTableAssociation:
+    RouteTableId: {{ $routeTableID }}


### PR DESCRIPTION
This PR
  + makes it possible to call deeply nested playbooks from code.  See `module_test` for examples
  + updates the callable `Options` to contain common parameters like `--print-only` and `--accept-defaults` to be settable in code.

Signed-off-by: David Chung <david.chung@docker.com>